### PR TITLE
support comments after opening parenthesis in `IN` expression

### DIFF
--- a/crates/uroborosql-fmt/src/cst/expr/column_list.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/column_list.rs
@@ -21,13 +21,17 @@ pub(crate) struct ColumnList {
 }
 
 impl ColumnList {
-    pub(crate) fn new(cols: Vec<AlignedExpr>, loc: Location) -> ColumnList {
+    pub(crate) fn new(
+        cols: Vec<AlignedExpr>,
+        loc: Location,
+        start_comments: Vec<Comment>,
+    ) -> ColumnList {
         ColumnList {
             cols,
             loc,
             force_multi_line: false,
             head_comment: None,
-            start_comments: vec![],
+            start_comments,
         }
     }
 
@@ -67,11 +71,6 @@ impl ColumnList {
         self.head_comment = Some(text);
         loc.append(self.loc());
         self.loc = loc;
-    }
-
-    /// 開きかっこから最初の式の間に現れるコメントを追加する
-    pub(crate) fn add_start_comment(&mut self, comment: Comment) {
-        self.start_comments.push(comment);
     }
 
     /// 列リストを複数行で描画するかを指定する。

--- a/crates/uroborosql-fmt/src/visitor/expr/column_list.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/column_list.rs
@@ -26,7 +26,7 @@ impl Visitor {
             return Ok(ColumnList::new(vec![], loc));
         }
 
-        // 開きかっこと式の間にあるコメントを保持
+        // 開き括弧と式との間にあるコメントを保持
         // 最後の要素はバインドパラメータの可能性があるので、最初の式を処理した後で付け替える
         let mut comment_buf = vec![];
         while cursor.node().kind() == COMMENT {
@@ -34,7 +34,7 @@ impl Visitor {
             cursor.goto_next_sibling();
         }
 
-        let mut fist_expr = self.visit_expr(cursor, src)?;
+        let mut first_expr = self.visit_expr(cursor, src)?;
 
         // ```
         // (
@@ -44,15 +44,15 @@ impl Visitor {
         //```
         // 開き括弧の後のコメントのうち最後のもの（最初の式の直前にあるもの）を取得
         if let Some(comment) = comment_buf.last() {
-            if comment.is_block_comment() && comment.loc().is_next_to(&fist_expr.loc()) {
+            if comment.is_block_comment() && comment.loc().is_next_to(&first_expr.loc()) {
                 // ブロックコメントかつ式に隣接していればバインドパラメータなので、式に付与する
-                fist_expr.set_head_comment(comment.clone());
+                first_expr.set_head_comment(comment.clone());
                 // comment_buf からも削除
                 comment_buf.pop().unwrap();
             }
         }
 
-        let mut exprs = vec![fist_expr.to_aligned()];
+        let mut exprs = vec![first_expr.to_aligned()];
 
         // カンマ区切りの式
         while cursor.goto_next_sibling() {

--- a/crates/uroborosql-fmt/testfiles/dst/comment/col_list_comment.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/comment/col_list_comment.sql
@@ -35,3 +35,15 @@ and	tbl.st	in	(
 	,	'T'	-- t
 	)											-- st
 ;
+select
+	*
+from
+	tbl	t
+where
+	t.id	in	(
+		-- after opening paren
+		-- another comment
+		/*firstId*/0
+	,	/*secondId*/1
+	)
+;

--- a/crates/uroborosql-fmt/testfiles/src/comment/col_list_comment.sql
+++ b/crates/uroborosql-fmt/testfiles/src/comment/col_list_comment.sql
@@ -16,3 +16,8 @@ and tbl.st in ('S' -- s
 , 'T' -- t
 ) -- st
 ;
+select * from tbl t
+where t.id in ( -- after opening paren
+        -- another comment
+/*firstId*/0, /*secondId*/1
+);


### PR DESCRIPTION
Fix #56 

## 概要
- `IN` 式の開き括弧の後のコメントをサポートしました

```sql
select
	*
from
	tbl	t
where
	t.id	in	(
		-- after opening paren
		-- another comment
		/*firstId*/0
	,	/*secondId*/1
	)
;
```