### PR TITLE
Support comments after `SET` keyword

### DIFF
--- a/crates/uroborosql-fmt/src/visitor/clause/set.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/set.rs
@@ -20,6 +20,9 @@ impl Visitor {
         let mut set_clause = Clause::from_node(cursor.node(), src);
         cursor.goto_next_sibling();
 
+        // キーワード直後のコメントを処理
+        self.consume_comment_in_clause(cursor, src, &mut set_clause)?;
+
         ensure_kind(cursor, "set_clause_body", src)?;
         cursor.goto_first_child();
 

--- a/crates/uroborosql-fmt/testfiles/dst/update/update.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/update/update.sql
@@ -5,3 +5,13 @@ set
 ,	tbl1.column3	=	100	-- カラム3
 where
 	tbl1.column1	=	10
+;
+update
+	t	t
+set
+-- after set keyword
+-- another comment
+	c	=	c	+	1
+where
+	id	=	1
+;

--- a/crates/uroborosql-fmt/testfiles/src/update/update.sql
+++ b/crates/uroborosql-fmt/testfiles/src/update/update.sql
@@ -2,4 +2,13 @@ UPDATE TABLE1 TBL1 -- テーブル1
 SET TBL1.COLUMN2 = 100 -- カラム2
 , TBL1.COLUMN3 = 100 -- カラム3
 WHERE TBL1.COLUMN1	=	10
-    
+;
+
+update
+	T	t
+set -- after set keyword
+-- another comment
+	c	=	c	+	1
+where
+	id	=	1
+;


### PR DESCRIPTION
Close #59 

## 概要
`SET` キーワードの後のコメントをサポートしました

フォーマット前：
```sql
update
	T	t
set -- after set keyword
-- another comment
	c	=	c	+	1
where
	id	=	1
;
```

フォーマット後：
```sql
update
	t	t
set
-- after set keyword
-- another comment
	c	=	c	+	1
where
	id	=	1
;
```
