### PR TITLE
Support comments after join keyword

### DIFF
--- a/crates/uroborosql-fmt/src/visitor/clause/join.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/join.rs
@@ -4,7 +4,7 @@ use crate::{
     config::CONFIG,
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{create_clause, ensure_kind, error_annotation_from_cursor, Visitor, COMMENT},
+    visitor::{create_clause, ensure_kind, error_annotation_from_cursor, Visitor},
 };
 
 impl Visitor {
@@ -32,9 +32,8 @@ impl Visitor {
         };
         cursor.goto_next_sibling();
 
-        if cursor.node().kind() == COMMENT {
-            self.consume_comment_in_clause(cursor, src, &mut join_clause)?;
-        }
+        // キーワード直後のコメントを処理
+        self.consume_comment_in_clause(cursor, src, &mut join_clause)?;
 
         // テーブル名だが補完は行わない
         let table = self.visit_aliasable_expr(cursor, src, None)?;

--- a/crates/uroborosql-fmt/src/visitor/clause/join.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/join.rs
@@ -4,7 +4,7 @@ use crate::{
     config::CONFIG,
     cst::*,
     error::UroboroSQLFmtError,
-    visitor::{create_clause, ensure_kind, error_annotation_from_cursor, Visitor},
+    visitor::{create_clause, ensure_kind, error_annotation_from_cursor, Visitor, COMMENT},
 };
 
 impl Visitor {
@@ -31,6 +31,10 @@ impl Visitor {
             create_clause(cursor, src, "JOIN")?
         };
         cursor.goto_next_sibling();
+
+        if cursor.node().kind() == COMMENT {
+            self.consume_comment_in_clause(cursor, src, &mut join_clause)?;
+        }
 
         // テーブル名だが補完は行わない
         let table = self.visit_aliasable_expr(cursor, src, None)?;

--- a/crates/uroborosql-fmt/testfiles/dst/select/join.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/join.sql
@@ -103,3 +103,14 @@ inner join
 	t2	-- tbl
 on
 	t1.num	=	t2.num	-- cond
+;
+select
+	*
+from
+	t1	-- after table
+inner join
+-- after keyword
+-- another comment 
+	t2	-- after table
+on
+	t1.num	=	t2.num	-- cond

--- a/crates/uroborosql-fmt/testfiles/src/select/join.sql
+++ b/crates/uroborosql-fmt/testfiles/src/select/join.sql
@@ -13,3 +13,12 @@ cross join t2 -- table 2
 ;
 select * from t1 inner join t2 -- tbl
 on t1.num = t2.num -- cond
+;
+select
+    *
+from
+    t1 -- after table
+inner join -- after keyword
+-- another comment 
+    t2 -- after table
+on t1.num = t2.num -- cond


### PR DESCRIPTION
Fix #54 
## 概要
JOINキーワードの後に現れるコメントをサポートしました

フォーマット前：
```sql
select
    *
from
    t1
inner join -- after keyword
-- another comment 
    t2
on t1.num = t2.num
```

フォーマット後：
```sql
select
	*
from
	t1
inner join
-- after keyword
-- another comment 
	t2
on
	t1.num	=	t2.num
;
```