### PR TITLE
Improvement error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b9d411ecbaf79885c6df4d75fff75858d5995ff25385657a28af47e82f9c36"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,9 +352,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
 name = "uroborosql-fmt"
 version = "0.1.0"
 dependencies = [
+ "annotate-snippets",
  "indexmap",
  "itertools",
  "once_cell",

--- a/crates/uroborosql-fmt/Cargo.toml
+++ b/crates/uroborosql-fmt/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+annotate-snippets = "0.9.1"
 indexmap = "1.9.3"
 itertools = "0.10.3"
 once_cell = "1.17.0"

--- a/crates/uroborosql-fmt/src/cst.rs
+++ b/crates/uroborosql-fmt/src/cst.rs
@@ -31,7 +31,7 @@ use tree_sitter::{Node, Point, Range};
 
 use crate::{config::CONFIG, error::UroboroSQLFmtError};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Position {
     pub(crate) row: usize,
     pub(crate) col: usize,
@@ -46,7 +46,7 @@ impl Position {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Location {
     pub(crate) start_position: Position,
     pub(crate) end_position: Position,

--- a/crates/uroborosql-fmt/src/util.rs
+++ b/crates/uroborosql-fmt/src/util.rs
@@ -4,7 +4,7 @@ use annotate_snippets::{
 };
 use itertools::Itertools;
 
-use crate::{config::CONFIG, cst::Location};
+use crate::{config::CONFIG, cst::Location, error::UroboroSQLFmtError};
 
 /// 設定ファイルに合わせて予約後の大文字・小文字を変換する
 pub(crate) fn convert_keyword_case(keyword: &str) -> String {
@@ -79,6 +79,29 @@ pub(crate) fn is_line_overflow(char_len: usize) -> bool {
     }
 }
 
+/// xバイト目が何文字目かを返す
+fn byte_to_char_index(input: &str, target_byte_index: usize) -> Result<usize, UroboroSQLFmtError> {
+    let mut char_index = 0;
+    let mut byte_index = 0;
+
+    for c in input.chars() {
+        if byte_index == target_byte_index {
+            return Ok(char_index);
+        }
+        char_index += 1;
+        byte_index += c.len_utf8();
+    }
+
+    if byte_index == target_byte_index {
+        Ok(char_index)
+    } else {
+        Err(UroboroSQLFmtError::Runtime(format!(
+            "byte_to_char_index: byte_index({}) is out of range",
+            target_byte_index
+        )))
+    }
+}
+
 /// エラー注釈を作成する関数
 /// 以下の形のエラー注釈を生成
 ///
@@ -88,7 +111,11 @@ pub(crate) fn is_line_overflow(char_len: usize) -> bool {
 ///   | ^^^^^^^^^^^^^ {label}
 ///   |
 /// ```
-pub(crate) fn create_error_annotation(location: &Location, label: &str, src: &str) -> String {
+pub(crate) fn create_error_annotation(
+    location: &Location,
+    label: &str,
+    src: &str,
+) -> Result<String, UroboroSQLFmtError> {
     // 元のSQLのエラーが発生した行を取得
     let source = src
         .lines()
@@ -98,7 +125,11 @@ pub(crate) fn create_error_annotation(location: &Location, label: &str, src: &st
         .join("\n");
 
     // エラー発生箇所の開始位置
-    let start_point = location.start_position.col;
+    // locaton.start_position.colはバイト数を指しているので文字数に変換する
+    let start_point = byte_to_char_index(
+        src.lines().collect_vec()[location.start_position.row],
+        location.start_position.col,
+    )?;
 
     // エラー発生箇所の終了位置
     // = (終了位置までの行の文字数合計) + (終了位置の行の終了位置までの文字数)
@@ -106,9 +137,12 @@ pub(crate) fn create_error_annotation(location: &Location, label: &str, src: &st
         .lines()
         .enumerate()
         .filter(|(i, _)| (location.start_position.row..location.end_position.row).contains(i))
-        .map(|(_, x)| x.len())
+        .map(|(_, x)| x.chars().count() + 1) // 改行コードの分1プラスする
         .sum::<usize>()
-        + location.end_position.col;
+        + byte_to_char_index(
+            src.lines().collect_vec()[location.end_position.row],
+            location.end_position.col,
+        )?; // エラー発生行の終了位置までの文字数 (locaton.end_position.colはバイト数を指しているので文字数に変換する)
 
     let snippet = Snippet {
         title: None,
@@ -130,5 +164,5 @@ pub(crate) fn create_error_annotation(location: &Location, label: &str, src: &st
         },
     };
 
-    DisplayList::from(snippet).to_string()
+    Ok(DisplayList::from(snippet).to_string())
 }

--- a/crates/uroborosql-fmt/src/util.rs
+++ b/crates/uroborosql-fmt/src/util.rs
@@ -1,4 +1,10 @@
-use crate::config::CONFIG;
+use annotate_snippets::{
+    display_list::{DisplayList, FormatOptions},
+    snippet::{AnnotationType, Slice, Snippet, SourceAnnotation},
+};
+use itertools::Itertools;
+
+use crate::{config::CONFIG, cst::Location};
 
 /// 設定ファイルに合わせて予約後の大文字・小文字を変換する
 pub(crate) fn convert_keyword_case(keyword: &str) -> String {
@@ -71,4 +77,58 @@ pub(crate) fn is_line_overflow(char_len: usize) -> bool {
     } else {
         char_len >= max_char_per_line as usize
     }
+}
+
+/// エラー注釈を作成する関数
+/// 以下の形のエラー注釈を生成
+///
+/// ```sh
+///   |
+/// 2 | using tbl_b b
+///   | ^^^^^^^^^^^^^ {label}
+///   |
+/// ```
+pub(crate) fn create_error_annotation(location: &Location, label: &str, src: &str) -> String {
+    // 元のSQLのエラーが発生した行を取得
+    let source = src
+        .lines()
+        .enumerate()
+        .filter(|(i, _)| (location.start_position.row..=location.end_position.row).contains(i))
+        .map(|(_, x)| x)
+        .join("\n");
+
+    // エラー発生箇所の開始位置
+    let start_point = location.start_position.col;
+
+    // エラー発生箇所の終了位置
+    // = (終了位置までの行の文字数合計) + (終了位置の行の終了位置までの文字数)
+    let end_point = src
+        .lines()
+        .enumerate()
+        .filter(|(i, _)| (location.start_position.row..location.end_position.row).contains(i))
+        .map(|(_, x)| x.len())
+        .sum::<usize>()
+        + location.end_position.col;
+
+    let snippet = Snippet {
+        title: None,
+        footer: vec![],
+        slices: vec![Slice {
+            source: &source,
+            line_start: location.start_position.row + 1,
+            origin: None,
+            fold: true,
+            annotations: vec![SourceAnnotation {
+                label,
+                annotation_type: AnnotationType::Error,
+                range: (start_point, end_point),
+            }],
+        }],
+        opt: FormatOptions {
+            color: true,
+            ..Default::default()
+        },
+    };
+
+    DisplayList::from(snippet).to_string()
 }

--- a/crates/uroborosql-fmt/src/validate.rs
+++ b/crates/uroborosql-fmt/src/validate.rs
@@ -114,7 +114,10 @@ impl Token {
             "".to_string()
         };
 
-        create_error_annotation(&self.location, &label, src)
+        match create_error_annotation(&self.location, &label, src) {
+            Ok(error_annotation) => error_annotation,
+            Err(_) => "".to_string(),
+        }
     }
 }
 

--- a/crates/uroborosql-fmt/src/visitor.rs
+++ b/crates/uroborosql-fmt/src/visitor.rs
@@ -82,10 +82,9 @@ impl Visitor {
                     // todo
                     _ => {
                         return Err(UroboroSQLFmtError::Unimplemented(format!(
-                            "visit_source(): Unimplemented statement\nnode_kind: {}\n{:#?}",
-                            cursor.node().kind(),
-                            cursor.node().range(),
-                        )))
+                            "visit_source(): Unimplemented statement\n{}",
+                            create_error_info(cursor, src)
+                        )));
                     }
                 };
 
@@ -345,4 +344,23 @@ fn create_clause(
     }
 
     Ok(clause)
+}
+
+/// cursorからエラー情報を生成する関数
+///
+/// node_kind: {nodeの種類}
+/// original_token: {元のソースコードのトークン}
+/// location: {nodeの位置情報}
+fn create_error_info(cursor: &TreeCursor, src: &str) -> String {
+    let original_token = cursor
+        .node()
+        .utf8_text(src.as_bytes())
+        .unwrap_or("<unknown token>");
+
+    format!(
+        "node_kind: {}\noriginal_token: {}\nlocation: {:#?}",
+        cursor.node().kind(),
+        original_token,
+        cursor.node().range(),
+    )
 }

--- a/crates/uroborosql-fmt/src/visitor.rs
+++ b/crates/uroborosql-fmt/src/visitor.rs
@@ -364,5 +364,8 @@ fn error_annotation_from_cursor(cursor: &TreeCursor, src: &str) -> String {
     let label = format!(r#"Appears as "{}" node on the CST"#, cursor.node().kind());
     let location = Location::new(cursor.node().range());
 
-    create_error_annotation(&location, &label, src)
+    match create_error_annotation(&location, &label, src) {
+        Ok(error_annotation) => error_annotation,
+        Err(_) => "".to_string(),
+    }
 }

--- a/crates/uroborosql-fmt/src/visitor/clause/for_update.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/for_update.rs
@@ -47,7 +47,7 @@ impl Visitor {
         }
 
         cursor.goto_parent();
-        ensure_kind(cursor, "for_update_clause")?;
+        ensure_kind(cursor, "for_update_clause", src)?;
 
         Ok(clauses)
     }

--- a/crates/uroborosql-fmt/src/visitor/clause/from.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/from.rs
@@ -37,7 +37,7 @@ impl Visitor {
 
         // cursorをfrom_clauseに戻す
         cursor.goto_parent();
-        ensure_kind(cursor, "from_clause")?;
+        ensure_kind(cursor, "from_clause", src)?;
 
         Ok(clause)
     }

--- a/crates/uroborosql-fmt/src/visitor/clause/group_by.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/group_by.rs
@@ -5,7 +5,7 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{create_clause, ensure_kind, Visitor, COMMA, COMMENT},
+    visitor::{create_clause, create_error_info, ensure_kind, Visitor, COMMA, COMMENT},
 };
 
 impl Visitor {
@@ -77,9 +77,8 @@ impl Visitor {
         let ret_value = match cursor.node().kind() {
             "grouping_sets_clause" | "rollup_clause" | "cube_clause" => {
                 Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_group_expression(): unimplemented node\nnode kind: {}\n{:?}",
-                    cursor.node().kind(),
-                    cursor.node().range()
+                    "visit_group_expression(): unimplemented node\n{}",
+                    create_error_info(cursor, src)
                 )))
             }
             _ => self.visit_expr(cursor, src),

--- a/crates/uroborosql-fmt/src/visitor/clause/group_by.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/group_by.rs
@@ -5,7 +5,7 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{create_clause, create_error_info, ensure_kind, Visitor, COMMA, COMMENT},
+    visitor::{create_clause, ensure_kind, error_annotation_from_cursor, Visitor, COMMA, COMMENT},
 };
 
 impl Visitor {
@@ -44,8 +44,8 @@ impl Visitor {
                 }
                 "ERROR" => {
                     return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                        "visit_group_by_clause: ERROR node appeared \n{:?}",
-                        cursor.node().range()
+                        "visit_group_by_clause: ERROR node appeared \n{}",
+                        error_annotation_from_cursor(cursor, src)
                     )));
                 }
                 _ => {
@@ -62,7 +62,7 @@ impl Visitor {
         }
 
         cursor.goto_parent();
-        ensure_kind(cursor, "group_by_clause")?;
+        ensure_kind(cursor, "group_by_clause", src)?;
 
         Ok(clauses)
     }
