### PR TITLE
English support for the demo by wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The main features:
 	```
 
 - [VSCode extension](https://marketplace.visualstudio.com/items?itemName=Future.uroborosql-fmt) is available.
-- You can try the [demo by wasm](https://future-architect.github.io/uroborosql-fmt/).
+- You can try the [demo by wasm](https://future-architect.github.io/uroborosql-fmt/) ([Japanese](https://future-architect.github.io/uroborosql-fmt/ja)).
 
 ![wasm_demo](images/wasm_demo.gif)
 

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -136,7 +136,7 @@
         <td>
           <div class="option">
             case of keyword:
-            <span class="option_balloon">lower: unify lower case<br>upper: unify upper case<br>preserve: preserve
+            <span class="option_balloon">upper: unify upper case<br>lower: unify lower case<br>preserve: preserve
               original case</span>
           </div>
         </td>
@@ -153,7 +153,7 @@
         <td>
           <div class="option">
             case of table name and column name:
-            <span class="option_balloon">lower: unify lower case<br>upper: unify upper case<br>preserve: preserve
+            <span class="option_balloon">upper: unify upper case<br>lower: unify lower case<br>preserve: preserve
               original case</span>
           </div>
         </td>

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -72,7 +72,7 @@
     <div class="option">
       <input type="checkbox" id="complement_outer_keyword" name="complement_outer_keyword" checked />
       <label for="complement_outer_keyword">Complement the OUTER of RIGHT/LEFT JOIN</label>
-      <span class="option_balloon">e.g. <code>JOIN</code> → <code>LEFT OUTER JOIN</code></span>
+      <span class="option_balloon">e.g. <code>LEFT JOIN</code> → <code>LEFT OUTER JOIN</code></span>
     </div>
 
     <!-- complement_column_as_keyword	 -->
@@ -136,6 +136,8 @@
         <td>
           <div class="option">
             case of keyword:
+            <span class="option_balloon">lower: unify lower case<br>upper: unify upper case<br>preserve: preserve
+              original case</span>
           </div>
         </td>
         <td>
@@ -151,6 +153,8 @@
         <td>
           <div class="option">
             case of table name and column name:
+            <span class="option_balloon">lower: unify lower case<br>upper: unify upper case<br>preserve: preserve
+              original case</span>
           </div>
         </td>
         <td>

--- a/wasm/ja.html
+++ b/wasm/ja.html
@@ -71,7 +71,7 @@
     <div class="option">
       <input type="checkbox" id="complement_outer_keyword" name="complement_outer_keyword" checked />
       <label for="complement_outer_keyword">RIGHT/LEFT JOINのOUTERを補完する</label>
-      <span class="option_balloon">例: <code>JOIN</code> → <code>LEFT OUTER JOIN</code></span>
+      <span class="option_balloon">例: <code>LEFT JOIN</code> → <code>LEFT OUTER JOIN</code></span>
     </div>
 
     <!-- complement_column_as_keyword	 -->

--- a/wasm/ja.html
+++ b/wasm/ja.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 
 <head>
   <meta charset="utf-8" />
@@ -14,20 +14,20 @@
         <h1>uroborosql-fmt</h1>
       </td>
       <td style="text-align: right;">
-        <a href="./ja.html">
-          <h2>Japanese<h2>
+        <a href="./">
+          <h2>English<h2>
         </a>
       </td>
     </tr>
   </table>
 
   <p>
-    Enter the SQL source you want to format in the left editor and press the 'format' button, the result of the
-    formatting will be displayed in the right box.
+    左側にフォーマットしたいSQLソースを入力し「format」ボタンを押すと、
+    右側にフォーマット結果が出力されます。
   </p>
-  <p>Supports</p>
+  <p>サポート</p>
   <ul>
-    <li><a href="https://www.postgresql.org/">PostgreSQL</a></li>
+    <li><a href="https://www.postgresql.org/">PostgreSQL</a>構文</li>
     <li>
       2WaySQL(
       <a href="https://future-architect.github.io/uroborosql-doc/background/">uroboroSQL</a>, <a
@@ -36,15 +36,15 @@
       )
     </li>
     <li>
-      compliant with
       <a
-        href="https://future-architect.github.io/coding-standards/documents/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88PostgreSQL%EF%BC%89.html">SQL
-        coding standards created by Future Corporation</a>
+        href="https://future-architect.github.io/coding-standards/documents/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88PostgreSQL%EF%BC%89.html">SQLコーディング規約（PostgreSQL）
+        | Future Enterprise Coding
+        Standards</a>
+      準拠
     </li>
   </ul>
   <details>
-    <summary>Option (<a href="https://github.com/future-architect/uroborosql-fmt#configuration-options">detail</a>)
-    </summary>
+    <summary>オプション (<a href="https://github.com/future-architect/uroborosql-fmt#configuration-options">詳細</a>)</summary>
     <div class="button_parent">
       <!-- defaultボタン -->
       <input type="button" value="dafault" id="default" class="small_button" />
@@ -56,66 +56,65 @@
     <!-- complement_alias -->
     <div class="option">
       <input type="checkbox" id="complement_alias" name="complement_alias" checked />
-      <label for="complement_alias">Complement aliases for columns</label>
-      <span class="option_balloon">Column names are auto-completed with the same name </br>e.g.
-        <code>COL1</code> → <code>COL1 AS COL1</code></span>
+      <label for="complement_alias">カラムのエイリアス名を補完する</label>
+      <span class="option_balloon">カラムのエイリアスを同じ名前で自動補完する。</br>例: <code>COL1</code> → <code>COL1 AS COL1</code></span>
     </div>
 
     <!-- trim_bind_param -->
     <div class="option">
       <input type="checkbox" id="trim_bind_param" name="trim_bind_param" />
-      <label for="trim_bind_param">Trim the contents of the bind parameters</label>
-      <span class="option_balloon">e.g. <code>/* foo */</code> → <code>/*foo*/</code></span>
+      <label for="trim_bind_param">バインドパラメータの空白をトリムする</label>
+      <span class="option_balloon">例: <code>/* foo */</code> → <code>/*foo*/</code></span>
     </div>
 
     <!-- complement_outer_keyword -->
     <div class="option">
       <input type="checkbox" id="complement_outer_keyword" name="complement_outer_keyword" checked />
-      <label for="complement_outer_keyword">Complement the OUTER of RIGHT/LEFT JOIN</label>
-      <span class="option_balloon">e.g. <code>JOIN</code> → <code>LEFT OUTER JOIN</code></span>
+      <label for="complement_outer_keyword">RIGHT/LEFT JOINのOUTERを補完する</label>
+      <span class="option_balloon">例: <code>JOIN</code> → <code>LEFT OUTER JOIN</code></span>
     </div>
 
     <!-- complement_column_as_keyword	 -->
     <div class="option">
       <input type="checkbox" id="complement_column_as_keyword" name="complement_column_as_keyword" checked />
-      <label for="complement_column_as_keyword">Complement AS in column aliases</label>
-      <span class="option_balloon">e.g. <code>SELECT COLUMN1 COL1</code> → <code>SELECT COLUMN1 AS COL1</code> </span>
+      <label for="complement_column_as_keyword">カラムエイリアスのASを補完する</label>
+      <span class="option_balloon">例: <code>SELECT COLUMN1 COL1</code> → <code>SELECT COLUMN1 AS COL1</code> </span>
     </div>
 
     <!-- remove_table_as_keyword -->
     <div class="option">
       <input type="checkbox" id="remove_table_as_keyword" name="remove_table_as_keyword" checked />
-      <label for="remove_table_as_keyword">Remove AS in table aliases</label>
-      <span class="option_balloon">e.g. <code>FROM TABLE1 AS TBL1</code> → <code>FROM TABLE1 TBL1</code></span>
+      <label for="remove_table_as_keyword">テーブルエイリアスのASを除去する</label>
+      <span class="option_balloon">例: <code>FROM TABLE1 AS TBL1</code> → <code>FROM TABLE1 TBL1</code></span>
     </div>
 
     <!-- remove_redundant_nest -->
     <div class="option">
       <input type="checkbox" id="remove_redundant_nest" name="remove_redundant_nest" checked />
-      <label for="remove_redundant_nest">Remove redundant parentheses</label>
-      <span class="option_balloon">e.g. <code>(((1 = 1)))</code> → <code>(1 = 1)</code> </span>
+      <label for="remove_redundant_nest">冗長な括弧を削除する</label>
+      <span class="option_balloon">例: <code>(((1 = 1)))</code> → <code>(1 = 1)</code> </span>
     </div>
 
     <!-- complement_sql_id -->
     <div class="option">
       <input type="checkbox" id="complement_sql_id" name="complement_sql_id" />
-      <label for="complement_sql_id">Complement <a
-          href="https://palette-doc.rtfa.as/coding-standards/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88uroboroSQL%EF%BC%89.html#sql-%E8%AD%98%E5%88%A5%E5%AD%90">SQL_ID</a></label>
-      <span class="option_balloon">e.g. <code>SELECT COL1</code> → <code>SELECT /* _SQL_ID_ */ COL1</code></span>
+      <label for="complement_sql_id"><a
+          href="https://palette-doc.rtfa.as/coding-standards/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88uroboroSQL%EF%BC%89.html#sql-%E8%AD%98%E5%88%A5%E5%AD%90">SQL_ID</a>を補完する</label>
+      <span class="option_balloon">例: <code>SELECT COL1</code> → <code>SELECT /* _SQL_ID_ */ COL1</code></span>
     </div>
 
     <!-- convert_double_colon_cast -->
     <div class="option">
       <input type="checkbox" id="convert_double_colon_cast" name="convert_double_colon_cast" checked />
-      <label for="convert_double_colon_cast">Convert casts by COL1::type to the form CAST(COL1 AS type)</label>
-      <span class="option_balloon">e.g. <code>SELECT ''::JSONB</code> → <code>SELECT CAST('' AS JSONB)</code> </span>
+      <label for="convert_double_colon_cast">COL1::typeをCAST(COL1 AS type)に変換する</label>
+      <span class="option_balloon">例: <code>SELECT ''::JSONB</code> → <code>SELECT CAST('' AS JSONB)</code> </span>
     </div>
 
     <!-- unify_not_equal -->
     <div class="option">
       <input type="checkbox" id="unify_not_equal" name="unify_not_equal" checked />
-      <label for="unify_not_equal">Convert comparison operator &lt;&gt; to !=</label>
-      <span class="option_balloon">e.g. <code>STUDENT_ID &lt;&gt; 2</code> → <code>STUDENT_ID != 2</code></span>
+      <label for="unify_not_equal">&lt;&gt;を!=に変換する</label>
+      <span class="option_balloon">例: <code>STUDENT_ID &lt;&gt; 2</code> → <code>STUDENT_ID != 2</code></span>
     </div>
 
     <table>
@@ -123,8 +122,8 @@
       <tr>
         <td>
           <div class="option">
-            tab size:
-            <span class="option_balloon">Tab size used for formatting</span>
+            タブのサイズ:
+            <span class="option_balloon">1つのタブ文字のサイズを指定</span>
           </div>
         </td>
         <td>
@@ -135,7 +134,8 @@
       <tr>
         <td>
           <div class="option">
-            case of keyword:
+            予約語:
+            <span class="option_balloon">lower: 小文字に統一</br>upper: 大文字に統一</br>preserve: 大文字小文字を保持</span>
           </div>
         </td>
         <td>
@@ -150,7 +150,8 @@
       <tr>
         <td>
           <div class="option">
-            case of table name and column name:
+            テーブル・カラム名:
+            <span class="option_balloon">lower: 小文字に統一</br>upper: 大文字に統一</br>preserve: 大文字小文字を保持</span>
           </div>
         </td>
         <td>
@@ -166,9 +167,8 @@
       <tr>
         <td>
           <div class="option">
-            max number of characters per line:
-            <span class="option_balloon">If the total number of characters in the function name and arguments exceeds
-              this number, the arguments are formatted with new lines</span>
+            1行の最大文字数:
+            <span class="option_balloon">関数名と引数の合計文字数がこの数値を超える場合は引数が改行して出力される</span>
           </div>
         </td>
         <td>

--- a/wasm/ja.html
+++ b/wasm/ja.html
@@ -135,7 +135,7 @@
         <td>
           <div class="option">
             予約語:
-            <span class="option_balloon">lower: 小文字に統一</br>upper: 大文字に統一</br>preserve: 大文字小文字を保持</span>
+            <span class="option_balloon">upper: 大文字に統一<br>lower: 小文字に統一<br>preserve: 大文字小文字を保持</span>
           </div>
         </td>
         <td>
@@ -151,7 +151,7 @@
         <td>
           <div class="option">
             テーブル・カラム名:
-            <span class="option_balloon">lower: 小文字に統一</br>upper: 大文字に統一</br>preserve: 大文字小文字を保持</span>
+            <span class="option_balloon">upper: 大文字に統一<br>lower: 小文字に統一<br>preserve: 大文字小文字を保持</span>
           </div>
         </td>
         <td>

--- a/wasm/style.css
+++ b/wasm/style.css
@@ -54,7 +54,7 @@ body {
 .option_balloon {
   display: none;
   position: absolute;
-  left: 300px;
+  left: 450px;
   padding: 16px;
   border-radius: 5px;
   background-color: gray;


### PR DESCRIPTION
wasm版デモの英語版に対応しました

- 既存の`wasm/index.html`(日本語で記述)を`wasm/ja.html`に変更
- 英語版の`wasm/index.html`を新たに作成

Close #23 
Close #26