### PR TITLE
End-of-Line comment support for keyword line in clause

### DIFF
--- a/crates/uroborosql-fmt/src/cst/clause.rs
+++ b/crates/uroborosql-fmt/src/cst/clause.rs
@@ -123,7 +123,6 @@ impl Clause {
                     self.comments.push(comment);
                 } else {
                     self.set_keyword_trailing_comment(comment)?;
-
                 }
             }
         }
@@ -170,7 +169,7 @@ impl Clause {
 
         if let Some(trailing_comment) = &self.keyword_trailing_comment {
             result.push(' ');
-            result.push_str(&trailing_comment);
+            result.push_str(trailing_comment);
         }
 
         // comments

--- a/crates/uroborosql-fmt/src/visitor/clause/join.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/join.rs
@@ -4,7 +4,7 @@ use crate::{
     config::CONFIG,
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{create_clause, ensure_kind, error_annotation_from_cursor, Visitor},
+    visitor::{create_clause, ensure_kind, error_annotation_from_cursor, Visitor, COMMENT},
 };
 
 impl Visitor {
@@ -31,6 +31,10 @@ impl Visitor {
             create_clause(cursor, src, "JOIN")?
         };
         cursor.goto_next_sibling();
+
+        if cursor.node().kind() == COMMENT {
+            self.consume_comment_in_clause(cursor, src, &mut join_clause)?;
+        }
 
         // テーブル名だが補完は行わない
         let table = self.visit_aliasable_expr(cursor, src, None)?;

--- a/crates/uroborosql-fmt/testfiles/config_test/dst_config1/where.sql
+++ b/crates/uroborosql-fmt/testfiles/config_test/dst_config1/where.sql
@@ -28,8 +28,7 @@ SELECT
 	*
 FROM
 	TBL	T
-WHERE
--- comment
+WHERE -- comment
 	T.ID	=	(
 		SELECT
 			MAX(T2.ID)
@@ -44,8 +43,7 @@ SELECT
 	*
 FROM
 	TBL	T
-WHERE
--- comment
+WHERE -- comment
 	T.ID	=	(
 		SELECT
 			MAX(T2.ID)

--- a/crates/uroborosql-fmt/testfiles/config_test/dst_config2/where.sql
+++ b/crates/uroborosql-fmt/testfiles/config_test/dst_config2/where.sql
@@ -28,8 +28,7 @@ SELECT
 	*
 FROM
 	tbl	t
-WHERE
--- comment
+WHERE -- comment
 	t.id	=	(
 		SELECT
 			MAX(t2.id)
@@ -44,8 +43,7 @@ SELECT
 	*
 FROM
 	tbl	t
-WHERE
--- comment
+WHERE -- comment
 	t.id	=	(
 		SELECT
 			MAX(t2.id)

--- a/crates/uroborosql-fmt/testfiles/config_test/dst_config3/where.sql
+++ b/crates/uroborosql-fmt/testfiles/config_test/dst_config3/where.sql
@@ -28,8 +28,7 @@ select
 	*
 from
 	tbl	t
-where
--- comment
+where -- comment
 	t.id	=	(
 		select
 			max(t2.id)
@@ -44,8 +43,7 @@ select
 	*
 from
 	tbl	t
-where
--- comment
+where -- comment
 	t.id	=	(
 		select
 			max(t2.id)

--- a/crates/uroborosql-fmt/testfiles/config_test/dst_config4/where.sql
+++ b/crates/uroborosql-fmt/testfiles/config_test/dst_config4/where.sql
@@ -28,8 +28,7 @@ select
 	*
 from
 	TBL	T
-where
--- comment
+where -- comment
 	T.ID	=	(
 		SELECT
 			MAX(T2.ID)
@@ -44,8 +43,7 @@ select
 	*
 from
 	TBL	T
-where
--- comment
+where -- comment
 	T.ID	=	(
 		SELECT
 			MAX(T2.ID)

--- a/crates/uroborosql-fmt/testfiles/config_test/dst_config5/where.sql
+++ b/crates/uroborosql-fmt/testfiles/config_test/dst_config5/where.sql
@@ -28,8 +28,7 @@ SELECT
 	*
 FROM
 	tbl	t
-WHERE
--- comment
+WHERE -- comment
 		t.id	=	(
 			SELECT
 				MAX(t2.id)
@@ -44,8 +43,7 @@ SELECT
 	*
 FROM
 	tbl	t
-WHERE
--- comment
+WHERE -- comment
 		t.id	=	(
 			SELECT
 				MAX(t2.id)

--- a/crates/uroborosql-fmt/testfiles/config_test/dst_default/where.sql
+++ b/crates/uroborosql-fmt/testfiles/config_test/dst_default/where.sql
@@ -28,8 +28,7 @@ select
 	*
 from
 	tbl	t
-where
--- comment
+where -- comment
 	t.id	=	(
 		select
 			max(t2.id)
@@ -44,8 +43,7 @@ select
 	*
 from
 	tbl	t
-where
--- comment
+where -- comment
 	t.id	=	(
 		select
 			max(t2.id)

--- a/crates/uroborosql-fmt/testfiles/dst/comment/case_comment.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/comment/case_comment.sql
@@ -3,20 +3,15 @@ select
 ,	case
 		-- case trailing
 		/* case */
-		when
-		-- cond_1
+		when -- cond_1
 			a	=	1	-- a equals 1
-		then
-		-- cond_1 == true
+		then -- cond_1 == true
 			'one'	-- one
-		when
-		-- cond_2
+		when -- cond_2
 			a	=	2	-- a equals 2
-		then
-		-- cond_2 == true
+		then -- cond_2 == true
 			'two'	-- two
-		else
-		-- forall i: cond_i == false
+		else -- forall i: cond_i == false
 			'other'	-- other
 	end
 from

--- a/crates/uroborosql-fmt/testfiles/dst/comment/many_comments.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/comment/many_comments.sql
@@ -1,6 +1,6 @@
 /* discription */
 -- hoge
-select /* _SQL_ID_ */
+select /* _SQL_ID_ */ -- after keyword, and on the same line as SQL_ID
 /* select body */
 -- comment
 	std.id		as	id		-- identifier

--- a/crates/uroborosql-fmt/testfiles/dst/select/join.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/join.sql
@@ -103,3 +103,13 @@ inner join
 	t2	-- tbl
 on
 	t1.num	=	t2.num	-- cond
+;
+select
+	*
+from
+	t1	-- after table
+inner join -- after keyword
+	t2	-- after table
+on -- after keyword
+	t1.num	=	t2.num	-- after condition
+;

--- a/crates/uroborosql-fmt/testfiles/dst/select/union.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/union.sql
@@ -3,8 +3,7 @@ select
 from
 	b
 /* select - union */
-union
--- union
+union -- union
 /* union - subselect */
 select
 	c	as	c

--- a/crates/uroborosql-fmt/testfiles/src/comment/many_comments.sql
+++ b/crates/uroborosql-fmt/testfiles/src/comment/many_comments.sql
@@ -1,6 +1,6 @@
 /* discription */
 -- hoge
-SELECT /* _SQL_ID_ */
+SELECT /* _SQL_ID_ */ -- after keyword, and on the same line as SQL_ID
 /* select body */ -- comment
     STD.ID AS ID -- identifier
 ,    STD.GRADE AS GRADE

--- a/crates/uroborosql-fmt/testfiles/src/select/join.sql
+++ b/crates/uroborosql-fmt/testfiles/src/select/join.sql
@@ -13,3 +13,11 @@ cross join t2 -- table 2
 ;
 select * from t1 inner join t2 -- tbl
 on t1.num = t2.num -- cond
+;
+select * from 
+    t1 -- after table
+inner join -- after keyword
+    t2 -- after table
+on -- after keyword
+    t1.num = t2.num -- after condition
+;


### PR DESCRIPTION
## 概要
JOIN句のキーワードと同行の行末コメントをサポートしました。

```sql
select 
    * 
from 
    t1
inner join -- supported!
    t2
on
    t1.num = t2.num
;
```

## 副作用
もとはJOIN句のキーワード行末にコメントを書けるようにするタスクでしたが、句をパースしているClause一般の処理へ変更を加えた（commit: [Add trailing comment support for a keyword line in Clause](https://github.com/future-architect/uroborosql-fmt/pull/95/commits/0e707ff3b97ccf6164e219e0ce622c65514bfac1)）ため、Clauseを利用するほかのフォーマット処理の挙動が変わります。

具体的には次のようになります：
- キーワードと同行の行末コメント（`-- after keyword`）
  - 変更後：フォーマット後も変わらず行末コメントとして出力されます
  - 変更前：キーワードの次行のコメントとして出力されていました
- キーワード次行のコメント（`-- next line`）
  - これまでと変わらずキーワードの下にフォーマットされます

入力：
```sql
select 
  *
from tbl t
where -- after keyword
-- next line
t.id = 1
;
```

変更前の挙動：
```sql
select
	*
from
	tbl	t
where 
-- after keyword
-- next line
	t.id	=	1
;
```

変更後の挙動：
```sql
select
	*
from
	tbl	t
where -- after keyword
-- next line 
	t.id	=	1
;
```

既存のテストケースから確認された範囲では、`where`, `union`, CASE式の `when`, `then`, `else` で同様の挙動変化が見られます。
  - commit: [Side Effects: line comments after keyword](https://github.com/future-architect/uroborosql-fmt/commit/aa2508a98df4cb53acfebd0594a6bd3aa9550fb6)

そのほかにもClauseを利用して処理されている部分では（visitor側でコメントが考慮されていれば）キーワードと同行の行末コメントが書けるようになります。