@@ -78,14 +78,14 @@ impl Visitor {
             "grouping_sets_clause" | "rollup_clause" | "cube_clause" => {
                 Err(UroboroSQLFmtError::Unimplemented(format!(
                     "visit_group_expression(): unimplemented node\n{}",
-                    create_error_info(cursor, src)
+                    error_annotation_from_cursor(cursor, src)
                 )))
             }
             _ => self.visit_expr(cursor, src),
         };
 
         cursor.goto_parent();
-        ensure_kind(cursor, "group_expression")?;
+        ensure_kind(cursor, "group_expression", src)?;
 
         ret_value
     }

--- a/crates/uroborosql-fmt/src/visitor/clause/join.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/join.rs
@@ -4,7 +4,7 @@ use crate::{
     config::CONFIG,
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{create_clause, ensure_kind, Visitor},
+    visitor::{create_clause, create_error_info, ensure_kind, Visitor},
 };
 
 impl Visitor {
@@ -80,9 +80,8 @@ impl Visitor {
                 cursor.node().range(),
             ))),
             _ => Err(UroboroSQLFmtError::Unimplemented(format!(
-                "visit_join_condition(): unimplemented node {}\n{:?}",
-                cursor.node().kind(),
-                cursor.node().range(),
+                "visit_join_condition(): unimplemented node\n{}",
+                create_error_info(cursor, src)
             ))),
         }
     }

