### PR TITLE
Fix swapping positions of comma and comment

### DIFF
--- a/crates/uroborosql-fmt/src/cst.rs
+++ b/crates/uroborosql-fmt/src/cst.rs
@@ -29,7 +29,7 @@ pub(crate) use with::*;
 use itertools::{repeat_n, Itertools};
 use tree_sitter::{Node, Point, Range};
 
-use crate::{config::CONFIG, error::UroboroSQLFmtError};
+use crate::{config::CONFIG, error::UroboroSQLFmtError, re::RE};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Position {
@@ -109,6 +109,10 @@ impl Comment {
     /// コメントがブロックコメントであればtrueを返す
     pub(crate) fn is_block_comment(&self) -> bool {
         self.text.starts_with("/*")
+    }
+
+    pub(crate) fn is_two_way_sql_comment(&self) -> bool {
+        RE.branching_keyword_re.find(self.text.as_str()).is_some()
     }
 
     fn render(&self, depth: usize) -> Result<String, UroboroSQLFmtError> {

--- a/crates/uroborosql-fmt/src/cst/body/separeted_lines.rs
+++ b/crates/uroborosql-fmt/src/cst/body/separeted_lines.rs
@@ -89,14 +89,12 @@ impl SepLinesContent {
                         result.push('\n');
                     }
                     result.push_str(&comment.render(depth - 1)?);
+                } else if is_first {
+                    is_first = false;
+                    result.push('\t');
+                    result.push_str(&comment.render(0)?);
                 } else {
-                    if is_first {
-                        is_first = false;
-                        result.push('\t');
-                        result.push_str(&comment.render(0)?);
-                    } else {
-                        result.push_str(&comment.render(new_depth_with_sep)?);
-                    }
+                    result.push_str(&comment.render(new_depth_with_sep)?);
                 }
 
                 result.push('\n');

--- a/crates/uroborosql-fmt/src/cst/body/separeted_lines.rs
+++ b/crates/uroborosql-fmt/src/cst/body/separeted_lines.rs
@@ -80,23 +80,23 @@ impl SepLinesContent {
 
         // セパレータ (カンマ, AND, OR) と式の間に現れるコメント
         if !self.preceding_comments.is_empty() {
-            result.push('\t');
-
             let mut is_first = true;
             for comment in &self.preceding_comments {
-                if is_first {
-                    is_first = false;
+                if comment.is_two_way_sql_comment() {
+                    if is_first {
+                        is_first = false;
 
-                    // 最初の要素かつ2WaySQLコメントならば改行を追加
-                    if comment.is_two_way_sql_comment() {
                         result.push('\n');
                     }
-                    result.push_str(&comment.render(0)?);
-                } else if comment.is_two_way_sql_comment() {
-                    // 2WaySQLコメントならば行頭に出力
-                    result.push_str(&comment.render(0)?);
+                    result.push_str(&comment.render(depth - 1)?);
                 } else {
-                    result.push_str(&comment.render(new_depth_with_sep)?);
+                    if is_first {
+                        is_first = false;
+                        result.push('\t');
+                        result.push_str(&comment.render(0)?);
+                    } else {
+                        result.push_str(&comment.render(new_depth_with_sep)?);
+                    }
                 }
 
                 result.push('\n');

--- a/crates/uroborosql-fmt/src/cst/body/separeted_lines.rs
+++ b/crates/uroborosql-fmt/src/cst/body/separeted_lines.rs
@@ -78,7 +78,7 @@ impl SepLinesContent {
         // sepを考慮したdepth
         let new_depth_with_sep = depth - 1 + to_tab_num(1.max(max_sep_len));
 
-        // AND/OR と式の間に現れるコメント
+        // セパレータ (カンマ, AND, OR) と式の間に現れるコメント
         if !self.preceding_comments.is_empty() {
             result.push('\t');
 
@@ -86,10 +86,19 @@ impl SepLinesContent {
             for comment in &self.preceding_comments {
                 if is_first {
                     is_first = false;
+
+                    // 最初の要素かつ2WaySQLコメントならば改行を追加
+                    if comment.is_two_way_sql_comment() {
+                        result.push('\n');
+                    }
+                    result.push_str(&comment.render(0)?);
+                } else if comment.is_two_way_sql_comment() {
+                    // 2WaySQLコメントならば行頭に出力
                     result.push_str(&comment.render(0)?);
                 } else {
                     result.push_str(&comment.render(new_depth_with_sep)?);
                 }
+
                 result.push('\n');
             }
 

--- a/crates/uroborosql-fmt/testfiles/dst/2way_sql/comment.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/2way_sql/comment.sql
@@ -1,0 +1,47 @@
+select
+	*
+from
+	foo	f
+order by
+/*IF true*/
+	f.bar1
+,	
+/*END*/
+	f.bar2
+,	f.bar3
+select
+	*
+from
+	foo	f
+order by
+/*IF true*/
+	f.bar1
+,	
+/*END*/
+	f.bar2
+,	f.bar3
+select
+	*
+from
+	foo	f
+order by
+/*IF true*/
+	f.bar1
+,	
+/*END*/
+	-- comment
+	f.bar2
+,	f.bar3
+select
+	*
+from
+	foo	f
+order by
+/*IF true*/
+	f.bar1
+,	/*prev*/
+/*END*/
+	/*next*/
+	-- some
+	f.bar2
+,	f.bar3

--- a/crates/uroborosql-fmt/testfiles/dst/2way_sql/comment.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/2way_sql/comment.sql
@@ -5,7 +5,7 @@ from
 order by
 /*IF true*/
 	f.bar1
-,	
+,
 /*END*/
 	f.bar2
 ,	f.bar3
@@ -16,7 +16,7 @@ from
 order by
 /*IF true*/
 	f.bar1
-,	
+,
 /*END*/
 	f.bar2
 ,	f.bar3
@@ -27,7 +27,7 @@ from
 order by
 /*IF true*/
 	f.bar1
-,	
+,
 /*END*/
 	-- comment
 	f.bar2
@@ -45,3 +45,20 @@ order by
 	-- some
 	f.bar2
 ,	f.bar3
+select
+	*
+from
+	(
+		select
+			*
+		from
+			foo	f
+		order by
+		/*IF true*/
+			f.bar1
+		,
+		/*END*/
+			-- comment
+			f.bar2
+		,	f.bar3
+	)

--- a/crates/uroborosql-fmt/testfiles/dst/select/order_by.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/order_by.sql
@@ -6,3 +6,21 @@ order by
 	col			asc					-- 昇順
 ,	long_col	desc nulls first	-- 降順
 ,	null_col	nulls first			-- NULL先
+select
+	*
+from
+	foo	t
+order by
+	t.bar1
+,	/* after comma */
+	t.bar2
+,	t.bar3
+select
+	*
+from
+	foo	t
+order by
+	t.bar1
+/* before comma */
+,	t.bar2
+,	t.bar3

--- a/crates/uroborosql-fmt/testfiles/src/2way_sql/comment.sql
+++ b/crates/uroborosql-fmt/testfiles/src/2way_sql/comment.sql
@@ -1,0 +1,37 @@
+select * from foo f
+order by
+/*IF true*/
+    f.bar1
+,/*END*/
+    f.bar2
+,   f.bar3
+
+select * from foo f
+order by /*IF true*/
+    f.bar1,   
+/*END*/
+    f.bar2
+, f.bar3
+
+select 
+    *
+from
+    foo f
+order by
+/*IF true*/
+    f.bar1
+,/*END*/ -- comment
+    f.bar2
+,   f.bar3
+
+
+select 
+    *
+from
+    foo f
+order by
+/*IF true*/
+    f.bar1
+,/*prev*//*END*//*next*/ -- some
+    f.bar2
+,   f.bar3

--- a/crates/uroborosql-fmt/testfiles/src/2way_sql/comment.sql
+++ b/crates/uroborosql-fmt/testfiles/src/2way_sql/comment.sql
@@ -35,3 +35,17 @@ order by
 ,/*prev*//*END*//*next*/ -- some
     f.bar2
 ,   f.bar3
+
+select *
+from (
+    select 
+        *
+    from
+        foo f
+    order by
+    /*IF true*/
+        f.bar1
+    ,/*END*/ -- comment
+        f.bar2
+    ,   f.bar3
+)

--- a/crates/uroborosql-fmt/testfiles/src/select/order_by.sql
+++ b/crates/uroborosql-fmt/testfiles/src/select/order_by.sql
@@ -2,3 +2,18 @@ select col from tab
 order by col asc -- 昇順
 , long_col desc nulls first -- 降順
 , null_col nulls first -- NULL先
+
+select * from foo t
+order by
+    t.bar1
+,   
+/* after comma */
+    t.bar2
+,   t.bar3
+
+select * from foo t
+order by
+    t.bar1
+/* before comma */
+,   t.bar2
+,   t.bar3


### PR DESCRIPTION
resolve #63 

## 概要
- `order_by`句でセパレータと式の間に現れるコメントに対応
- 2WaySQLの分岐処理に使われるコメントの場合は行頭にフォーマットされ出力されるよう変更


simple comment:
```sql
-- フォーマット前
select * from foo f
order by
    t.bar1
,   /* after comma */
    t.bar2
,   t.bar3

-- フォーマット後
select
	*
from
	foo	f
order by
	t.bar1
,	/* after comma */
	t.bar2
,	t.bar3
```

2WaySQL:
```sql
-- フォーマット前
select * from foo f
order by
/*IF true*/
    f.bar1
,/*END*/
    f.bar2
,   f.bar3

-- フォーマット後
select
	*
from
	foo	f
order by
/*IF true*/
	f.bar1
,	
/*END*/
	f.bar2
,	f.bar3
```