### PR TITLE
Support comments before select_statement in insert_statement

### DIFF
--- a/crates/uroborosql-fmt/testfiles/dst/insert/insert_select.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/insert/insert_select.sql
@@ -63,3 +63,18 @@ on
 do
 	nothing
 ;
+insert
+into
+	tbl
+(
+	id
+)
+-- comments
+-- before select
+select
+	id	as	id
+from
+	tbl2
+where
+	id	=	1
+;

--- a/crates/uroborosql-fmt/testfiles/src/insert/insert_select.sql
+++ b/crates/uroborosql-fmt/testfiles/src/insert/insert_select.sql
@@ -12,3 +12,8 @@ insert into tbl (id)
   select id from tbl2 where id = 1 -- trailing comment
   on conflict do nothing
   ;
+
+insert into tbl (id) 
+-- comments
+-- before select
+select id from tbl2 where id = 1;


### PR DESCRIPTION
Fix #100 

insert文内でselect文前のコメントに対応しました

```sql
insert
into
	tbl
(
	id
)
-- comments
-- before select
select
	id	as	id
from
	tbl2
where
	id	=	1
;
```