--- a/crates/uroborosql-fmt/src/visitor/clause/limit.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/limit.rs
@@ -3,7 +3,7 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{ensure_kind, Visitor, COMMENT},
+    visitor::{ensure_kind, error_annotation_from_cursor, Visitor, COMMENT},
 };
 
 impl Visitor {
@@ -15,7 +15,7 @@ impl Visitor {
         src: &str,
     ) -> Result<Clause, UroboroSQLFmtError> {
         cursor.goto_first_child();
-        ensure_kind(cursor, "LIMIT")?;
+        ensure_kind(cursor, "LIMIT", src)?;
         let mut limit_clause = Clause::from_node(cursor.node(), src);
 
         cursor.goto_next_sibling();
@@ -44,15 +44,15 @@ impl Visitor {
             }
             _ => {
                 return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                    r#"visit_limit_clause(): expected node is number or ALL, but actual {}\n{:#?}"#,
+                    r#"visit_limit_clause(): expected node is number or ALL, but actual {}\n{}"#,
                     cursor.node().kind(),
-                    cursor.node().range()
+                    error_annotation_from_cursor(cursor, src)
                 )));
             }
         }
 
         cursor.goto_parent();
-        ensure_kind(cursor, "limit_clause")?;
+        ensure_kind(cursor, "limit_clause", src)?;
 
         Ok(limit_clause)
     }

--- a/crates/uroborosql-fmt/src/visitor/clause/offset.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/offset.rs
@@ -15,7 +15,7 @@ impl Visitor {
         src: &str,
     ) -> Result<Clause, UroboroSQLFmtError> {
         cursor.goto_first_child();
-        ensure_kind(cursor, "OFFSET")?;
+        ensure_kind(cursor, "OFFSET", src)?;
 
         let mut offset_clause = Clause::from_node(cursor.node(), src);
 
@@ -31,7 +31,7 @@ impl Visitor {
         offset_clause.set_body(body);
 
         cursor.goto_parent();
-        ensure_kind(cursor, "offset_clause")?;
+        ensure_kind(cursor, "offset_clause", src)?;
 
         Ok(offset_clause)
     }

--- a/crates/uroborosql-fmt/src/visitor/clause/order_by.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/order_by.rs
@@ -4,7 +4,7 @@ use crate::{
     cst::*,
     error::UroboroSQLFmtError,
     util::convert_keyword_case,
-    visitor::{create_clause, ensure_kind, Visitor, COMMA, COMMENT},
+    visitor::{create_clause, ensure_kind, error_annotation_from_cursor, Visitor, COMMA, COMMENT},
 };
 
 impl Visitor {
@@ -40,9 +40,9 @@ impl Visitor {
                 }
                 _ => {
                     return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                        "visit_order_by_clause(): unexpected node\nnode kind: {}\n{:?}",
+                        "visit_order_by_clause(): unexpected node\nnode kind: {}\n{}",
                         cursor.node().kind(),
-                        cursor.node().range()
+                        error_annotation_from_cursor(cursor, src)
                     )))
                 }
             }
@@ -52,7 +52,7 @@ impl Visitor {
         clause.set_body(body);
 
         cursor.goto_parent();
-        ensure_kind(cursor, "order_by_clause")?;
+        ensure_kind(cursor, "order_by_clause", src)?;
 
         Ok(clause)
     }
@@ -72,7 +72,7 @@ impl Visitor {
         let order_expr = self.visit_order_option(cursor, src, expr)?;
 
         cursor.goto_parent();
-        ensure_kind(cursor, "order_expression")?;
+        ensure_kind(cursor, "order_expression", src)?;
 
         Ok(order_expr)
     }

