### PR TITLE
Support for all settings and save settings to local storage

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -42,100 +42,128 @@
       <!-- clear allボタン -->
       <input type="button" value="clear all" id="clear_all" class="small_button" />
     </div>
-    <div class="options">
-      <!-- complement_alias -->
-      <div>
-        <input type="checkbox" id="complement_alias" name="complement_alias" checked />
-        <label for="complement_alias">カラムのエイリアス名を補完する</label>
-      </div>
-
-      <!-- trim_bind_param -->
-      <div>
-        <input type="checkbox" id="trim_bind_param" name="trim_bind_param" />
-        <label for="trim_bind_param">バインドパラメータの空白をトリムする</label>
-      </div>
-
-      <!-- complement_outer_keyword -->
-      <div>
-        <input type="checkbox" id="complement_outer_keyword" name="complement_outer_keyword" checked />
-        <label for="complement_outer_keyword">省略可能なOUTERを補完する</label>
-      </div>
-
-      <!-- complement_column_as_keyword	 -->
-      <div>
-        <input type="checkbox" id="complement_column_as_keyword" name="complement_column_as_keyword" checked />
-        <label for="complement_column_as_keyword">カラムエイリアスのASを補完する</label>
-      </div>
-
-      <!-- remove_table_as_keyword -->
-      <div>
-        <input type="checkbox" id="remove_table_as_keyword" name="remove_table_as_keyword" checked />
-        <label for="remove_table_as_keyword">テーブルエイリアスのASを除去する</label>
-      </div>
-
-      <!-- remove_redundant_nest -->
-      <div>
-        <input type="checkbox" id="remove_redundant_nest" name="remove_redundant_nest" checked />
-        <label for="remove_redundant_nest">冗長な括弧を削除する</label>
-      </div>
-
-      <!-- complement_sql_id -->
-      <div>
-        <input type="checkbox" id="complement_sql_id" name="complement_sql_id" />
-        <label for="complement_sql_id">SQL_IDを補完する</label>
-      </div>
-
-      <!-- convert_double_colon_cast -->
-      <div>
-        <input type="checkbox" id="convert_double_colon_cast" name="convert_double_colon_cast" checked />
-        <label for="convert_double_colon_cast">X::typeをCAST(X AS type)に変換する</label>
-      </div>
-
-      <!-- unify_not_equal -->
-      <div>
-        <input type="checkbox" id="unify_not_equal" name="unify_not_equal" checked />
-        <label for="unify_not_equal">&lt;&gt;を!=に変換する</label>
-      </div>
-
-      <table>
-        <!-- tab_size -->
-        <tr>
-          <td>タブのサイズ:</td>
-          <td>
-            <input type="number" id="tab_size" name="tab_size" value="4" />
-          </td>
-        </tr>
-        <!-- keyword_case -->
-        <tr>
-          <td>予約語:</td>
-          <td>
-            <select id="keyword_case">
-              <option value="upper">upper</option>
-              <option value="lower" selected>lower</option>
-              <option value="preserve">preserve</option>
-            </select>
-          </td>
-        </tr>
-        <!-- identifier_case -->
-        <tr>
-          <td>テーブル・カラム名:</td>
-          <td>
-            <select id="identifier_case">
-              <option value="upper">upper</option>
-              <option value="lower" selected>lower</option>
-              <option value="preserve">preserve</option>
-            </select>
-          </td>
-        </tr>
-        <!-- max_char_per_line -->
-        <tr>
-          <td>1行の最大文字数:</td>
-          <td>
-            <input type="number" id="max_char_per_line" name="max_char_per_line" value="50" />
-          </td>
-        </tr>
-      </table>
+    <!-- complement_alias -->
+    <div class="option">
+      <input type="checkbox" id="complement_alias" name="complement_alias" checked />
+      <label for="complement_alias">カラムのエイリアス名を補完する</label>
+      <span class="option_balloon">カラムのエイリアスを同じ名前で自動補完する。</br>例: <code>COL1</code> → <code>COL1 AS COL1</code></span>
     </div>
