### PR TITLE
Correction indentation when the HAVING clause contains AND/OR

### DIFF
--- a/crates/uroborosql-fmt/src/cst/expr.rs
+++ b/crates/uroborosql-fmt/src/cst/expr.rs
@@ -25,6 +25,7 @@ use super::{ColumnList, Comment, ExistsSubquery, ExprSeq, Location, SeparatedLin
 ///
 /// renderの際に改行とインデントをせずに描画する（※ ただし、例外的にExpr::Booleanは先頭での改行とインデントを行う）
 #[derive(Debug, Clone)]
+#[allow(clippy::enum_variant_names)] // TODO: この警告を解消する (https://rust-lang.github.io/rust-clippy/master/index.html#/enum_variant_names)
 pub(crate) enum Expr {
     /// AS句、二項比較演算、BETWEEN述語など、縦ぞろえを行う式
     Aligned(Box<AlignedExpr>),

--- a/crates/uroborosql-fmt/src/two_way_sql/merge.rs
+++ b/crates/uroborosql-fmt/src/two_way_sql/merge.rs
@@ -5,7 +5,7 @@ use crate::error::UroboroSQLFmtError;
 use super::{dag::Kind, tree::TreeNode};
 
 /// 現在のネストのENDまで読む
-fn read_before_end(src_lines: &Vec<&str>, cursor: &mut usize) -> Vec<String> {
+fn read_before_end(src_lines: &[&str], cursor: &mut usize) -> Vec<String> {
     let mut res_lines = vec![];
     let mut nest_count = 0;
 

--- a/crates/uroborosql-fmt/src/validate.rs
+++ b/crates/uroborosql-fmt/src/validate.rs
@@ -206,7 +206,7 @@ fn compare_token_text(
 }
 
 /// トークン列に [カンマ, 行末コメント] の並びがあれば、それを入れ替える関数。
-fn swap_comma_and_trailing_comment(tokens: &mut Vec<Token>) {
+fn swap_comma_and_trailing_comment(tokens: &mut [Token]) {
     for idx in 0..(tokens.len() - 1) {
         let fst_tok = tokens.get(idx).unwrap();
 

--- a/crates/uroborosql-fmt/src/visitor/clause.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause.rs
@@ -2,6 +2,7 @@ mod for_update;
 mod frame;
 mod from;
 mod group_by;
+mod having;
 mod join;
 mod limit;
 mod offset;

--- a/crates/uroborosql-fmt/src/visitor/clause/group_by.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/group_by.rs
@@ -58,7 +58,7 @@ impl Visitor {
         clauses.push(clause);
 
         if cursor.node().kind() == "having_clause" {
-            clauses.push(self.visit_simple_clause(cursor, src, "having_clause", "HAVING")?);
+            clauses.push(self.visit_having_clause(cursor, src)?);
         }
 
         cursor.goto_parent();

--- a/crates/uroborosql-fmt/src/visitor/clause/group_by.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/group_by.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 impl Visitor {
-    /// GROPU BY句に対応するClauseを持つVecを返す。
+    /// GROUP BY句に対応するClauseを持つVecを返す。
     /// HAVING句がある場合は、HAVING句に対応するClauseも含む。
     pub(crate) fn visit_group_by_clause(
         &mut self,

--- a/crates/uroborosql-fmt/src/visitor/clause/having.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/having.rs
@@ -1,0 +1,36 @@
+use tree_sitter::TreeCursor;
+
+use crate::{
+    cst::*,
+    error::UroboroSQLFmtError,
+    visitor::{create_clause, ensure_kind, Visitor},
+};
+
+impl Visitor {
+    /// HAVING句をClauseで返す
+    pub(crate) fn visit_having_clause(
+        &mut self,
+        cursor: &mut TreeCursor,
+        src: &str,
+    ) -> Result<Clause, UroboroSQLFmtError> {
+        cursor.goto_first_child();
+
+        let mut clause = create_clause(cursor, src, "HAVING")?;
+        cursor.goto_next_sibling();
+        self.consume_comment_in_clause(cursor, src, &mut clause)?;
+
+        // cursor -> _expression
+        let expr = self.visit_expr(cursor, src)?;
+
+        // 結果として得られた式をBodyに変換する
+        let body = Body::from(expr);
+
+        clause.set_body(body);
+
+        // cursorを戻す
+        cursor.goto_parent();
+        ensure_kind(cursor, "having_clause", src)?;
+
+        Ok(clause)
+    }
+}

--- a/crates/uroborosql-fmt/testfiles/dst/select/group_by.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/group_by.sql
@@ -6,6 +6,7 @@ from
 group by
 	id
 having
+/* comment */
 	sum(cnt)	>	1
 and	avg(cnt)	<	10
 ;

--- a/crates/uroborosql-fmt/testfiles/dst/select/group_by.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/group_by.sql
@@ -1,0 +1,11 @@
+select
+	id			as	id
+,	sum(cnt)
+from
+	tbl
+group by
+	id
+having
+	sum(cnt)	>	1
+and	avg(cnt)	<	10
+;

--- a/crates/uroborosql-fmt/testfiles/src/select/group_by.sql
+++ b/crates/uroborosql-fmt/testfiles/src/select/group_by.sql
@@ -1,0 +1,9 @@
+select
+	id, sum(cnt)
+from
+	tbl
+	group by
+	id
+	having
+	sum(cnt)	>	1 and avg(cnt)	<	10
+;

--- a/crates/uroborosql-fmt/testfiles/src/select/group_by.sql
+++ b/crates/uroborosql-fmt/testfiles/src/select/group_by.sql
@@ -4,6 +4,7 @@ from
 	tbl
 	group by
 	id
-	having
+	having 
+    /* comment */
 	sum(cnt)	>	1 and avg(cnt)	<	10
 ;


### PR DESCRIPTION
 HAVING句がAND/ORを持つ場合にインデントがずれていたバグを修正しました。

After: 
```sql
select
	id			as	id
,	sum(cnt)
from
	tbl
group by
	id
having
	sum(cnt)	>	1
and	avg(cnt)	<	10
;

```

close #49 