--- a/crates/uroborosql-fmt/src/visitor/clause/select.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/select.rs
@@ -92,7 +92,7 @@ impl Visitor {
 
         // cursorをselect_clauseに戻す
         cursor.goto_parent();
-        ensure_kind(cursor, "select_clause")?;
+        ensure_kind(cursor, "select_clause", src)?;
 
         Ok(clause)
     }
@@ -117,7 +117,7 @@ impl Visitor {
 
         // cursorをselect_clause_bodyに
         cursor.goto_parent();
-        ensure_kind(cursor, "select_clause_body")?;
+        ensure_kind(cursor, "select_clause_body", src)?;
 
         Ok(body)
     }

--- a/crates/uroborosql-fmt/src/visitor/clause/simple.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/simple.rs
@@ -37,7 +37,7 @@ impl Visitor {
 
         // cursorを戻す
         cursor.goto_parent();
-        ensure_kind(cursor, clause_node_name)?;
+        ensure_kind(cursor, clause_node_name, src)?;
 
         Ok(clause)
     }

--- a/crates/uroborosql-fmt/src/visitor/clause/where_clause.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/where_clause.rs
@@ -30,7 +30,7 @@ impl Visitor {
 
         // cursorをwhere_clauseに戻す
         cursor.goto_parent();
-        ensure_kind(cursor, "where_clause")?;
+        ensure_kind(cursor, "where_clause", src)?;
 
         Ok(clause)
     }

--- a/crates/uroborosql-fmt/src/visitor/clause/with.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/with.rs
@@ -4,7 +4,7 @@ use crate::{
     cst::*,
     error::UroboroSQLFmtError,
     util::{convert_identifier_case, convert_keyword_case},
-    visitor::{create_clause, ensure_kind, Visitor, COMMA, COMMENT},
+    visitor::{create_clause, create_error_info, ensure_kind, Visitor, COMMA, COMMENT},
 };
 
 impl Visitor {
@@ -149,10 +149,9 @@ impl Visitor {
             "update_statement" => self.visit_update_stmt(cursor, src)?,
             _ => {
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_cte(): Unimplemented statement\nnode_kind: {}\n{:#?}",
-                    cursor.node().kind(),
-                    cursor.node().range(),
-                )))
+                    "visit_cte(): Unimplemented statement\n{}",
+                    create_error_info(cursor, src)
+                )));
             }
         };
         stmt_loc.append(Location::new(cursor.node().range()));

--- a/crates/uroborosql-fmt/src/visitor/clause/with.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/with.rs
@@ -4,7 +4,7 @@ use crate::{
     cst::*,
     error::UroboroSQLFmtError,
     util::{convert_identifier_case, convert_keyword_case},
-    visitor::{create_clause, create_error_info, ensure_kind, Visitor, COMMA, COMMENT},
+    visitor::{create_clause, ensure_kind, error_annotation_from_cursor, Visitor, COMMA, COMMENT},
 };
 
 impl Visitor {
@@ -43,8 +43,8 @@ impl Visitor {
                 }
                 "ERROR" => {
                     return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                        "visit_with_clause: ERROR node appeared \n{:?}",
-                        cursor.node().range()
+                        "visit_with_clause: ERROR node appeared \n{}",
+                        error_annotation_from_cursor(cursor, src)
                     )));
                 }
                 _ => {
@@ -60,7 +60,7 @@ impl Visitor {
         with_clause.set_body(Body::With(Box::new(with_body)));
 
         cursor.goto_parent();
-        ensure_kind(cursor, "with_clause")?;
+        ensure_kind(cursor, "with_clause", src)?;
 
         Ok(with_clause)
     }
@@ -98,7 +98,7 @@ impl Visitor {
         }
 
         // cursor -> "AS"
-        ensure_kind(cursor, "AS")?;
+        ensure_kind(cursor, "AS", src)?;
 
         let as_keyword = convert_keyword_case(cursor.node().utf8_text(src.as_ref()).unwrap());
 
@@ -150,7 +150,7 @@ impl Visitor {
             _ => {
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
                     "visit_cte(): Unimplemented statement\n{}",
-                    create_error_info(cursor, src)
+                    error_annotation_from_cursor(cursor, src)
                 )));
             }
         };
@@ -166,7 +166,7 @@ impl Visitor {
         }
 
         // cursor -> )
-        ensure_kind(cursor, ")")?;
+        ensure_kind(cursor, ")", src)?;
         stmt_loc.append(Location::new(cursor.node().range()));
 
         // 開きかっことstatementの間にあるコメントを追加
@@ -178,7 +178,7 @@ impl Visitor {
 
         // cursorを戻しておく
         cursor.goto_parent();
-        ensure_kind(cursor, "cte")?;
+        ensure_kind(cursor, "cte", src)?;
 
         let mut cte = Cte::new(
             loc,

--- a/crates/uroborosql-fmt/src/visitor/expr.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr.rs
@@ -18,7 +18,7 @@ use crate::{cst::*, error::UroboroSQLFmtError, util::convert_identifier_case};
 
 pub(crate) use aliasable::{ComplementConfig, ComplementKind};
 
-use super::{create_error_info, ensure_kind, Visitor, COMMENT};
+use super::{ensure_kind, error_annotation_from_cursor, Visitor, COMMENT};
 
 impl Visitor {
     /// 式のフォーマットを行う。
@@ -63,8 +63,8 @@ impl Visitor {
                         "." => dotted_name.push('.'),
                         "ERROR" => {
                             return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                                "visit_expr: ERROR node appeared \n{:?}",
-                                cursor.node().range()
+                                "visit_expr: ERROR node appeared \n{}",
+                                error_annotation_from_cursor(cursor, src)
                             )));
                         }
                         _ => dotted_name.push_str(cursor.node().utf8_text(src.as_bytes()).unwrap()),
@@ -76,7 +76,7 @@ impl Visitor {
 
                 // cursorをdotted_nameに戻す
                 cursor.goto_parent();
-                ensure_kind(cursor, "dotted_name")?;
+                ensure_kind(cursor, "dotted_name", src)?;
 
                 Expr::Primary(Box::new(primary))
             }
@@ -141,7 +141,7 @@ impl Visitor {
                 // todo
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
                     "visit_expr(): unimplemented expression \n{}",
-                    create_error_info(cursor, src)
+                    error_annotation_from_cursor(cursor, src)
                 )));
             }
         };