+
+    <!-- trim_bind_param -->
+    <div class="option">
+      <input type="checkbox" id="trim_bind_param" name="trim_bind_param" />
+      <label for="trim_bind_param">バインドパラメータの空白をトリムする</label>
+      <span class="option_balloon">例: <code>/* foo */</code> → <code>/*foo*/</code></span>
+    </div>
+
+    <!-- complement_outer_keyword -->
+    <div class="option">
+      <input type="checkbox" id="complement_outer_keyword" name="complement_outer_keyword" checked />
+      <label for="complement_outer_keyword">省略可能なOUTERを補完する</label>
+      <span class="option_balloon">例: <code>JOIN</code> → <code>LEFT OUTER JOIN</code></span>
+    </div>
+
+    <!-- complement_column_as_keyword	 -->
+    <div class="option">
+      <input type="checkbox" id="complement_column_as_keyword" name="complement_column_as_keyword" checked />
+      <label for="complement_column_as_keyword">カラムエイリアスのASを補完する</label>
+      <span class="option_balloon">例: <code>SELECT COLUMN1 COL1</code> → <code>SELECT COLUMN1 AS COL1</code> </span>
+    </div>
+
+    <!-- remove_table_as_keyword -->
+    <div class="option">
+      <input type="checkbox" id="remove_table_as_keyword" name="remove_table_as_keyword" checked />
+      <label for="remove_table_as_keyword">テーブルエイリアスのASを除去する</label>
+      <span class="option_balloon">例: <code>FROM TABLE1 AS TBL1</code> → <code>FROM TABLE1 TBL1</code></span>
+    </div>
+
+    <!-- remove_redundant_nest -->
+    <div class="option">
+      <input type="checkbox" id="remove_redundant_nest" name="remove_redundant_nest" checked />
+      <label for="remove_redundant_nest">冗長な括弧を削除する</label>
+      <span class="option_balloon">例: <code>(((1 = 1)))</code> → <code>(1 = 1)</code> </span>
+    </div>
+
+    <!-- complement_sql_id -->
+    <div class="option">
+      <input type="checkbox" id="complement_sql_id" name="complement_sql_id" />
+      <label for="complement_sql_id">SQL_IDを補完する</label>
+      <span class="option_balloon">例: <code>SELECT COL1</code> → <code>SELECT /* _SQL_ID_ */ COL1</code></span>
+    </div>
+
+    <!-- convert_double_colon_cast -->
+    <div class="option">
+      <input type="checkbox" id="convert_double_colon_cast" name="convert_double_colon_cast" checked />
+      <label for="convert_double_colon_cast">X::typeをCAST(X AS type)に変換する</label>
+      <span class="option_balloon">例: <code>SELECT ''::JSONB</code> → <code>SELECT CAST('' AS JSONB)</code> </span>
+    </div>
+
+    <!-- unify_not_equal -->
+    <div class="option">
+      <input type="checkbox" id="unify_not_equal" name="unify_not_equal" checked />
+      <label for="unify_not_equal">&lt;&gt;を!=に変換する</label>
+      <span class="option_balloon">例: <code>STUDENT_ID &lt;&gt; 2</code> → <code>STUDENT_ID != 2</code></span>
+    </div>
+
+    <table>
+      <!-- tab_size -->
+      <tr>
+        <td>
+          <div class="option">
+            タブのサイズ:
+            <span class="option_balloon">1つのタブ文字のサイズを指定</span>
+          </div>
+        </td>
+        <td>
+          <input type="number" id="tab_size" name="tab_size" value="4" />
+        </td>
+      </tr>
+      <!-- keyword_case -->
+      <tr>
+        <td>
+          <div class="option">
+            予約語:
+            <span class="option_balloon">lower: 小文字に統一</br>upper: 大文字に統一</br>preserve: 大文字小文字を保持</span>
+          </div>
+        </td>
+        <td>
+          <select id="keyword_case">
+            <option value="upper">upper</option>
+            <option value="lower" selected>lower</option>
+            <option value="preserve">preserve</option>
+          </select>
+        </td>
+      </tr>
+      <!-- identifier_case -->
+      <tr>
+        <td>
+          <div class="option">
+            テーブル・カラム名:
+            <span class="option_balloon">lower: 小文字に統一</br>upper: 大文字に統一</br>preserve: 大文字小文字を保持</span>
+          </div>
+        </td>
+        <td>
+          <select id="identifier_case">
+            <option value="upper">upper</option>
+            <option value="lower" selected>lower</option>
+            <option value="preserve">preserve</option>
+          </select>
+        </td>
+      </tr>
+
+      <!-- max_char_per_line -->
+      <tr>
+        <td>
+          <div class="option">
+            1行の最大文字数:
+            <span class="option_balloon">関数名と引数の合計文字数がこの数値を超える場合は引数が改行して出力される</span>
+          </div>
+        </td>
+        <td>
+          <input type="number" id="max_char_per_line" name="max_char_per_line" value="50" />
+        </td>
+      </tr>
+    </table>
   </details>
 
   <!-- エディタ -->

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -34,119 +34,107 @@
   </ul>
   <details>
     <summary>オプション (<a href="https://github.com/future-architect/uroborosql-fmt#configuration-options">詳細</a>)</summary>
+    <div class="button_parent">
+      <!-- defaultボタン -->
+      <input type="button" value="dafault" id="default" class="small_button" />
+      <!-- select allボタン -->
+      <input type="button" value="select all" id="select_all" class="small_button" />
+      <!-- clear allボタン -->
+      <input type="button" value="clear all" id="clear_all" class="small_button" />
+    </div>
     <div class="options">
-      <ul style="list-style: none;">
-        <!-- complement_alias -->
-        <li>
-          <div>
-            <input type="checkbox" id="complement_alias" name="complement_alias" checked />
-            <label for="complement_alias">カラムのエイリアス名を補完する</label>
-          </div>
-        </li>
+      <!-- complement_alias -->
+      <div>
+        <input type="checkbox" id="complement_alias" name="complement_alias" checked />
+        <label for="complement_alias">カラムのエイリアス名を補完する</label>
+      </div>
 
-        <!-- trim_bind_param -->
-        <li>
-          <div>
-            <input type="checkbox" id="trim_bind_param" name="trim_bind_param" />
-            <label for="trim_bind_param">バインドパラメータの空白をトリムする</label>
-          </div>
-        </li>
+      <!-- trim_bind_param -->
+      <div>
+        <input type="checkbox" id="trim_bind_param" name="trim_bind_param" />
+        <label for="trim_bind_param">バインドパラメータの空白をトリムする</label>
+      </div>
 
