### PR TITLE
Fix the vertical alignment of 2WaySQL

### DIFF
--- a/crates/uroborosql-fmt/src/validate.rs
+++ b/crates/uroborosql-fmt/src/validate.rs
@@ -4,7 +4,7 @@ use tree_sitter::{Language, Node, Tree};
 use crate::{
     config::{load_never_complement_settings, CONFIG},
     cst::Location,
-    format, print_cst,
+    format_tree, has_syntax_error, print_cst,
     two_way_sql::format_two_way_sql,
     util::create_error_annotation,
     visitor::COMMENT,
@@ -27,10 +27,13 @@ pub(crate) fn validate_format_result(
     // 補完を行わない設定に切り替える
     load_never_complement_settings();
 
-    let format_result = if is_two_way_sql {
+    let tree = parser.parse(src, None).unwrap();
+    let has_syntax_error = has_syntax_error(&tree);
+
+    let format_result = if is_two_way_sql && has_syntax_error {
         format_two_way_sql(src, language)?
     } else {
-        format(src, language)?
+        format_tree(tree, src)?
     };
 
     let dst_ts_tree = parser.parse(&format_result, None).unwrap();

--- a/crates/uroborosql-fmt/testfiles/dst/2way_sql/align.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/2way_sql/align.sql
@@ -3,6 +3,6 @@ select
 /*IF true*/
 ,	'b'					as	b
 /*ELSE*/
-,	'ccccccccccccccc'	as	b
+,	'ccccccccccccccc'	as	c
 /*END*/
 ;

--- a/crates/uroborosql-fmt/testfiles/dst/2way_sql/align.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/2way_sql/align.sql
@@ -1,0 +1,8 @@
+select
+	''					as	a
+/*IF true*/
+,	'b'					as	b
+/*ELSE*/
+,	'ccccccccccccccc'	as	b
+/*END*/
+;

--- a/crates/uroborosql-fmt/testfiles/src/2way_sql/align.sql
+++ b/crates/uroborosql-fmt/testfiles/src/2way_sql/align.sql
@@ -1,0 +1,8 @@
+select
+'' as a
+/*IF true*/
+,'b' as b
+/*ELSE*/
+,'ccccccccccccccc' as b
+/*END*/
+;

--- a/crates/uroborosql-fmt/testfiles/src/2way_sql/align.sql
+++ b/crates/uroborosql-fmt/testfiles/src/2way_sql/align.sql
@@ -3,6 +3,6 @@ select
 /*IF true*/
 ,'b' as b
 /*ELSE*/
-,'ccccccccccccccc' as b
+,'ccccccccccccccc' as c
 /*END*/
 ;


### PR DESCRIPTION
## 概要
2WaySQLで条件分岐をまたぐ縦ぞろえが崩れる問題（#86）を部分的に修正

- 2WaySQLモードでフォーマットされる条件を変更しました
  - 変更前: フォーマット前テキストに`/*IF*/`を含む 場合
  - 変更後: フォーマット前テキストに`/*IF*/`を含み、かつ **SQLの構文として不正** な場合
- これにより、通常のSQLとしてパースできる2WaySQLについては縦ぞろえの問題が解消されます
  - **通常のSQLとして不正な構文を含む2WaySQLの場合は**、依然として同様の問題が発生し得ます

フォーマット前：
```sql
select
'' as a
/*IF true*/
,'b' as b
/*ELSE*/
,'ccccccccccccccc' as c
/*END*/
;
```
フォーマット後：
```sql
select
	''					as	a
/*IF true*/
,	'b'					as	b
/*ELSE*/
,	'ccccccccccccccc'	as	c
/*END*/
;
```