@@ -155,7 +155,7 @@ impl Visitor {
                 // TODO: 隣接していないコメント
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
                     "visit_expr(): (bind parameter) separated comment\n{}",
-                    create_error_info(cursor, src)
+                    error_annotation_from_cursor(cursor, src)
                 )));
             }
         }

--- a/crates/uroborosql-fmt/src/visitor/expr.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr.rs
@@ -18,7 +18,7 @@ use crate::{cst::*, error::UroboroSQLFmtError, util::convert_identifier_case};
 
 pub(crate) use aliasable::{ComplementConfig, ComplementKind};
 
-use super::{ensure_kind, Visitor, COMMENT};
+use super::{create_error_info, ensure_kind, Visitor, COMMENT};
 
 impl Visitor {
     /// 式のフォーマットを行う。
@@ -140,9 +140,8 @@ impl Visitor {
             _ => {
                 // todo
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_expr(): unimplemented expression \nnode_kind: {}\n{:#?}",
-                    cursor.node().kind(),
-                    cursor.node().range(),
+                    "visit_expr(): unimplemented expression \n{}",
+                    create_error_info(cursor, src)
                 )));
             }
         };
@@ -155,9 +154,8 @@ impl Visitor {
             } else {
                 // TODO: 隣接していないコメント
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_expr(): (bind parameter) separated comment\nnode_kind: {}\n{:#?}",
-                    cursor.node().kind(),
-                    cursor.node().range(),
+                    "visit_expr(): (bind parameter) separated comment\n{}",
+                    create_error_info(cursor, src)
                 )));
             }
         }

--- a/crates/uroborosql-fmt/src/visitor/expr/aliasable.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/aliasable.rs
@@ -5,7 +5,7 @@ use crate::{
     cst::*,
     error::UroboroSQLFmtError,
     util::convert_keyword_case,
-    visitor::{create_alias, ensure_kind, Visitor, COMMENT},
+    visitor::{create_alias, ensure_kind, error_annotation_from_cursor, Visitor, COMMENT},
 };
 
 /// 補完の種類
@@ -120,8 +120,8 @@ impl Visitor {
                     } else {
                         // エイリアス式の直前のコメントは、バインドパラメータしか考慮していない
                         return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                            "visit_aliasable_expr(): unexpected comment\n{:?}",
-                            cursor.node().range()
+                            "visit_aliasable_expr(): unexpected comment\n{}",
+                            error_annotation_from_cursor(cursor, src)
                         )));
                     }
                 }