-        <!-- complement_outer_keyword -->
-        <li>
-          <div>
-            <input type="checkbox" id="complement_outer_keyword" name="complement_outer_keyword" checked />
-            <label for="complement_outer_keyword">省略可能なOUTERを補完する</label>
-          </div>
-        </li>
+      <!-- complement_outer_keyword -->
+      <div>
+        <input type="checkbox" id="complement_outer_keyword" name="complement_outer_keyword" checked />
+        <label for="complement_outer_keyword">省略可能なOUTERを補完する</label>
+      </div>
 
-        <!-- complement_column_as_keyword	 -->
-        <li>
-          <div>
-            <input type="checkbox" id="complement_column_as_keyword" name="complement_column_as_keyword" checked />
-            <label for="complement_column_as_keyword">カラムエイリアスのASを補完する</label>
-          </div>
-        </li>
+      <!-- complement_column_as_keyword	 -->
+      <div>
+        <input type="checkbox" id="complement_column_as_keyword" name="complement_column_as_keyword" checked />
+        <label for="complement_column_as_keyword">カラムエイリアスのASを補完する</label>
+      </div>
 
-        <!-- remove_table_as_keyword -->
-        <li>
-          <div>
-            <input type="checkbox" id="remove_table_as_keyword" name="remove_table_as_keyword" checked />
-            <label for="remove_table_as_keyword">テーブルエイリアスのASを除去する</label>
-          </div>
-        </li>
+      <!-- remove_table_as_keyword -->
+      <div>
+        <input type="checkbox" id="remove_table_as_keyword" name="remove_table_as_keyword" checked />
+        <label for="remove_table_as_keyword">テーブルエイリアスのASを除去する</label>
+      </div>
 
-        <!-- remove_redundant_nest -->
-        <li>
-          <div>
-            <input type="checkbox" id="remove_redundant_nest" name="remove_redundant_nest" checked />
-            <label for="remove_redundant_nest">冗長な括弧を削除する</label>
-          </div>
-        </li>
+      <!-- remove_redundant_nest -->
+      <div>
+        <input type="checkbox" id="remove_redundant_nest" name="remove_redundant_nest" checked />
+        <label for="remove_redundant_nest">冗長な括弧を削除する</label>
+      </div>
 
-        <!-- complement_sql_id -->
-        <li>
-          <div>
-            <input type="checkbox" id="complement_sql_id" name="complement_sql_id" />
-            <label for="complement_sql_id">SQL_IDを補完する</label>
-          </div>
-        </li>
+      <!-- complement_sql_id -->
+      <div>
+        <input type="checkbox" id="complement_sql_id" name="complement_sql_id" />
+        <label for="complement_sql_id">SQL_IDを補完する</label>
+      </div>
 
-        <!-- convert_double_colon_cast -->
-        <li>
-          <div>
-            <input type="checkbox" id="convert_double_colon_cast" name="convert_double_colon_cast" checked />
-            <label for="convert_double_colon_cast">X::typeをCAST(X AS type)に変換する</label>
-          </div>
-        </li>
+      <!-- convert_double_colon_cast -->
+      <div>
+        <input type="checkbox" id="convert_double_colon_cast" name="convert_double_colon_cast" checked />
+        <label for="convert_double_colon_cast">X::typeをCAST(X AS type)に変換する</label>
+      </div>
 
-        <!-- unify_not_equal -->
-        <li>
-          <div>
-            <input type="checkbox" id="unify_not_equal" name="unify_not_equal" checked />
-            <label for="unify_not_equal">&lt;&gt;を!=に変換する</label>
-          </div>
-        </li>
+      <!-- unify_not_equal -->
+      <div>
+        <input type="checkbox" id="unify_not_equal" name="unify_not_equal" checked />
+        <label for="unify_not_equal">&lt;&gt;を!=に変換する</label>
+      </div>
 
-        <table>
-          <!-- tab_size -->
-          <tr>
-            <td>タブのサイズ:</td>
-            <td>
-              <input type="number" id="tab_size" name="tab_size" value="4" />
-            </td>
-          </tr>
-          <!-- keyword_case -->
-          <tr>
-            <td>予約語:</td>
-            <td>
-              <select id="keyword_case">
-                <option value="upper">upper</option>
-                <option value="lower" selected>lower</option>
-                <option value="preserve">preserve</option>
-              </select>
-            </td>
-          </tr>
-          <!-- identifier_case -->
-          <tr>
-            <td>テーブル・カラム名:</td>
-            <td>
-              <select id="identifier_case">
-                <option value="upper">upper</option>
-                <option value="lower" selected>lower</option>
-                <option value="preserve">preserve</option>
-              </select>
-            </td>
-          </tr>
-          <!-- max_char_per_line -->
-          <tr>
-            <td>1行の最大文字数:</td>
-            <td>
-              <input type="number" id="max_char_per_line" name="max_char_per_line" value="50" />
-            </td>
-          </tr>
-        </table>
-      </ul>
+      <table>
+        <!-- tab_size -->
+        <tr>
+          <td>タブのサイズ:</td>
+          <td>
+            <input type="number" id="tab_size" name="tab_size" value="4" />
+          </td>
+        </tr>
+        <!-- keyword_case -->
+        <tr>
+          <td>予約語:</td>
+          <td>
+            <select id="keyword_case">
+              <option value="upper">upper</option>
+              <option value="lower" selected>lower</option>
+              <option value="preserve">preserve</option>
+            </select>
+          </td>
+        </tr>
+        <!-- identifier_case -->
+        <tr>
+          <td>テーブル・カラム名:</td>
+          <td>
+            <select id="identifier_case">
+              <option value="upper">upper</option>
+              <option value="lower" selected>lower</option>
+              <option value="preserve">preserve</option>
+            </select>
+          </td>
+        </tr>
+        <!-- max_char_per_line -->
+        <tr>
+          <td>1行の最大文字数:</td>
+          <td>
+            <input type="number" id="max_char_per_line" name="max_char_per_line" value="50" />
+          </td>
+        </tr>
+      </table>
     </div>
   </details>
 
