### PR TITLE
Fix consecutive comments at the end of with_clause parentheses

### DIFF
--- a/crates/uroborosql-fmt/src/visitor/clause/with.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/with.rs
@@ -159,7 +159,7 @@ impl Visitor {
         cursor.goto_next_sibling();
 
         // statementの最後のコメントを処理する
-        if cursor.node().kind() == COMMENT {
+        while cursor.node().kind() == COMMENT {
             let comment = Comment::new(cursor.node(), src);
             statement.add_comment_to_child(comment)?;
             cursor.goto_next_sibling();

--- a/crates/uroborosql-fmt/testfiles/dst/select/with.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/with.sql
@@ -6,6 +6,7 @@ with /* _SQL_ID_ */
 			*
 		from
 			foo
+		-- end
 	)	-- test
 ,	t2	as	(
 		--internal_comment

--- a/crates/uroborosql-fmt/testfiles/dst/select/with.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/with.sql
@@ -5,7 +5,7 @@ with /* _SQL_ID_ */
 		select
 			*
 		from
-			foo
+			foo	-- foo
 		-- end
 	)	-- test
 ,	t2	as	(

--- a/crates/uroborosql-fmt/testfiles/src/select/with.sql
+++ b/crates/uroborosql-fmt/testfiles/src/select/with.sql
@@ -1,6 +1,7 @@
 WITH/* _SQL_ID_ */ t -- with句
 AS not materialized( --internal_comment
     SELECT * FROM foo
+	-- end
 ), --test
 
 t2 AS ( --internal_comment

--- a/crates/uroborosql-fmt/testfiles/src/select/with.sql
+++ b/crates/uroborosql-fmt/testfiles/src/select/with.sql
@@ -1,6 +1,6 @@
 WITH/* _SQL_ID_ */ t -- with句
 AS not materialized( --internal_comment
-    SELECT * FROM foo
+    SELECT * FROM foo -- foo
 	-- end
 ), --test
 


### PR DESCRIPTION
fix #61

with句の中の閉じ括弧直前に複数コメントがある場合にもエラーにならずフォーマットされるようにしました
```sql
with T as (
		select
			*
		from
			T	t
		where
			1		=	1
		AND	t.id	=	1	-- ID
		-- multiple
		-- formatted
		-- comments
)
select
	*
from T t
```