@@ -142,9 +142,9 @@ impl Visitor {
                             // 通常、エイリアスの直前に複数コメントが来るような書き方はしないため未対応
                             // エイリアスがない場合は、コメントノードがここに現れない
                             return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                                "visit_aliasable_expr(): unexpected syntax\nnode_kind: {}\n{:#?}",
+                                "visit_aliasable_expr(): unexpected syntax\nnode_kind: {}\n{}",
                                 cursor.node().kind(),
-                                cursor.node().range(),
+                                error_annotation_from_cursor(cursor, src)
                             )));
                         } else {
                             // 行末コメント
@@ -177,7 +177,7 @@ impl Visitor {
                     // cursor -> identifier
 
                     // identifier
-                    ensure_kind(cursor, "identifier")?;
+                    ensure_kind(cursor, "identifier", src)?;
 
                     let rhs_expr =
                         PrimaryExpr::with_node(cursor.node(), src, PrimaryExprKind::Expr);

--- a/crates/uroborosql-fmt/src/visitor/expr/assignment.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/assignment.rs
@@ -16,14 +16,14 @@ impl Visitor {
         cursor.goto_first_child();
         let identifier = self.visit_expr(cursor, src)?;
         cursor.goto_next_sibling();
-        ensure_kind(cursor, "=")?;
+        ensure_kind(cursor, "=", src)?;
         cursor.goto_next_sibling();
         let expr = self.visit_expr(cursor, src)?;
 
         let mut aligned = AlignedExpr::new(identifier);
         aligned.add_rhs(Some("=".to_string()), expr);
         cursor.goto_parent();
-        ensure_kind(cursor, "assigment_expression")?;
+        ensure_kind(cursor, "assigment_expression", src)?;
 
         Ok(aligned)
     }

--- a/crates/uroborosql-fmt/src/visitor/expr/binary.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/binary.rs
@@ -43,7 +43,7 @@ impl Visitor {
 
         // cursorを戻しておく
         cursor.goto_parent();
-        ensure_kind(cursor, "binary_expression")?;
+        ensure_kind(cursor, "binary_expression", src)?;
 
         if is_comp_op(&op_str) {
             // 比較演算子ならばそろえる必要があるため、AlignedExprとする

--- a/crates/uroborosql-fmt/src/visitor/expr/boolean.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/boolean.rs
@@ -38,7 +38,7 @@ impl Visitor {
             let not_expr = UnaryExpr::new(convert_keyword_case(not_keyword), expr, loc);
 
             cursor.goto_parent();
-            ensure_kind(cursor, "boolean_expression")?;
+            ensure_kind(cursor, "boolean_expression", src)?;
 
             // Unaryとして返す
             return Ok(Expr::Unary(Box::new(not_expr)));
@@ -83,7 +83,7 @@ impl Visitor {
         }
         // cursorをboolean_expressionに戻す
         cursor.goto_parent();
-        ensure_kind(cursor, "boolean_expression")?;
+        ensure_kind(cursor, "boolean_expression", src)?;
 
         Ok(Expr::Boolean(Box::new(boolean_expr)))
     }
@@ -113,7 +113,7 @@ impl Visitor {
             cursor.goto_next_sibling();
         }
 
-        ensure_kind(cursor, "BETWEEN")?;
+        ensure_kind(cursor, "BETWEEN", src)?;
         let between_keyword = cursor.node().utf8_text(src.as_bytes()).unwrap();
         operator += &convert_keyword_case(between_keyword);
         cursor.goto_next_sibling();
@@ -133,7 +133,7 @@ impl Visitor {
             None
         };
 
-        ensure_kind(cursor, "AND")?;
+        ensure_kind(cursor, "AND", src)?;
         let and_keyword = cursor.node().utf8_text(src.as_bytes()).unwrap();
         cursor.goto_next_sibling();
         // cursor -> _expression
@@ -153,7 +153,7 @@ impl Visitor {
         aligned.add_rhs(Some(operator), Expr::Aligned(Box::new(rhs)));
 
         cursor.goto_parent();
-        ensure_kind(cursor, "between_and_expression")?;
+        ensure_kind(cursor, "between_and_expression", src)?;
 
         Ok(aligned)
     }
@@ -183,7 +183,7 @@ impl Visitor {
             cursor.goto_next_sibling();
         }
 
-        ensure_kind(cursor, "LIKE")?;
+        ensure_kind(cursor, "LIKE", src)?;
 
         let text = cursor.node().utf8_text(src.as_bytes()).unwrap();
         operator += &convert_keyword_case(text);
@@ -221,7 +221,7 @@ impl Visitor {
         aligned.add_rhs(Some(operator), expr_seq);
 
         cursor.goto_parent();
-        ensure_kind(cursor, "like_expression")?;
+        ensure_kind(cursor, "like_expression", src)?;
 
         Ok(aligned)
     }

--- a/crates/uroborosql-fmt/src/visitor/expr/column_list.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/column_list.rs
@@ -3,7 +3,7 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{ensure_kind, Visitor, COMMA, COMMENT},
+    visitor::{ensure_kind, error_annotation_from_cursor, Visitor, COMMA, COMMENT},
 };
 
 impl Visitor {
@@ -14,7 +14,7 @@ impl Visitor {
         cursor: &mut TreeCursor,
         src: &str,
     ) -> Result<ColumnList, UroboroSQLFmtError> {
-        ensure_kind(cursor, "(")?;
+        ensure_kind(cursor, "(", src)?;
 
         // ColumnListの位置
         let mut loc = Location::new(cursor.node().range());
@@ -49,17 +49,17 @@ impl Visitor {
                     } else {
                         // バインドパラメータ、末尾コメント以外のコメントは想定していない
                         return Err(UroboroSQLFmtError::Unimplemented(format!(
-                            "visit_column_list(): Unexpected comment\nnode_kind: {}\n{:#?}",
+                            "visit_column_list(): Unexpected comment\nnode_kind: {}\n{}",
                             cursor.node().kind(),
-                            cursor.node().range(),
+                            error_annotation_from_cursor(cursor, src)
                         )));
                     }
                 }
                 _ => {
                     return Err(UroboroSQLFmtError::Unimplemented(format!(
-                        "visit_column_list(): Unexpected node\nnode_kind: {}\n{:#?}",
+                        "visit_column_list(): Unexpected node\nnode_kind: {}\n{}",
                         cursor.node().kind(),
-                        cursor.node().range(),
+                        error_annotation_from_cursor(cursor, src)
                     )));
                 }
             }

--- a/crates/uroborosql-fmt/src/visitor/expr/cond.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/cond.rs
@@ -116,7 +116,7 @@ impl Visitor {
         }
 
         cursor.goto_parent();
-        ensure_kind(cursor, "conditional_expression")?;
+        ensure_kind(cursor, "conditional_expression", src)?;
 
         Ok(cond_expr)
     }

--- a/crates/uroborosql-fmt/src/visitor/expr/is.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/is.rs
@@ -20,7 +20,7 @@ impl Visitor {
         let lhs = self.visit_expr(cursor, src)?;
 
         cursor.goto_next_sibling();
-        ensure_kind(cursor, "IS")?;
+        ensure_kind(cursor, "IS", src)?;
         let op = convert_keyword_case(cursor.node().utf8_text(src.as_bytes()).unwrap());
         cursor.goto_next_sibling();
 
@@ -42,7 +42,7 @@ impl Visitor {
         aligned.add_rhs(Some(op), rhs);
 
         cursor.goto_parent();
-        ensure_kind(cursor, "is_expression")?;
+        ensure_kind(cursor, "is_expression", src)?;
 
         Ok(aligned)
     }

--- a/crates/uroborosql-fmt/src/visitor/expr/paren.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/paren.rs
@@ -67,7 +67,7 @@ impl Visitor {
 
         // tree-sitter-sqlを修正したら削除する
         cursor.goto_parent();
-        ensure_kind(cursor, "parenthesized_expression")?;
+        ensure_kind(cursor, "parenthesized_expression", src)?;
 
         Ok(paren_expr)
     }

--- a/crates/uroborosql-fmt/src/visitor/expr/subquery.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/subquery.rs
@@ -56,7 +56,7 @@ impl Visitor {
 
         // cursor -> )
         cursor.goto_parent();
-        ensure_kind(cursor, "select_subexpression")?;
+        ensure_kind(cursor, "select_subexpression", src)?;
 
         Ok(SubExpr::new(select_stmt, loc))
     }
@@ -74,7 +74,7 @@ impl Visitor {
         cursor.goto_first_child();
         // cursor -> "EXISTS"
 
-        ensure_kind(cursor, "EXISTS")?;
+        ensure_kind(cursor, "EXISTS", src)?;
         let exists_keyword = convert_keyword_case(cursor.node().utf8_text(src.as_bytes()).unwrap());
 
         cursor.goto_next_sibling();
@@ -85,7 +85,7 @@ impl Visitor {
         let exists_subquery = ExistsSubquery::new(&exists_keyword, select_subexpr, exists_loc);
 
         cursor.goto_parent();
-        ensure_kind(cursor, "exists_subquery_expression")?;
+        ensure_kind(cursor, "exists_subquery_expression", src)?;
 
         Ok(exists_subquery)
     }
@@ -122,21 +122,21 @@ impl Visitor {
             // cursor -> "IN"
         }
 
-        ensure_kind(cursor, "IN")?;
+        ensure_kind(cursor, "IN", src)?;
         op.push_str(&convert_keyword_case(
             cursor.node().utf8_text(src.as_bytes()).unwrap(),
         ));
         cursor.goto_next_sibling();
         // cursor -> select_subexpression
 
-        ensure_kind(cursor, "select_subexpression")?;
+        ensure_kind(cursor, "select_subexpression", src)?;
         let rhs = Expr::Sub(Box::new(self.visit_select_subexpr(cursor, src)?));
 
         let mut in_sub = AlignedExpr::new(lhs);
         in_sub.add_rhs(Some(op), rhs);
 
         cursor.goto_parent();
-        ensure_kind(cursor, "in_subquery_expression")?;
+        ensure_kind(cursor, "in_subquery_expression", src)?;
 
         Ok(in_sub)
     }
@@ -187,7 +187,7 @@ impl Visitor {
         );
 
         cursor.goto_parent();
-        ensure_kind(cursor, "all_some_any_subquery_expression")?;
+        ensure_kind(cursor, "all_some_any_subquery_expression", src)?;
 
         Ok(all_some_any_sub)
     }

--- a/crates/uroborosql-fmt/src/visitor/statement/delete.rs
+++ b/crates/uroborosql-fmt/src/visitor/statement/delete.rs
@@ -3,7 +3,7 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{create_clause, create_error_info, ensure_kind, Visitor, COMMENT},
+    visitor::{create_clause, ensure_kind, error_annotation_from_cursor, Visitor, COMMENT},
 };
 
 impl Visitor {
@@ -29,7 +29,7 @@ impl Visitor {
         }
 
         // cursor -> delete_clause
-        ensure_kind(cursor, "DELETE")?;
+        ensure_kind(cursor, "DELETE", src)?;
 
         // DELETE
         let mut clause = create_clause(cursor, src, "DELETE")?;
@@ -61,14 +61,14 @@ impl Visitor {
                 _ => {
                     return Err(UroboroSQLFmtError::Unimplemented(format!(
                         "visit_delete_stmt(): unimplemented delete_statement\n{}",
-                        create_error_info(cursor, src)
+                        error_annotation_from_cursor(cursor, src)
                     )));
                 }
             }
         }
 
         cursor.goto_parent();
-        ensure_kind(cursor, "delete_statement")?;
+        ensure_kind(cursor, "delete_statement", src)?;
 
         Ok(statement)
     }