@@ -157,7 +145,7 @@
   </div>
 
 
-  <div class="button_parent">
+  <div class="button_parent_center">
     <!-- formatボタン -->
     <div class="format_btn">
       <input type="button" value="format" id="format" class="button" />

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -32,54 +32,138 @@
       準拠
     </li>
   </ul>
-  <div class="options">
-    <div>
-      <input type="checkbox" id="complement_alias" name="complement_alias" />
-      <label for="complement_alias">カラムのエイリアス名を補完する</label>
+  <details>
+    <summary>オプション (<a href="https://github.com/future-architect/uroborosql-fmt#configuration-options">詳細</a>)</summary>
+    <div class="options">
+      <ul style="list-style: none;">
+        <!-- complement_alias -->
+        <li>
+          <div>
+            <input type="checkbox" id="complement_alias" name="complement_alias" checked />
+            <label for="complement_alias">カラムのエイリアス名を補完する</label>
+          </div>
+        </li>
+
+        <!-- trim_bind_param -->
+        <li>
+          <div>
+            <input type="checkbox" id="trim_bind_param" name="trim_bind_param" />
+            <label for="trim_bind_param">バインドパラメータの空白をトリムする</label>
+          </div>
+        </li>
+
+        <!-- complement_outer_keyword -->
+        <li>
+          <div>
+            <input type="checkbox" id="complement_outer_keyword" name="complement_outer_keyword" checked />
+            <label for="complement_outer_keyword">省略可能なOUTERを補完する</label>
+          </div>
+        </li>
+
+        <!-- complement_column_as_keyword	 -->
+        <li>
+          <div>
+            <input type="checkbox" id="complement_column_as_keyword" name="complement_column_as_keyword" checked />
+            <label for="complement_column_as_keyword">カラムエイリアスのASを補完する</label>
+          </div>
+        </li>
+
+        <!-- remove_table_as_keyword -->
+        <li>
+          <div>
+            <input type="checkbox" id="remove_table_as_keyword" name="remove_table_as_keyword" checked />
+            <label for="remove_table_as_keyword">テーブルエイリアスのASを除去する</label>
+          </div>
+        </li>
+
+        <!-- remove_redundant_nest -->
+        <li>
+          <div>
+            <input type="checkbox" id="remove_redundant_nest" name="remove_redundant_nest" checked />
+            <label for="remove_redundant_nest">冗長な括弧を削除する</label>
+          </div>
+        </li>
+
+        <!-- complement_sql_id -->
+        <li>
+          <div>
+            <input type="checkbox" id="complement_sql_id" name="complement_sql_id" />
+            <label for="complement_sql_id">SQL_IDを補完する</label>
+          </div>
+        </li>
+
+        <!-- convert_double_colon_cast -->
+        <li>
+          <div>
+            <input type="checkbox" id="convert_double_colon_cast" name="convert_double_colon_cast" checked />
+            <label for="convert_double_colon_cast">X::typeをCAST(X AS type)に変換する</label>
+          </div>
+        </li>
+
+        <!-- unify_not_equal -->
+        <li>
+          <div>
+            <input type="checkbox" id="unify_not_equal" name="unify_not_equal" checked />
+            <label for="unify_not_equal">&lt;&gt;を!=に変換する</label>
+          </div>
+        </li>
+
+        <table>
+          <!-- tab_size -->
+          <tr>
+            <td>タブのサイズ:</td>
+            <td>
+              <input type="number" id="tab_size" name="tab_size" value="4" />
+            </td>
+          </tr>
+          <!-- keyword_case -->
+          <tr>
+            <td>予約語:</td>
+            <td>
+              <select id="keyword_case">
+                <option value="upper">upper</option>
+                <option value="lower" selected>lower</option>
+                <option value="preserve">preserve</option>
+              </select>
+            </td>
+          </tr>
+          <!-- identifier_case -->
+          <tr>
+            <td>テーブル・カラム名:</td>
+            <td>
+              <select id="identifier_case">
+                <option value="upper">upper</option>
+                <option value="lower" selected>lower</option>
+                <option value="preserve">preserve</option>
+              </select>
+            </td>
+          </tr>
+          <!-- max_char_per_line -->
+          <tr>
+            <td>1行の最大文字数:</td>
+            <td>
+              <input type="number" id="max_char_per_line" name="max_char_per_line" value="50" />
+            </td>
+          </tr>
+        </table>
+      </ul>
     </div>
