### PR TITLE
fix: macos runner image

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
+          - host: macos-latest-large
             target: x86_64-apple-darwin
             build: |
               yarn build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest-large
+          - host: macos-13
             target: x86_64-apple-darwin
             build: |
               yarn build


### PR DESCRIPTION
mac(intel版)でvscode拡張によるSQLフォーマットできない不具合が発生しており、その対応です。

[x86_64向けのBuildジョブ](https://github.com/future-architect/uroborosql-fmt/actions/runs/10823817092/job/30029981935) で `uroborosql-fmt-napi.darwin-arm64.node` が作成されることが原因のようです。
https://github.com/actions/runner-images/issues/9741#issuecomment-2312004709 を参考に、mac(intel版)については `macos-latest-large` のイメージを使用するよう変更しました。

@ota-meshi 