### PR TITLE
Rename the configuration file to .uroborosqlfmtrc.json

### DIFF
--- a/.uroborosqlfmtrc.json
+++ b/.uroborosqlfmtrc.json
@@ -12,5 +12,5 @@
   "remove_redundant_nest": true,
   "complement_sql_id": true,
   "convert_double_colon_cast": false,
-  "unify_not_equal" : true
+  "unify_not_equal": true
 }

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The formatting result of `input.sql` will output to `result.sql`.
 
 ### Configuration options
 
-Create `uroborosqlfmt-config.json` in the directory where you run the command and write the configuration there.
+Create `.uroborosqlfmtrc.json` in the directory where you run the command and write the configuration there.
 
 If there is no configuration file, the default values are used.
 

--- a/crates/uroborosql-fmt-cli/src/main.rs
+++ b/crates/uroborosql-fmt-cli/src/main.rs
@@ -13,10 +13,10 @@ fn main() {
 
     let src = read_to_string(input_file).unwrap();
 
-    let config_path = match Path::is_file(Path::new("./uroborosqlfmt-config.json")) {
-        true => Some("./uroborosqlfmt-config.json"),
+    let config_path = match Path::is_file(Path::new("./.uroborosqlfmtrc.json")) {
+        true => Some("./.uroborosqlfmtrc.json"),
         false => {
-            eprintln!("hint: Create the file 'uroborosqlfmt-config.json' if you want to customize the configuration");
+            eprintln!("hint: Create the file '.uroborosqlfmtrc.json' if you want to customize the configuration");
             None
         }
     };


### PR DESCRIPTION
VSCode拡張に合わせて設定ファイルの名前を`uroborosqlfmt-config.json`から`.uroborosqlfmtrc.json`に変更しました．

Close #40 