### PR TITLE
Handle block comments after recursive keyword

### DIFF
--- a/crates/uroborosql-fmt/src/visitor/clause/with.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/with.rs
@@ -20,6 +20,12 @@ impl Visitor {
 
         cursor.goto_next_sibling();
 
+        if cursor.node().kind() == "RECURSIVE" {
+            // WITH句のキーワードにRECURSIVEを付与する
+            with_clause.extend_kw(cursor.node(), src);
+            cursor.goto_next_sibling();
+        }
+
         // SQL_IDとコメントを消費
         self.consume_or_complement_sql_id(cursor, src, &mut with_clause);
         self.consume_comment_in_clause(cursor, src, &mut with_clause)?;
@@ -27,10 +33,6 @@ impl Visitor {
         let mut with_body = WithBody::new();
         loop {
             match cursor.node().kind() {
-                "RECURSIVE" => {
-                    // WITH句のキーワードにRECURSIVEを付与する
-                    with_clause.extend_kw(cursor.node(), src);
-                }
                 COMMA => {}
                 "cte" => {
                     let cte = self.visit_cte(cursor, src)?;

--- a/crates/uroborosql-fmt/testfiles/dst/select/with.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/with.sql
@@ -78,3 +78,13 @@ select
 from
 	t1
 ;
+with recursive /* _SQL_ID_ */
+/* block */
+-- line
+	t	as	(
+		select
+			1
+	)
+select
+	1
+;

--- a/crates/uroborosql-fmt/testfiles/src/select/with.sql
+++ b/crates/uroborosql-fmt/testfiles/src/select/with.sql
@@ -65,3 +65,11 @@ RETURNING
 	DID 	-- test
 ) --comment
 SELECT * FROM t1;
+
+with recursive /* _SQL_ID_ */ /* block */ -- line
+	t	as	(
+		select
+			1
+	)
+select
+	1;


### PR DESCRIPTION
Fix #91 

## 概要
`with`句の`recursive`キーワードの後にブロックコメントがあってもフォーマットされるようになりました

```sql
with recursive /* _SQL_ID_ */
	t	as	(
		select
			1
	)
select
	1
;
```