### PR TITLE
Display error messages in the wasm demo

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,7 +167,7 @@ jobs:
             -o ./wasm/uroborosql-fmt.js
             -s ALLOW_MEMORY_GROWTH=1
             -s STACK_SIZE=5MB
-            -s EXPORTED_FUNCTIONS=['_format_sql','_free_format_string']
+            -s EXPORTED_FUNCTIONS=['_format_sql','_get_result_address','_get_error_msg_address']
             -s EXPORTED_RUNTIME_METHODS=ccall
 
       - name: Upload artifact

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
 name = "uroborosql-fmt-wasm"
 version = "0.1.0"
 dependencies = [
+ "once_cell",
  "uroborosql-fmt",
 ]
 

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ export EMCC_CFLAGS="-O3
                     -o ./wasm/uroborosql-fmt.js
                     -s ALLOW_MEMORY_GROWTH=1
                     -s STACK_SIZE=5MB
-                    -s EXPORTED_FUNCTIONS=['_format_sql','_free_format_string'] 
+                    -s EXPORTED_FUNCTIONS=['_format_sql','_get_result_address','_get_error_msg_address']
                     -s EXPORTED_RUNTIME_METHODS=ccall"
 # 全体のビルドを実行
 cargo build --package uroborosql-fmt-wasm --target wasm32-unknown-emscripten --release

--- a/crates/uroborosql-fmt-wasm/Cargo.toml
+++ b/crates/uroborosql-fmt-wasm/Cargo.toml
@@ -13,4 +13,5 @@ repository.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
+once_cell = "1.18.0"
 uroborosql-fmt = { workspace = true }

--- a/crates/uroborosql-fmt-wasm/src/lib.rs
+++ b/crates/uroborosql-fmt-wasm/src/lib.rs
@@ -1,6 +1,29 @@
 use std::ffi::{c_char, CStr, CString};
 
+static mut RESULT: &mut [u8] = &mut [0; 50000];
+static mut ERROR_MSG: &mut [u8] = &mut [0; 50000];
+
 use uroborosql_fmt::{config::Config, format_sql_with_config};
+
+/// Returns the address of the result string.
+///
+/// # Safety
+///
+/// This is unsafe because it returns a raw pointer.
+#[no_mangle]
+pub unsafe extern "C" fn get_result_address() -> *const u8 {
+    &RESULT[0]
+}
+
+/// Returns the address of the error message string.
+///
+/// # Safety
+///
+/// This is unsafe because it returns a raw pointer.
+#[no_mangle]
+pub unsafe extern "C" fn get_error_msg_address() -> *const u8 {
+    &ERROR_MSG[0]
+}
 
 /// Formats SQL code given as char pointer `src` by WASM (JavaScript).
 ///
@@ -10,31 +33,52 @@ use uroborosql_fmt::{config::Config, format_sql_with_config};
 /// [`CStr::from_ptr`](https://doc.rust-lang.org/stable/std/ffi/struct.CStr.html#method.from_ptr).
 #[export_name = "format_sql"]
 #[no_mangle]
