### PR TITLE
Fix invalid testcases

### DIFF
--- a/crates/uroborosql-fmt/testfiles/dst/select/order_by.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/order_by.sql
@@ -6,6 +6,7 @@ order by
 	col			asc					-- 昇順
 ,	long_col	desc nulls first	-- 降順
 ,	null_col	nulls first			-- NULL先
+;
 select
 	*
 from
@@ -15,6 +16,7 @@ order by
 ,	/* after comma */
 	t.bar2
 ,	t.bar3
+;
 select
 	*
 from
@@ -24,3 +26,4 @@ order by
 /* before comma */
 ,	t.bar2
 ,	t.bar3
+;

--- a/crates/uroborosql-fmt/testfiles/dst/select/unary.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/unary.sql
@@ -1,26 +1,37 @@
 select
 	+5	as	positive_value
+;
 select
 	+5	as	positive_value
+;
 select
 	-10	as	negative_value
+;
 select
 	-10	as	negative_value
+;
 select
 	not	true	as	not_true
+;
 select
 	~5	as	bitwise_not
+;
 select
 	~5	as	bitwise_not
+;
 select
 	|/25	as	square_root
+;
 select
 	|/25	as	square_root
+;
+-- select @-5 as absolute_value; : PostgreSQLでは、`@-5` と書くと `@-` が一つのトークンとして扱われるため無効なSQLになる
 select
 	@-5	as	absolute_value
-select
-	@-5	as	absolute_value
-select
-	||/8	as	cube_root
+;
 select
 	||/8	as	cube_root
+;
+select
+	||/8	as	cube_root
+;

--- a/crates/uroborosql-fmt/testfiles/src/select/order_by.sql
+++ b/crates/uroborosql-fmt/testfiles/src/select/order_by.sql
@@ -2,6 +2,7 @@ select col from tab
 order by col asc -- 昇順
 , long_col desc nulls first -- 降順
 , null_col nulls first -- NULL先
+;
 
 select * from foo t
 order by
@@ -9,11 +10,11 @@ order by
 ,   
 /* after comma */
     t.bar2
-,   t.bar3
+,   t.bar3;
 
 select * from foo t
 order by
     t.bar1
 /* before comma */
 ,   t.bar2
-,   t.bar3
+,   t.bar3;

--- a/crates/uroborosql-fmt/testfiles/src/select/unary.sql
+++ b/crates/uroborosql-fmt/testfiles/src/select/unary.sql
@@ -1,19 +1,19 @@
-select +5 as positive_value
-select + 5 as positive_value
+select +5 as positive_value;
+select + 5 as positive_value;
 
-select -10 as negative_value
-select - 10 as negative_value
+select -10 as negative_value;
+select - 10 as negative_value;
 
-select not true as not_true
+select not true as not_true;
 
-select ~5 as bitwise_not
-select ~ 5 as bitwise_not
+select ~5 as bitwise_not;
+select ~ 5 as bitwise_not;
 
-select |/25 as square_root
-select |/ 25 as square_root
+select |/25 as square_root;
+select |/ 25 as square_root;
 
-select @-5 as absolute_value
-select @ -5 as absolute_value
+-- select @-5 as absolute_value; : PostgreSQLでは、`@-5` と書くと `@-` が一つのトークンとして扱われるため無効なSQLになる
+select @ -5 as absolute_value;
 
-select ||/8 as cube_root
-select ||/ 8 as cube_root
+select ||/8 as cube_root;
+select ||/ 8 as cube_root;


### PR DESCRIPTION
テストケースのうち、不正なSQLを修正しました

1. 複数文から構成されるが、各文の末尾にセミコロンがないもの にセミコロンを付加
    - #81 と #63 のテストケース追加時にセミコロンをつけるのを忘れました
    - 該当箇所：
        - #81: https://github.com/future-architect/uroborosql-fmt/commit/c79404830f219d2577a8e7237da56ebfb13db434#diff-2604424602feeb7005d7d04c5cb2977a6e15d707f7edc2b6757a1390b1b5da65
        - #63: https://github.com/future-architect/uroborosql-fmt/commit/97b145fd1076312f85dc279550dce0b96bf65d49#diff-2b59a004d7ffc3852690be046a9d67c9c5e613e34a55e9ec51d44952afae6d92
1. 絶対値演算子 `@` と `-` を空白なしで組み合わせるケースを削除
     - `@-` が一つの演算子として扱われるため無効 