-    <div>
-      <input type="checkbox" id="trim_bind_param" name="trim_bind_param" />
-      <label for="trim_bind_param">バインドパラメータの空白をトリムする</label>
-    </div>
-    <table>
-      <tr>
-        <td>タブのサイズ:</td>
-        <td>
-          <input type="number" id="tab_size" name="tab_size" value="4" />
-        </td>
-      </tr>
-      <tr>
-        <td>予約語:</td>
-        <td>
-          <select id="keyword_case">
-            <option value="upper">upper</option>
-            <option value="lower">lower</option>
-            <option value="preserve">preserve</option>
-          </select>
-        </td>
-      </tr>
-      <tr>
-        <td>テーブル・カラム名:</td>
-        <td>
-          <select id="identifier_case">
-            <option value="upper">upper</option>
-            <option value="lower">lower</option>
-            <option value="preserve">preserve</option>
-          </select>
-        </td>
-      </tr>
-    </table>
-    <div class="editor_parent">
-      <div class="editor" id="src_editor"></div>
-      <div class="editor" id="dst_editor"></div>
-    </div>
+  </details>
+
+  <!-- エディタ -->
+  <div class="editor_parent">
+    <div class="editor" id="src_editor"></div>
+    <div class="editor" id="dst_editor"></div>
   </div>
 
+
   <div class="button_parent">
+    <!-- formatボタン -->
     <div class="format_btn">
       <input type="button" value="format" id="format" class="button" />
       <span class="format_balloon">Ctrl+Shift+F</span>
     </div>
+    <!-- copyボタン -->
     <div class="copy_btn">
       <input type="button" value="copy" id="copy" class="button" />
     </div>

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -59,7 +59,7 @@
     <!-- complement_outer_keyword -->
     <div class="option">
       <input type="checkbox" id="complement_outer_keyword" name="complement_outer_keyword" checked />
-      <label for="complement_outer_keyword">省略可能なOUTERを補完する</label>
+      <label for="complement_outer_keyword">RIGHT/LEFT JOINのOUTERを補完する</label>
       <span class="option_balloon">例: <code>JOIN</code> → <code>LEFT OUTER JOIN</code></span>
     </div>
 
@@ -87,14 +87,15 @@
     <!-- complement_sql_id -->
     <div class="option">
       <input type="checkbox" id="complement_sql_id" name="complement_sql_id" />
-      <label for="complement_sql_id">SQL_IDを補完する</label>
+      <label for="complement_sql_id"><a
+          href="https://palette-doc.rtfa.as/coding-standards/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88uroboroSQL%EF%BC%89.html#sql-%E8%AD%98%E5%88%A5%E5%AD%90">SQL_ID</a>を補完する</label>
       <span class="option_balloon">例: <code>SELECT COL1</code> → <code>SELECT /* _SQL_ID_ */ COL1</code></span>
     </div>
 
     <!-- convert_double_colon_cast -->
     <div class="option">
       <input type="checkbox" id="convert_double_colon_cast" name="convert_double_colon_cast" checked />
-      <label for="convert_double_colon_cast">X::typeをCAST(X AS type)に変換する</label>
+      <label for="convert_double_colon_cast">COL1::typeをCAST(COL1 AS type)に変換する</label>
       <span class="option_balloon">例: <code>SELECT ''::JSONB</code> → <code>SELECT CAST('' AS JSONB)</code> </span>
     </div>
 

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -1,82 +1,93 @@
 <!DOCTYPE html>
 <html lang="ja">
-  <head>
-    <meta charset="utf-8">
-    <title>uroborosql-fmt wasm demo page</title>
-    <link href="style.css" rel="stylesheet">
-  </head>
-  
-  <body>
-    <h1> uroborosql-fmt </h1>
 
-    <p>
-      左側にフォーマットしたいSQLソースを入力し「format」ボタンを押すと、
-      右側にフォーマット結果が出力されます。
-    </p>
-    <p>サポート</p>
-    <ul>
-      <li><a href="https://www.postgresql.org/">PostgreSQL</a>構文</li>
-      <li>2WaySQL(
-          <a href="https://future-architect.github.io/uroborosql-doc/background/">uroboroSQL</a>,
-          <a href="https://doma.readthedocs.io/en/2.54.0/">Doma 2</a>,
-          <a href="https://github.com/future-architect/go-twowaysql">go-twowaysql</a>
-          )
-      </li>
-      <li><a href="https://future-architect.github.io/coding-standards/documents/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88PostgreSQL%EF%BC%89.html">SQLコーディング規約（PostgreSQL） | Future Enterprise Coding Standards</a> 準拠</li>
-    </ul>
-    <div class="options">
-      <div>
-        <input type="checkbox" id="complement_alias" name="complement_alias">
-        <label for="complement_alias">カラムのエイリアス名を補完する</label>
-      </div>
-      <div>
-        <input type="checkbox" id="trim_bind_param" name="trim_bind_param">
-        <label for="trim_bind_param">バインドパラメータの空白をトリムする</label>
-      </div>
-      <table>
-        <tr>
-          <td>タブのサイズ:</td>
-          <td><input type="number" id="tab_size" name="tab_size" value="4"></td>
-        </tr>
-        <tr>
-          <td>予約語:</td>
-          <td>
-            <select id="keyword_case">
-              <option value="upper">upper</option>
-              <option value="lower">lower</option>
-              <option value="preserve">preserve</option>
-            </select>
-          </td>
-        </tr>
-        <tr>
-          <td>テーブル・カラム名:</td>
-          <td>
-            <select id="identifier_case">
-              <option value="upper">upper</option>
-              <option value="lower">lower</option>
-              <option value="preserve">preserve</option>
-            </select>
-          </td>
-        </tr>
-      </table>
-      <div class="editor_parent">
-        <div class="editor" id="src_editor"></div>
-        <div class="editor" id="dst_editor"></div>
-      </div>
-    </div>
+<head>
+  <meta charset="utf-8" />
+  <title>uroborosql-fmt wasm demo page</title>
+  <link href="style.css" rel="stylesheet" />
+</head>
 