-pub unsafe extern "C" fn format_sql_for_wasm(
-    src: *mut c_char,
-    config_json_str: *mut c_char,
-) -> *mut c_char {
+pub unsafe extern "C" fn format_sql_for_wasm(src: *mut c_char, config_json_str: *mut c_char) {
     let src = CStr::from_ptr(src).to_str().unwrap().to_owned();
 
     let config_json_str = CStr::from_ptr(config_json_str).to_str().unwrap();
     let config = Config::from_json_str(config_json_str).unwrap();
 
-    // TODO: error handling
-    let result = format_sql_with_config(&src, config).unwrap();
+    let result = format_sql_with_config(&src, config);
 
-    CString::new(result).unwrap().into_raw()
-}
+    match result {
+        Ok(result) => {
+            CString::new(result)
+                .unwrap()
+                .as_bytes_with_nul()
+                .iter()
+                .enumerate()
+                .for_each(|(i, x)| {
+                    RESULT[i] = *x;
+                });
 
-/// Free the string `s` allocated by Rust.
-///
-/// # Safety
-///
-/// This is unsafe because it uses the unsafe function
-/// [`CString::from_war()`](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.from_raw).
-#[no_mangle]
-pub unsafe extern "C" fn free_format_string(s: *mut c_char) {
-    if s.is_null() {
-        return;
+            CString::new("")
+                .unwrap()
+                .as_bytes_with_nul()
+                .iter()
+                .enumerate()
+                .for_each(|(i, x)| {
+                    ERROR_MSG[i] = *x;
+                });
+        }
+        Err(err) => {
+            CString::new(err.to_string())
+                .unwrap()
+                .as_bytes_with_nul()
+                .iter()
+                .enumerate()
+                .for_each(|(i, x)| {
+                    ERROR_MSG[i] = *x;
+                });
+
+            CString::new("")
+                .unwrap()
+                .as_bytes_with_nul()
+                .iter()
+                .enumerate()
+                .for_each(|(i, x)| {
+                    RESULT[i] = *x;
+                });
+        }
     }
-    let _ = CString::from_raw(s);
 }

--- a/crates/uroborosql-fmt-wasm/src/lib.rs
+++ b/crates/uroborosql-fmt-wasm/src/lib.rs
@@ -1,7 +1,11 @@
-use std::ffi::{c_char, CStr, CString};
+use once_cell::sync::Lazy;
+use std::{
+    ffi::{c_char, CStr, CString},
+    sync::Mutex,
+};
 
-static mut RESULT: &mut [u8] = &mut [0; 50000];
-static mut ERROR_MSG: &mut [u8] = &mut [0; 50000];
+static RESULT: Lazy<Mutex<CString>> = Lazy::new(|| Mutex::new(CString::new("").unwrap()));
+static ERROR_MSG: Lazy<Mutex<CString>> = Lazy::new(|| Mutex::new(CString::new("").unwrap()));
 
 use uroborosql_fmt::{config::Config, format_sql_with_config};
 
@@ -11,8 +15,8 @@ use uroborosql_fmt::{config::Config, format_sql_with_config};
 ///
 /// This is unsafe because it returns a raw pointer.
 #[no_mangle]
-pub unsafe extern "C" fn get_result_address() -> *const u8 {
-    &RESULT[0]
+pub unsafe extern "C" fn get_result_address() -> *const c_char {
+    RESULT.lock().unwrap().as_c_str().as_ptr()
 }
 
 /// Returns the address of the error message string.
@@ -21,8 +25,8 @@ pub unsafe extern "C" fn get_result_address() -> *const u8 {
 ///
 /// This is unsafe because it returns a raw pointer.
 #[no_mangle]
-pub unsafe extern "C" fn get_error_msg_address() -> *const u8 {
-    &ERROR_MSG[0]
+pub unsafe extern "C" fn get_error_msg_address() -> *const c_char {
+    ERROR_MSG.lock().unwrap().as_c_str().as_ptr()
 }
 
 /// Formats SQL code given as char pointer `src` by WASM (JavaScript).
@@ -33,7 +37,11 @@ pub unsafe extern "C" fn get_error_msg_address() -> *const u8 {
 /// [`CStr::from_ptr`](https://doc.rust-lang.org/stable/std/ffi/struct.CStr.html#method.from_ptr).
 #[export_name = "format_sql"]
 #[no_mangle]
-pub unsafe extern "C" fn format_sql_for_wasm(src: *mut c_char, config_json_str: *mut c_char) {
+pub unsafe extern "C" fn format_sql_for_wasm(src: *const c_char, config_json_str: *const c_char) {
+    // Clear previous format result
+    *RESULT.lock().unwrap() = CString::new("").unwrap();
+    *ERROR_MSG.lock().unwrap() = CString::new("").unwrap();
+
     let src = CStr::from_ptr(src).to_str().unwrap().to_owned();
 
     let config_json_str = CStr::from_ptr(config_json_str).to_str().unwrap();
@@ -42,43 +50,7 @@ pub unsafe extern "C" fn format_sql_for_wasm(src: *mut c_char, config_json_str: 
     let result = format_sql_with_config(&src, config);
 
     match result {
-        Ok(result) => {
-            CString::new(result)
-                .unwrap()
-                .as_bytes_with_nul()
-                .iter()
-                .enumerate()
-                .for_each(|(i, x)| {
-                    RESULT[i] = *x;
-                });
-
-            CString::new("")
-                .unwrap()
-                .as_bytes_with_nul()
-                .iter()
-                .enumerate()
-                .for_each(|(i, x)| {
-                    ERROR_MSG[i] = *x;
-                });
-        }
-        Err(err) => {
-            CString::new(err.to_string())
-                .unwrap()
-                .as_bytes_with_nul()
-                .iter()
-                .enumerate()
-                .for_each(|(i, x)| {
-                    ERROR_MSG[i] = *x;
-                });
-
-            CString::new("")
-                .unwrap()
-                .as_bytes_with_nul()
-                .iter()
-                .enumerate()
-                .for_each(|(i, x)| {
-                    RESULT[i] = *x;
-                });
-        }
+        Ok(result) => *RESULT.lock().unwrap() = CString::new(result).unwrap(),
+        Err(err) => *ERROR_MSG.lock().unwrap() = CString::new(err.to_string()).unwrap(),
     }
 }

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -201,6 +201,8 @@
     </div>
   </div>
 
+  <div id="error_msg" style="color: red;"></div>
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.43.0/min/vs/loader.min.js"></script>
   <script src="main.js"></script>
   <script async src="uroborosql-fmt.js"></script>

--- a/wasm/ja.html
+++ b/wasm/ja.html
@@ -197,6 +197,8 @@
     </div>
   </div>
 
+  <div id="error_msg" style="color: red;"></div>
+
   <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.43.0/min/vs/loader.min.js"></script>
   <script src="main.js"></script>
   <script async src="uroborosql-fmt.js"></script>

--- a/wasm/main.js
+++ b/wasm/main.js
@@ -133,10 +133,6 @@ clear_all_button.addEventListener("click", () => clear_all_config());
 
 // wasmの初期化が終了した際の処理
 function initialize() {
-  // Rust側で確保したメモリのポインタを取得
-  const result_ptr = ccall("get_result_address", "number", [], []);
-  const error_ptr = ccall("get_error_msg_address", "number", [], []);
-
   function formatSql() {
     if (!src_editor || !dst_editor) {
       console.log("editors have not been loaded.");
@@ -236,6 +232,10 @@ function initialize() {
     const endTime = performance.now();
     // 何ミリ秒かかったかを表示する
     console.log("format complete: " + (endTime - startTime) + "ms");
+
+    // Rust側で確保したメモリのポインタを取得
+    const result_ptr = ccall("get_result_address", "number", [], []);
+    const error_ptr = ccall("get_error_msg_address", "number", [], []);
 
     // Module.UTF8ToString() でポインタを js の string に変換
     const res = UTF8ToString(result_ptr);


### PR DESCRIPTION
![image](https://github.com/future-architect/uroborosql-fmt/assets/52311998/374fc314-62e8-4c81-b85a-7aedfaa27f30)

## 概要
wasm版demoにおいて、フォーマットに失敗した際にエラーメッセージを表示するように変更しました。 (#25 )
ただし、UroboroSQLFmtErrorを単純に文字列に変更して表示しているため、エラー内容はわかりにくいものとなっています。
エラーメッセージの内容については別で議論する必要があると思うので、とりあえずドラフトの形でPRを作成しました。

## 実装
以前は`format_sql_for_wasm`でフォーマット結果を格納したポインタを返していました。
しかし、今回の変更ではフォーマット結果とエラーメッセージの2つの文字列を返したいため、実装を以下のように変更しました。

1. Rustであらかじめ結果とエラーメッセージを格納するメモリを確保 (それぞれ`RESULT`、`ERROR_MSG`とする。現状大きさ50000としている。)
2. wasmの初期化時に`RESULT`と`ERROR_MSG`の先頭アドレスを取得 (Rust側でアドレスを教える関数を作成して実現)
4. `format_sql_for_wasm`が呼び出されたらフォーマットを実行し、正常ならば結果を`RESULT`に、エラーの場合はエラーメッセージを`ERROR_MSG`に格納
5. js側で`RESULT`、`ERROR_MSG`から結果とエラーメッセージを取得して表示