--- a/crates/uroborosql-fmt/src/visitor/statement/delete.rs
+++ b/crates/uroborosql-fmt/src/visitor/statement/delete.rs
@@ -3,7 +3,7 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{create_clause, ensure_kind, Visitor, COMMENT},
+    visitor::{create_clause, create_error_info, ensure_kind, Visitor, COMMENT},
 };
 
 impl Visitor {
@@ -60,10 +60,9 @@ impl Visitor {
                 }
                 _ => {
                     return Err(UroboroSQLFmtError::Unimplemented(format!(
-                        "visit_delete_stmt(): unimplemented delete_statement\nnode_kind: {}\n{:#?}",
-                        cursor.node().kind(),
-                        cursor.node().range(),
-                    )))
+                        "visit_delete_stmt(): unimplemented delete_statement\n{}",
+                        create_error_info(cursor, src)
+                    )));
                 }
             }
         }

--- a/crates/uroborosql-fmt/src/visitor/statement/select.rs
+++ b/crates/uroborosql-fmt/src/visitor/statement/select.rs
@@ -3,7 +3,7 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{ensure_kind, Visitor, COMMENT},
+    visitor::{ensure_kind, error_annotation_from_cursor, Visitor, COMMENT},
 };
 
 impl Visitor {
@@ -41,7 +41,7 @@ impl Visitor {
         }
 
         // cursor -> select_clause
-        ensure_kind(cursor, "select_clause")?;
+        ensure_kind(cursor, "select_clause", src)?;
 
         // select句を追加する
         statement.add_clause(self.visit_select_clause(cursor, src)?);
@@ -121,8 +121,8 @@ impl Visitor {
                 }
                 "ERROR" => {
                     return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                        "visit_select_stmt: ERROR node appeared \n{:?}",
-                        cursor.node().range()
+                        "visit_select_stmt: ERROR node appeared \n{}",
+                        error_annotation_from_cursor(cursor, src)
                     )));
                 }
                 _ => {
@@ -132,7 +132,7 @@ impl Visitor {
         }
 
         cursor.goto_parent();
-        ensure_kind(cursor, "select_statement")?;
+        ensure_kind(cursor, "select_statement", src)?;
 
         Ok(statement)
     }