-    <div class="button_parent">
-      <div class="format_btn">
-        <input type="button" value="format" id="format" class="button"/>
-        <span class="format_balloon">Ctrl+Shift+F</span>
-      </div>
-      <div class="copy_btn">
-        <input type="button" value="copy" id="copy" class="button"/>
-      </div>
+<body>
+  <h1>uroborosql-fmt</h1>
+
+  <p>
+    左側にフォーマットしたいSQLソースを入力し「format」ボタンを押すと、
+    右側にフォーマット結果が出力されます。
+  </p>
+  <p>サポート</p>
+  <ul>
+    <li><a href="https://www.postgresql.org/">PostgreSQL</a>構文</li>
+    <li>
+      2WaySQL(
+      <a href="https://future-architect.github.io/uroborosql-doc/background/">uroboroSQL</a>, <a
+        href="https://doma.readthedocs.io/en/2.54.0/">Doma 2</a>,
+      <a href="https://github.com/future-architect/go-twowaysql">go-twowaysql</a>
+      )
+    </li>
+    <li>
+      <a
+        href="https://future-architect.github.io/coding-standards/documents/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88PostgreSQL%EF%BC%89.html">SQLコーディング規約（PostgreSQL）
+        | Future Enterprise Coding
+        Standards</a>
+      準拠
+    </li>
+  </ul>
+  <div class="options">
+    <div>
+      <input type="checkbox" id="complement_alias" name="complement_alias" />
+      <label for="complement_alias">カラムのエイリアス名を補完する</label>
     </div>
-  
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.43.0/min/vs/loader.min.js"></script>
-    <script src="main.js"></script>
-    <script async src=uroborosql-fmt.js></script>
-  </body>
+    <div>
+      <input type="checkbox" id="trim_bind_param" name="trim_bind_param" />
+      <label for="trim_bind_param">バインドパラメータの空白をトリムする</label>
+    </div>
+    <table>
+      <tr>
+        <td>タブのサイズ:</td>
+        <td>
+          <input type="number" id="tab_size" name="tab_size" value="4" />
+        </td>
+      </tr>
+      <tr>
+        <td>予約語:</td>
+        <td>
+          <select id="keyword_case">
+            <option value="upper">upper</option>
+            <option value="lower">lower</option>
+            <option value="preserve">preserve</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td>テーブル・カラム名:</td>
+        <td>
+          <select id="identifier_case">
+            <option value="upper">upper</option>
+            <option value="lower">lower</option>
+            <option value="preserve">preserve</option>
+          </select>
+        </td>
+      </tr>
+    </table>
+    <div class="editor_parent">
+      <div class="editor" id="src_editor"></div>
+      <div class="editor" id="dst_editor"></div>
+    </div>
+  </div>
+
+  <div class="button_parent">
+    <div class="format_btn">
+      <input type="button" value="format" id="format" class="button" />
+      <span class="format_balloon">Ctrl+Shift+F</span>
+    </div>
+    <div class="copy_btn">
+      <input type="button" value="copy" id="copy" class="button" />
+    </div>
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.43.0/min/vs/loader.min.js"></script>
+  <script src="main.js"></script>
+  <script async src="uroborosql-fmt.js"></script>
+</body>
+
 </html>

--- a/wasm/main.js
+++ b/wasm/main.js
@@ -35,6 +35,33 @@ Module = {
   onAborted: abort,
 };
 