--- a/crates/uroborosql-fmt/src/visitor/statement/update.rs
+++ b/crates/uroborosql-fmt/src/visitor/statement/update.rs
@@ -3,7 +3,7 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{create_clause, ensure_kind, Visitor, COMMENT},
+    visitor::{create_clause, create_error_info, ensure_kind, Visitor, COMMENT},
 };
 
 impl Visitor {
@@ -88,10 +88,9 @@ impl Visitor {
                 }
                 _ => {
                     return Err(UroboroSQLFmtError::Unimplemented(format!(
-                        "visit_update_stmt(): unimplemented update_statement\nnode_kind: {}\n{:#?}",
-                        cursor.node().kind(),
-                        cursor.node().range(),
-                    )))
+                        "visit_update_stmt(): unimplemented update_statement\n{}",
+                        create_error_info(cursor, src)
+                    )));
                 }
             }
         }

--- a/crates/uroborosql-fmt/src/visitor/statement/update.rs
+++ b/crates/uroborosql-fmt/src/visitor/statement/update.rs
@@ -3,7 +3,7 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{create_clause, create_error_info, ensure_kind, Visitor, COMMENT},
+    visitor::{create_clause, ensure_kind, error_annotation_from_cursor, Visitor, COMMENT},
 };
 
 impl Visitor {
@@ -28,7 +28,7 @@ impl Visitor {
         }
 
         // cursor -> update_clause
-        ensure_kind(cursor, "UPDATE")?;
+        ensure_kind(cursor, "UPDATE", src)?;
 
         let mut update_clause = create_clause(cursor, src, "UPDATE")?;
         cursor.goto_next_sibling();
@@ -58,7 +58,7 @@ impl Visitor {
         }
 
         // set句を処理する
-        ensure_kind(cursor, "set_clause")?;
+        ensure_kind(cursor, "set_clause", src)?;
         let set_clause = self.visit_set_clause(cursor, src)?;
         statement.add_clause(set_clause);
 
@@ -89,14 +89,14 @@ impl Visitor {
                 _ => {
                     return Err(UroboroSQLFmtError::Unimplemented(format!(
                         "visit_update_stmt(): unimplemented update_statement\n{}",
-                        create_error_info(cursor, src)
+                        error_annotation_from_cursor(cursor, src)
                     )));
                 }
             }
         }
 
         cursor.goto_parent();
-        ensure_kind(cursor, "update_statement")?;
+        ensure_kind(cursor, "update_statement", src)?;
 
         Ok(statement)
     }

--- a/out.sql
+++ b/out.sql
@@ -1,0 +1,4 @@
+delete from tbl_a a
+using   
+    tbl_b b
+where a.col1 = b.col1 and b.col2 > 10

--- a/out.sql
+++ b/out.sql
@@ -1,4 +1,0 @@
-delete from tbl_a a
-using   
-    tbl_b b
-where a.col1 = b.col1 and b.col2 > 10

--- a/test.sql
+++ b/test.sql
@@ -1,0 +1,4 @@
+delete from tbl_a a
+using   
+    tbl_b b
+where a.col1 = b.col1 and b.col2 > 10

--- a/test.sql
+++ b/test.sql
@@ -1,4 +1,0 @@
-delete from tbl_a a
-using   
-    tbl_b b
-where a.col1 = b.col1 and b.col2 > 10

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -201,7 +201,7 @@
     </div>
   </div>
 
-  <div id="error_msg" style="color: red;"></div>
+  <pre><code id="error_msg" style="color: red;"></code></pre>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.43.0/min/vs/loader.min.js"></script>
   <script src="main.js"></script>

--- a/wasm/ja.html
+++ b/wasm/ja.html
@@ -197,7 +197,7 @@
     </div>
   </div>
 
-  <div id="error_msg" style="color: red;"></div>
+  <pre><code id="error_msg" style="color: red;"></code></pre>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.43.0/min/vs/loader.min.js"></script>
   <script src="main.js"></script>

--- a/wasm/style.css
+++ b/wasm/style.css
@@ -2,6 +2,10 @@ body {
   font-size: small;
 }
 
+code {
+  font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+}
+
 /* options */
 #tab_size {
   width: 68px;


### PR DESCRIPTION
<img width="1440" alt="スクリーンショット 2023-10-28 17 26 13" src="https://github.com/future-architect/uroborosql-fmt/assets/52311998/9c119a28-e792-479c-bcb6-c44de392816e">

## 概要
- `visitor/`以下、`validate.rs`において発生するエラーの表示をcargo風に変更しました。

## 例1 (ERRORノードが発生した場合)
input
```sql
select * from test from test from test
```

従来
```sh
Unexpected syntax error: visit_select_stmt: ERROR node appeared
Range { start_byte: 9, end_byte: 28, start_point: Point { row: 0, column: 9 }, end_point: Point { row: 0, column: 28 } }
```

変更後
```sh
Unexpected syntax error: visit_select_stmt: ERROR node appeared 
  |
1 | select * from test from test from test
  |          ^^^^^^^^^^^^^^^^^^^ Appears as "ERROR" node on the CST
  |
```

## 例2 (フォーマット前とフォーマット後のトークン数が違う場合)
input
```sql
seelect * from y
```

従来
```sh
Validation Error: different length. src=2, dst=1
```

変更後
```sh
Validation Error: different kind token: Errors have occurred near the following token
  |
1 | seelect * from y
  |         ^ After format: " (kind: source_file)"
  |
```

close #32