+// ローカルストレージから設定を復元
+const storedConfig = localStorage.getItem("config");
+if (storedConfig) {
+  const config = JSON.parse(storedConfig);
+  Object.keys(config).forEach((key) => {
+    const element = document.getElementById(key);
+
+    if (!element) return;
+
+    const value = config[key];
+
+    if (typeof value === "boolean") {
+      element.checked = value;
+    } else if (typeof value === "number") {
+      element.value = value;
+    } else {
+      let options = element.options;
+      for (let i = 0; i < options.length; i++) {
+        if (options[i].value === value) {
+          element.selectedIndex = i;
+          break;
+        }
+      }
+    }
+  });
+}
+
 // wasmの初期化が終了した際の処理
 function initialize() {
   function formatSql() {
@@ -144,6 +171,10 @@ function initialize() {
 
     src_editor.updateOptions({ tabSize: tab_size });
     dst_editor.updateOptions({ tabSize: tab_size });
+
+    // 設定をjson形式でローカルストレージに保存
+    const encodedConfig = JSON.stringify(config);
+    localStorage.setItem("config", encodedConfig);
   }
 
   const button = document.getElementById("format");

--- a/wasm/main.js
+++ b/wasm/main.js
@@ -45,14 +45,60 @@ function initialize() {
 
     const target = sql_value;
 
+    // tab_size
     const tab_size = parseInt(document.getElementById("tab_size").value);
+
+    // complement_alias
     const complement_alias =
       document.getElementById("complement_alias").checked;
+
+    // trim_bind_param
     const trim_bind_param = document.getElementById("trim_bind_param").checked;
+
+    // keyword_case
     const keyword_case =
       document.getElementById("keyword_case").selectedOptions[0].value;
+
+    // identifier_case
     const identifier_case =
       document.getElementById("identifier_case").selectedOptions[0].value;
+
+    // max_char_per_line
+    const max_char_per_line = parseInt(
+      document.getElementById("max_char_per_line").value
+    );
+
+    // complement_outer_keyword
+    const compement_outer_keyword = document.getElementById(
+      "complement_outer_keyword"
+    ).checked;
+
+    // complement_column_as_keyword
+    const complement_column_as_keyword = document.getElementById(
+      "complement_column_as_keyword"
+    ).checked;
+
+    // remove_table_as_keyword
+    const remove_table_as_keyword = document.getElementById(
+      "remove_table_as_keyword"
+    ).checked;
+
+    // remove_redundant_nest
+    const remove_redundant_nest = document.getElementById(
+      "remove_redundant_nest"
+    ).checked;
+
+    // complement_sql_id
+    const complement_sql_id =
+      document.getElementById("complement_sql_id").checked;
+
+    // convert_double_colon_cast
+    const convert_double_colon_cast = document.getElementById(
+      "convert_double_colon_cast"
+    ).checked;
+
+    // unify_not_equal
+    const unify_not_equal = document.getElementById("unify_not_equal").checked;
 
     const config = {
       debug: false,
@@ -61,14 +107,16 @@ function initialize() {
       trim_bind_param: trim_bind_param,
       keyword_case: keyword_case,
       identifier_case: identifier_case,
-      max_char_per_line: 50,
-      complement_outer_keyword: true,
-      complement_column_as_keyword: true,
-      remove_table_as_keyword: true,
-      remove_redundant_nest: true,
-      complement_sql_id: true,
-      convert_double_colon_cast: true,
+      max_char_per_line: max_char_per_line,
+      complement_outer_keyword: compement_outer_keyword,
+      complement_column_as_keyword: complement_column_as_keyword,
+      remove_table_as_keyword: remove_table_as_keyword,
+      remove_redundant_nest: remove_redundant_nest,
+      complement_sql_id: complement_sql_id,
+      convert_double_colon_cast: convert_double_colon_cast,
+      unify_not_equal: unify_not_equal,
     };
+
     const config_str = JSON.stringify(config);
 
     // タイマースタート

--- a/wasm/main.js
+++ b/wasm/main.js
@@ -215,6 +215,9 @@ function initialize() {
 
     const config_str = JSON.stringify(config);
 
+    // 設定をjson形式でローカルストレージに保存
+    localStorage.setItem("config", config_str);
+
     // タイマースタート
     const startTime = performance.now();
 
@@ -240,10 +243,6 @@ function initialize() {
 
     src_editor.updateOptions({ tabSize: tab_size });
     dst_editor.updateOptions({ tabSize: tab_size });
-
-    // 設定をjson形式でローカルストレージに保存
-    const encodedConfig = JSON.stringify(config);
-    localStorage.setItem("config", encodedConfig);
   }
 
   // フォーマットボタンを押したときの処理

--- a/wasm/main.js
+++ b/wasm/main.js
@@ -35,10 +35,7 @@ Module = {
   onAborted: abort,
 };
 
-// ローカルストレージから設定を復元
-const storedConfig = localStorage.getItem("config");
-if (storedConfig) {
-  const config = JSON.parse(storedConfig);
+function set_config(config) {
   Object.keys(config).forEach((key) => {
     const element = document.getElementById(key);
 
@@ -61,6 +58,78 @@ if (storedConfig) {
     }
   });
 }
+
+// ローカルストレージから設定を復元
+const storedConfig = localStorage.getItem("config");
+if (storedConfig) {
+  const config = JSON.parse(storedConfig);
+  set_config(config);
+}
+
+function set_default_config() {
+  const dafault_config = {
+    debug: false,
+    tab_size: 4,
+    complement_alias: true,
+    trim_bind_param: false,
+    keyword_case: "lower",
+    identifier_case: "lower",
+    max_char_per_line: 50,
+    complement_outer_keyword: true,
+    complement_column_as_keyword: true,
+    remove_table_as_keyword: true,
+    remove_redundant_nest: true,
+    complement_sql_id: false,
+    convert_double_colon_cast: true,
+    unify_not_equal: true,
+  };
+
+  set_config(dafault_config);
+}
+
+// dafaultボタンを押したときの処理
+const default_button = document.getElementById("default");
+default_button.addEventListener("click", () => set_default_config());
+
+function select_all_config() {
+  const all_selected_config = {
+    complement_alias: true,
+    trim_bind_param: true,
+    complement_outer_keyword: true,
+    complement_column_as_keyword: true,
+    remove_table_as_keyword: true,
+    remove_redundant_nest: true,
+    complement_sql_id: true,
+    convert_double_colon_cast: true,
+    unify_not_equal: true,
+  };
+
+  set_config(all_selected_config);
+}
+
+// select_allボタンを押したときの処理
+const select_all_button = document.getElementById("select_all");
+select_all_button.addEventListener("click", () => select_all_config());
+
+function clear_all_config() {
+  const all_cleared_config = {
+    complement_alias: false,
+    trim_bind_param: false,
+    complement_outer_keyword: false,
+    complement_column_as_keyword: false,
+    remove_table_as_keyword: false,
+    remove_redundant_nest: false,
+    complement_sql_id: false,
+    convert_double_colon_cast: false,
+    unify_not_equal: false,
+  };
+
+  set_config(all_cleared_config);
+}
+
+// clear_allボタンを押したときの処理
+const clear_all_button = document.getElementById("clear_all");
+clear_all_button.addEventListener("click", () => clear_all_config());
 
 // wasmの初期化が終了した際の処理
 function initialize() {
@@ -177,14 +246,17 @@ function initialize() {
     localStorage.setItem("config", encodedConfig);
   }
 
+  // フォーマットボタンを押したときの処理
   const button = document.getElementById("format");
   button.addEventListener("click", (event) => formatSql());
 
+  // コピーボタンを押したときの処理
   document.getElementById("copy").addEventListener("click", (event) => {
     const value = dst_editor.getValue();
     navigator.clipboard.writeText(value).catch((reason) => console.log(reason));
   });
 
+  // Ctrl + Shift + F が押されたときの処理
   addEventListener("keydown", (event) => {
     if (event.ctrlKey && event.shiftKey && event.code == "KeyF") {
       formatSql();

--- a/wasm/style.css
+++ b/wasm/style.css
@@ -18,10 +18,6 @@ body {
   border: 1px solid gray;
 }
 
-.options {
-  text-indent: 10px;
-}
-
 /* button */
 .button_parent_center {
   display: flex;
@@ -49,6 +45,21 @@ body {
 
 .copy_btn {
   margin-right: auto;
+}
+
+.option:hover .option_balloon {
+  display: inline;
+}
+
+.option_balloon {
+  display: none;
+  position: absolute;
+  left: 300px;
+  padding: 16px;
+  border-radius: 5px;
+  background-color: gray;
+  color: white;
+  z-index: 10;
 }
 
 .format_btn:hover .format_balloon {

--- a/wasm/style.css
+++ b/wasm/style.css
@@ -18,16 +18,29 @@ body {
   border: 1px solid gray;
 }
 
+.options {
+  text-indent: 10px;
+}
+
 /* button */
-.button_parent {
+.button_parent_center {
   display: flex;
   align-items: center;
+}
+
+.button_parent {
+  display: flex;
 }
 
 .button {
   height: 40px;
   width: 100px;
   font-size: 20px;
+}
+
+.small_button {
+  font-size: small;
+  text-align: center;
 }
 
 .format_btn {

--- a/wasm/style.css
+++ b/wasm/style.css
@@ -1,50 +1,50 @@
 body {
-    font-size: small
+  font-size: small;
 }
 
 /* options */
 #tab_size {
-    width: 68px
+  width: 68px;
 }
 
 /* editor */
 .editor_parent {
-    display: flex;
+  display: flex;
 }
 
 .editor {
-    height: 360px;
-    width: 50%;
-    border: 1px solid gray
+  height: 360px;
+  width: 50%;
+  border: 1px solid gray;
 }
 
 /* button */
 .button_parent {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 
 .button {
-    height: 40px;
-    width: 100px;
-    font-size: 20px;
+  height: 40px;
+  width: 100px;
+  font-size: 20px;
 }
 
 .format_btn {
-    margin-left: auto;
+  margin-left: auto;
 }
 
 .copy_btn {
-    margin-right: auto;
+  margin-right: auto;
 }
 
 .format_btn:hover .format_balloon {
-    display: inline;
+  display: inline;
 }
 
 .format_balloon {
-    position: absolute;
-    display: none;
-    background-color:gray;
-    color: white;
+  position: absolute;
+  display: none;
+  background-color: gray;
+  color: white;
 }


### PR DESCRIPTION
<img width="634" alt="スクリーンショット 2023-10-15 14 14 28" src="https://github.com/future-architect/uroborosql-fmt/assets/52311998/5a4c4af1-6535-47ce-9eda-616bd939f9be">

## 概要
- 全ての設定に対応
- 設定をローカルストレージに保持するように変更
  - formatボタンを押した際にローカルストレージに保存される
  - 起動時にローカルストレージから設定を読み込む
- defaultボタン、select_allボタン、clear_allボタンの実装
- オプションのテキストにホバーすると具体例が表示されるように変更

## 動作確認方法
1. [gh-pagesブランチ](https://github.com/future-architect/uroborosql-fmt/tree/gh-pages)の`uroborosql-fmt.js`、`uroborosql-fmt.wasm`を`wasm/`以下にコピー
2. 適当な方法でローカルでサーバを立てて動作確認

close #21 
