### PR TITLE
body なし select をサポート

### DIFF
--- a/crates/uroborosql-fmt/src/cst.rs
+++ b/crates/uroborosql-fmt/src/cst.rs
@@ -314,3 +314,25 @@ impl SqlID {
         }
     }
 }
+
+/*
+    postgresql-cst-parser 用
+*/
+
+impl From<postgresql_cst_parser::tree_sitter::Point> for Position {
+    fn from(point: postgresql_cst_parser::tree_sitter::Point) -> Self {
+        Position {
+            row: point.row,
+            col: point.column,
+        }
+    }
+}
+
+impl From<postgresql_cst_parser::tree_sitter::Range> for Location {
+    fn from(range: postgresql_cst_parser::tree_sitter::Range) -> Self {
+        Location {
+            start_position: range.start_position.into(),
+            end_position: range.end_position.into(),
+        }
+    }
+}

--- a/crates/uroborosql-fmt/src/cst/clause.rs
+++ b/crates/uroborosql-fmt/src/cst/clause.rs
@@ -34,6 +34,18 @@ impl Clause {
         }
     }
 
+    pub(crate) fn from_pg_node(kw_node: postgresql_cst_parser::tree_sitter::Node) -> Clause {
+        let keyword = convert_keyword_case(kw_node.text());
+        let loc = Location::from(kw_node.range());
+        Clause {
+            keyword,
+            body: None,
+            loc,
+            sql_id: None,
+            comments: vec![],
+        }
+    }
+
     pub(crate) fn loc(&self) -> Location {
         self.loc.clone()
     }

--- a/crates/uroborosql-fmt/src/new_visitor.rs
+++ b/crates/uroborosql-fmt/src/new_visitor.rs
@@ -384,8 +384,7 @@ fn create_clause(
 
 fn pg_create_clause(
     cursor: &mut postgresql_cst_parser::tree_sitter::TreeCursor,
-    _src: &str,
-    _keyword: &str,
+    _keyword: SyntaxKind,
 ) -> Result<Clause, UroboroSQLFmtError> {
     // pg_ensure_kind(cursor, SyntaxKind::select_clause, src)?;
 

--- a/crates/uroborosql-fmt/src/new_visitor.rs
+++ b/crates/uroborosql-fmt/src/new_visitor.rs
@@ -2,6 +2,7 @@ mod clause;
 mod expr;
 mod statement;
 
+use postgresql_cst_parser::syntax_kind::SyntaxKind;
 use tree_sitter::{Node, TreeCursor};
 
 pub(crate) const COMMENT: &str = "comment";
@@ -38,7 +39,7 @@ impl Visitor {
     /// sqlソースファイルをフォーマット用構造体に変形する
     pub(crate) fn visit_sql(
         &mut self,
-        node: Node,
+        node: postgresql_cst_parser::tree_sitter::Node,
         src: &str,
     ) -> Result<Vec<Statement>, UroboroSQLFmtError> {
         // CSTを走査するTreeCursorを生成する
@@ -52,19 +53,23 @@ impl Visitor {
     /// 呼び出し終了後、cursorはsource_fileを指している
     fn visit_source(
         &mut self,
-        cursor: &mut TreeCursor,
+        cursor: &mut postgresql_cst_parser::tree_sitter::TreeCursor,
         src: &str,
     ) -> Result<Vec<Statement>, UroboroSQLFmtError> {
+        use postgresql_cst_parser::syntax_kind::SyntaxKind::{
+            DeleteStmt, InsertStmt, SelectStmt, Semicolon, UpdateStmt,
+        };
+
         // source_file -> _statement*
         let mut source: Vec<Statement> = vec![];
 
         if !cursor.goto_first_child() {
             // source_fileに子供がない、つまり、ソースファイルが空である場合
             // todo
-            return Err(UroboroSQLFmtError::Unimplemented(format!(
-                "visit_source(): source_file has no child\n{}",
-                error_annotation_from_cursor(cursor, src)
-            )));
+            return Err(UroboroSQLFmtError::Unimplemented(
+                // TODO: error_annotation_from_cursorの移植
+                "visit_source(): source_file has no child\n".to_string(),
+            ));
         }
 
         // ソースファイル先頭のコメントを保存するバッファ
@@ -77,48 +82,57 @@ impl Visitor {
         loop {
             let kind = cursor.node().kind();
 
-            if kind.ends_with("_statement") {
-                let mut stmt = match kind {
-                    "select_statement" => self.visit_select_stmt(cursor, src)?,
-                    "delete_statement" => self.visit_delete_stmt(cursor, src)?,
-                    "update_statement" => self.visit_update_stmt(cursor, src)?,
-                    "insert_statement" => self.visit_insert_stmt(cursor, src)?,
-                    // todo
-                    _ => {
-                        return Err(UroboroSQLFmtError::Unimplemented(format!(
-                            "visit_source(): Unimplemented statement\n{}",
-                            error_annotation_from_cursor(cursor, src)
-                        )));
+            match kind {
+                stmt_kind @ SelectStmt
+                //  | DeleteStmt | UpdateStmt | InsertStmt 
+                => {
+                    let mut stmt = match stmt_kind {
+                        SelectStmt => self.visit_select_stmt(cursor, src)?, // とりあえず Statement を返す
+                        // DeleteStmt => self.visit_delete_stmt(cursor, src)?,
+                        // UpdateStmt => self.visit_update_stmt(cursor, src)?,
+                        // InsertStmt => self.visit_insert_stmt(cursor, src)?,
+                        _ => {
+                            return Err(UroboroSQLFmtError::Unimplemented(
+                                // TODO: error_annotation_from_cursorの移植
+                                "visit_source(): Unimplemented statement\n".to_string()
+
+                                // format!(
+                                // "visit_source(): Unimplemented statement\n",
+                                // error_annotation_from_cursor(cursor, src)
+                            )
+                        );
+                        }
+                    };
+
+                    comment_buf
+                        .iter()
+                        .cloned()
+                        .for_each(|c| stmt.add_comment(c));
+                    comment_buf.clear();
+
+                    source.push(stmt);
+                    above_semi = true;
+                }
+                // SyntaxKind::C_COMMENT| SyntaxKind::SQL_COMMENT => {
+                //     let comment = Comment::pg_new(cursor.node());
+                //     if !source.is_empty() && above_semi {
+                //         let last_stmt = source.last_mut().unwrap();
+                //         // すでにstatementがある場合、末尾に追加
+                //         last_stmt.add_comment_to_child(comment)?;
+                //     } else {
+                //         // まだstatementがない場合、バッファに詰めておく
+                //         comment_buf.push(comment);
+                //     }
+                // }
+                Semicolon => {
+                    above_semi = false;
+                    if let Some(last) = source.last_mut() {
+                        last.set_semi(true);
                     }
-                };
-
-                // コメントが以前にあれば先頭に追加
-                comment_buf
-                    .iter()
-                    .cloned()
-                    .for_each(|c| stmt.add_comment(c));
-                comment_buf.clear();
-
-                source.push(stmt);
-                above_semi = true;
-            } else if kind == COMMENT {
-                let comment = Comment::new(cursor.node(), src);
-
-                if !source.is_empty() && above_semi {
-                    let last_stmt = source.last_mut().unwrap();
-                    // すでにstatementがある場合、末尾に追加
-                    last_stmt.add_comment_to_child(comment)?;
-                } else {
-                    // まだstatementがない場合、バッファに詰めておく
-                    comment_buf.push(comment);
+                    // TODO: ; の上に文がない場合にどうなるか (tree-sitter-sqlでは構文エラーになる)
                 }
-            } else if kind == ";" {
-                above_semi = false;
-                if let Some(last) = source.last_mut() {
-                    last.set_semi(true);
-                }
-                // tree-sitter-sqlでは、;の上に文がない場合syntax errorになる
-            }
+                _ => {}
+            };
 
             if !cursor.goto_next_sibling() {
                 // 次の子供がいない場合、終了
@@ -306,6 +320,23 @@ fn ensure_kind<'a>(
     }
 }
 
+fn pg_ensure_kind<'a>(
+    cursor: &'a postgresql_cst_parser::tree_sitter::TreeCursor<'a>,
+    kind: postgresql_cst_parser::syntax_kind::SyntaxKind,
+    src: &'a str,
+) -> Result<&'a postgresql_cst_parser::tree_sitter::TreeCursor<'a>, UroboroSQLFmtError> {
+    if cursor.node().kind() != kind {
+        Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
+            "pg_ensure_kind(): excepted node is {}, but actual {}\n{}",
+            kind,
+            cursor.node().kind(),
+            "TODO: annotation".to_string() // error_annotation_from_cursor(cursor, src)
+        )))
+    } else {
+        Ok(cursor)
+    }
+}
+
 /// エイリアス補完を行う際に、エイリアス名を持つ Expr を生成する関数。
 /// 引数に元の式を与える。その式がPrimary式ではない場合は、エイリアス名を生成できないので、None を返す。
 fn create_alias(lhs: &Expr) -> Option<Expr> {
@@ -347,6 +378,21 @@ fn create_clause(
         ensure_kind(cursor, keyword, src)?;
         clause.extend_kw(cursor.node(), src);
     }
+
+    Ok(clause)
+}
+
+fn pg_create_clause(
+    cursor: &mut postgresql_cst_parser::tree_sitter::TreeCursor,
+    _src: &str,
+    _keyword: &str,
+) -> Result<Clause, UroboroSQLFmtError> {
+    // pg_ensure_kind(cursor, SyntaxKind::select_clause, src)?;
+
+    // TODO: 複数の語からなるキーワードについて検討
+    // とりあえず一つの語からなるキーワードをカバー
+    let clause = Clause::from_pg_node(cursor.node());
+    cursor.goto_next_sibling();
 
     Ok(clause)
 }

--- a/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
@@ -28,7 +28,7 @@ impl Visitor {
         pg_ensure_kind(cursor, SyntaxKind::SELECT, src)?;
 
         // cursor -> SELECT
-        let mut clause = pg_create_clause(cursor, src, "SELECT")?;
+        let mut clause = pg_create_clause(cursor, SyntaxKind::SELECT)?;
         cursor.goto_next_sibling();
 
         // // SQL_IDとコメントを消費

--- a/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
@@ -1,3 +1,4 @@
+use postgresql_cst_parser::syntax_kind::SyntaxKind;
 use tree_sitter::TreeCursor;
 
 use crate::{
@@ -6,7 +7,7 @@ use crate::{
     new_visitor::{
         create_clause, ensure_kind,
         expr::{ComplementConfig, ComplementKind},
-        Visitor,
+        pg_create_clause, pg_ensure_kind, Visitor,
     },
 };
 
@@ -15,7 +16,7 @@ impl Visitor {
     /// 呼び出し後、cursorはselect_clauseを指している
     pub(crate) fn visit_select_clause(
         &mut self,
-        cursor: &mut TreeCursor,
+        cursor: &mut postgresql_cst_parser::tree_sitter::TreeCursor,
         src: &str,
     ) -> Result<Clause, UroboroSQLFmtError> {
         // SELECT句の定義
@@ -24,75 +25,75 @@ impl Visitor {
         //          [ ALL | DISTINCT [ ON ( expression [, ...] ) ] ] ]
         //          [ select_clause_body ]
 
-        // select_clauseは必ずSELECTを子供に持っているはずである
-        cursor.goto_first_child();
+        pg_ensure_kind(cursor, SyntaxKind::SELECT, src)?;
 
         // cursor -> SELECT
-        let mut clause = create_clause(cursor, src, "SELECT")?;
+        let mut clause = pg_create_clause(cursor, src, "SELECT")?;
         cursor.goto_next_sibling();
 
-        // SQL_IDとコメントを消費
-        self.consume_or_complement_sql_id(cursor, src, &mut clause);
-        self.consume_comment_in_clause(cursor, src, &mut clause)?;
+        // // SQL_IDとコメントを消費
+        // self.consume_or_complement_sql_id(cursor, src, &mut clause);
+        // self.consume_comment_in_clause(cursor, src, &mut clause)?;
 
-        let mut select_body = SelectBody::new();
+        let select_body = SelectBody::new();
 
-        // [ ALL | DISTINCT [ ON ( expression [, ...] ) ] ] ]
-        match cursor.node().kind() {
-            "ALL" => {
-                let all_clause = create_clause(cursor, src, "ALL")?;
+        // // [ ALL | DISTINCT [ ON ( expression [, ...] ) ] ] ]
+        // match cursor.node().kind() {
+        //     "ALL" => {
+        //         let all_clause = create_clause(cursor, src, "ALL")?;
 
-                select_body.set_all_distinct(all_clause);
+        //         select_body.set_all_distinct(all_clause);
 
-                cursor.goto_next_sibling();
-            }
-            "DISTINCT" => {
-                let mut distinct_clause = create_clause(cursor, src, "DISTINCT")?;
+        //         cursor.goto_next_sibling();
+        //     }
+        //     "DISTINCT" => {
+        //         let mut distinct_clause = create_clause(cursor, src, "DISTINCT")?;
 
-                cursor.goto_next_sibling();
+        //         cursor.goto_next_sibling();
 
-                // ON ( expression [, ...] )
-                if cursor.node().kind() == "ON" {
-                    // DISTINCTにONキーワードを追加
-                    distinct_clause.extend_kw(cursor.node(), src);
+        //         // ON ( expression [, ...] )
+        //         if cursor.node().kind() == "ON" {
+        //             // DISTINCTにONキーワードを追加
+        //             distinct_clause.extend_kw(cursor.node(), src);
 
-                    cursor.goto_next_sibling();
+        //             cursor.goto_next_sibling();
 
-                    // ( expression [, ...] ) をColumnList構造体に格納
-                    let mut column_list = self.visit_column_list(cursor, src)?;
-                    // 改行によるフォーマットを強制
-                    column_list.set_force_multi_line(true);
+        //             // ( expression [, ...] ) をColumnList構造体に格納
+        //             let mut column_list = self.visit_column_list(cursor, src)?;
+        //             // 改行によるフォーマットを強制
+        //             column_list.set_force_multi_line(true);
 
-                    // ColumntListをSeparatedLinesに格納してBody
-                    let mut sep_lines = SeparatedLines::new();
+        //             // ColumntListをSeparatedLinesに格納してBody
+        //             let mut sep_lines = SeparatedLines::new();
 
-                    sep_lines.add_expr(
-                        Expr::ColumnList(Box::new(column_list)).to_aligned(),
-                        None,
-                        vec![],
-                    );
+        //             sep_lines.add_expr(
+        //                 Expr::ColumnList(Box::new(column_list)).to_aligned(),
+        //                 None,
+        //                 vec![],
+        //             );
 
-                    distinct_clause.set_body(Body::SepLines(sep_lines));
-                }
+        //             distinct_clause.set_body(Body::SepLines(sep_lines));
+        //         }
 
-                select_body.set_all_distinct(distinct_clause);
+        //         select_body.set_all_distinct(distinct_clause);
 
-                cursor.goto_next_sibling();
-            }
-            _ => {}
-        }
+        //         cursor.goto_next_sibling();
+        //     }
+        //     _ => {}
+        // }
 
-        // cursor -> select_caluse_body
-        if cursor.node().kind() == "select_clause_body" {
-            let select_clause_body = self.visit_select_clause_body(cursor, src)?;
-            select_body.set_select_clause_body(select_clause_body)
-        }
+        // // cursor -> select_caluse_body
+        // if cursor.node().kind() == "select_clause_body" {
+        //     let select_clause_body = self.visit_select_clause_body(cursor, src)?;
+        //     select_body.set_select_clause_body(select_clause_body)
+        // }
 
         clause.set_body(Body::Select(Box::new(select_body)));
 
-        // cursorをselect_clauseに戻す
-        cursor.goto_parent();
-        ensure_kind(cursor, "select_clause", src)?;
+        // cursor.goto_parent(); // SelectStmt goto parent しちゃだめ
+        // pg_ensure_kind(cursor, SyntaxKind::SelectStmt, src)?;
+
+        cursor.goto_next_sibling(); // select の次
 
         Ok(clause)
     }

--- a/crates/uroborosql-fmt/src/new_visitor/clause/with.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/with.rs
@@ -3,8 +3,10 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
+    new_visitor::{
+        create_clause, ensure_kind, error_annotation_from_cursor, Visitor, COMMA, COMMENT,
+    },
     util::{convert_identifier_case, convert_keyword_case},
-    new_visitor::{create_clause, ensure_kind, error_annotation_from_cursor, Visitor, COMMA, COMMENT},
 };
 
 impl Visitor {
@@ -145,7 +147,8 @@ impl Visitor {
 
         // cursor -> select_statement | delete_statement | insert_statement | update_statement
         let mut statement = match cursor.node().kind() {
-            "select_statement" => self.visit_select_stmt(cursor, src)?,
+            // TODO: パーサ置き換えのためコメントアウト
+            // "select_statement" => self.visit_select_stmt(cursor, src)?,
             "delete_statement" => self.visit_delete_stmt(cursor, src)?,
             "insert_statement" => self.visit_insert_stmt(cursor, src)?,
             "update_statement" => self.visit_update_stmt(cursor, src)?,

--- a/crates/uroborosql-fmt/src/new_visitor/expr/subquery.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/expr/subquery.rs
@@ -5,8 +5,8 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    util::{convert_keyword_case, single_space},
     new_visitor::{ensure_kind, Visitor, COMMENT},
+    util::{convert_keyword_case, single_space},
 };
 
 impl Visitor {
@@ -37,7 +37,9 @@ impl Visitor {
         }
 
         // cursor -> select_statement
-        let mut select_stmt = self.visit_select_stmt(cursor, src)?;
+        // TODO: パーサ置き換えのためコメントアウト
+        // let mut select_stmt = self.visit_select_stmt(cursor, src)?;
+        let mut select_stmt = Statement::new();
 
         // select_statementの前にコメントがあった場合、コメントを追加
         comment_buf

--- a/crates/uroborosql-fmt/src/new_visitor/statement/insert.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/statement/insert.rs
@@ -4,8 +4,9 @@ use crate::{
     cst::*,
     error::UroboroSQLFmtError,
     new_visitor::{
-        create_clause, ensure_kind, error_annotation_from_cursor, expr::{ComplementConfig, ComplementKind}, Visitor, COMMA, COMMENT
-    }, util::convert_keyword_case,
+        create_clause, ensure_kind, error_annotation_from_cursor, Visitor, COMMA, COMMENT,
+    },
+    util::convert_keyword_case,
 };
 
 impl Visitor {
@@ -162,19 +163,20 @@ impl Visitor {
 
                 cursor.goto_next_sibling();
             }
-            "select_statement" => {
-                // select文
-                let mut stmt = self.visit_select_stmt(cursor, src)?;
+            // // visit_select_stmt 書き換えのためコメントアウト
+            // "select_statement" => {
+            //     // select文
+            //     let mut stmt = self.visit_select_stmt(cursor, src)?;
 
-                // select 文の前にあったコメントを付与
-                for comment in comments_before_values_or_query {
-                    stmt.add_comment(comment);
-                }
+            //     // select 文の前にあったコメントを付与
+            //     for comment in comments_before_values_or_query {
+            //         stmt.add_comment(comment);
+            //     }
 
-                insert_body.set_query(stmt);
+            //     insert_body.set_query(stmt);
 
-                cursor.goto_next_sibling();
-            }
+            //     cursor.goto_next_sibling();
+            // }
             "select_subexpression" => {
                 if !comments_before_values_or_query.is_empty() {
                     return Err(UroboroSQLFmtError::Unimplemented(format!(

--- a/crates/uroborosql-fmt/src/new_visitor/statement/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/statement/select.rs
@@ -1,9 +1,10 @@
+use postgresql_cst_parser::syntax_kind::SyntaxKind;
 use tree_sitter::TreeCursor;
 
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    new_visitor::{ensure_kind, error_annotation_from_cursor, Visitor, COMMENT},
+    new_visitor::{ensure_kind, error_annotation_from_cursor, pg_ensure_kind, Visitor, COMMENT},
 };
 
 impl Visitor {
@@ -11,13 +12,13 @@ impl Visitor {
     /// 呼び出し後、cursorはselect_statementを指す
     pub(crate) fn visit_select_stmt(
         &mut self,
-        cursor: &mut TreeCursor,
+        cursor: &mut postgresql_cst_parser::tree_sitter::TreeCursor,
         src: &str,
     ) -> Result<Statement, UroboroSQLFmtError> {
         // SELECT文の定義
         // select_statement =
         //      [with_clause]
-        //      select_clause
+        //      select_clause (clause 自体はない)
         //      [from_clause]
         //      [where_clause]
         //      [_combining_query]
@@ -30,109 +31,114 @@ impl Visitor {
         cursor.goto_first_child();
         // cusor -> with_clause?
 
-        if cursor.node().kind() == "with_clause" {
-            // with句を追加する
-            let mut with_clause = self.visit_with_clause(cursor, src)?;
-            cursor.goto_next_sibling();
-            // with句の後に続くコメントを消費する
-            self.consume_comment_in_clause(cursor, src, &mut with_clause)?;
+        if cursor.node().kind() == SyntaxKind::with_clause {
+            return Err(UroboroSQLFmtError::Unimplemented(
+                "visit_select_stmt(): with_clause\n".to_string(),
+            ));
 
-            statement.add_clause(with_clause);
+            // // with句を追加する
+            // let mut with_clause = self.visit_with_clause(cursor, src)?;
+            // cursor.goto_next_sibling();
+            // // with句の後に続くコメントを消費する
+            // self.consume_comment_in_clause(cursor, src, &mut with_clause)?;
+
+            // statement.add_clause(with_clause);
         }
 
-        // cursor -> select_clause
-        ensure_kind(cursor, "select_clause", src)?;
+        // cursor -> SELECT keyword
+        // select_clause を消去したので、select_clause の中身が並ぶ
+        pg_ensure_kind(cursor, SyntaxKind::SELECT, src)?;
 
         // select句を追加する
         statement.add_clause(self.visit_select_clause(cursor, src)?);
 
-        // from句以下を追加する
+        // TODO: from句以下を追加する
         while cursor.goto_next_sibling() {
             // 次の兄弟へ移動
             // select_statementの子供がいなくなったら終了
-            match cursor.node().kind() {
-                "from_clause" => {
-                    let clause = self.visit_from_clause(cursor, src)?;
-                    statement.add_clause(clause);
-                }
-                // where_clause: $ => seq(kw("WHERE"), $._expression),
-                "where_clause" => {
-                    let clause = self.visit_where_clause(cursor, src)?;
-                    statement.add_clause(clause);
-                }
-                "join_clause" => {
-                    let clauses = self.visit_join_clause(cursor, src)?;
-                    clauses.into_iter().for_each(|c| statement.add_clause(c));
-                }
-                "UNION" | "INTERSECT" | "EXCEPT" => {
-                    // 演算(e.g., "INTERSECT", "UNION ALL", ...)
-                    let mut combining_clause = Clause::from_node(cursor.node(), src);
+            // match cursor.node().kind() {
+            //     "from_clause" => {
+            //         let clause = self.visit_from_clause(cursor, src)?;
+            //         statement.add_clause(clause);
+            //     }
+            //     // where_clause: $ => seq(kw("WHERE"), $._expression),
+            //     "where_clause" => {
+            //         let clause = self.visit_where_clause(cursor, src)?;
+            //         statement.add_clause(clause);
+            //     }
+            //     "join_clause" => {
+            //         let clauses = self.visit_join_clause(cursor, src)?;
+            //         clauses.into_iter().for_each(|c| statement.add_clause(c));
+            //     }
+            //     "UNION" | "INTERSECT" | "EXCEPT" => {
+            //         // 演算(e.g., "INTERSECT", "UNION ALL", ...)
+            //         let mut combining_clause = Clause::from_node(cursor.node(), src);
 
-                    cursor.goto_next_sibling();
-                    // cursor -> (ALL | DISTINCT) | select_statement
+            //         cursor.goto_next_sibling();
+            //         // cursor -> (ALL | DISTINCT) | select_statement
 
-                    if matches!(cursor.node().kind(), "ALL" | "DISTINCT") {
-                        // ALL または DISTINCT を追加する
-                        combining_clause.extend_kw(cursor.node(), src);
-                        cursor.goto_next_sibling();
-                    }
-                    // cursor -> comments | select_statement
+            //         if matches!(cursor.node().kind(), "ALL" | "DISTINCT") {
+            //             // ALL または DISTINCT を追加する
+            //             combining_clause.extend_kw(cursor.node(), src);
+            //             cursor.goto_next_sibling();
+            //         }
+            //         // cursor -> comments | select_statement
 
-                    // 演算子のみからなる句を追加
-                    statement.add_clause(combining_clause);
+            //         // 演算子のみからなる句を追加
+            //         statement.add_clause(combining_clause);
 
-                    while cursor.node().kind() == COMMENT {
-                        let comment = Comment::new(cursor.node(), src);
-                        statement.add_comment_to_child(comment)?;
-                        cursor.goto_next_sibling();
-                    }
+            //         while cursor.node().kind() == COMMENT {
+            //             let comment = Comment::new(cursor.node(), src);
+            //             statement.add_comment_to_child(comment)?;
+            //             cursor.goto_next_sibling();
+            //         }
 
-                    // 副問い合わせを計算
-                    let select_stmt = self.visit_select_stmt(cursor, src)?;
-                    select_stmt
-                        .get_clauses()
-                        .iter()
-                        .for_each(|clause| statement.add_clause(clause.to_owned()));
+            //         // 副問い合わせを計算
+            //         let select_stmt = self.visit_select_stmt(cursor, src)?;
+            //         select_stmt
+            //             .get_clauses()
+            //             .iter()
+            //             .for_each(|clause| statement.add_clause(clause.to_owned()));
 
-                    // cursorはselect_statementになっているはずである
-                }
-                "group_by_clause" => {
-                    let clauses = self.visit_group_by_clause(cursor, src)?;
-                    clauses.into_iter().for_each(|c| statement.add_clause(c));
-                }
-                "order_by_clause" => {
-                    let clause = self.visit_order_by_clause(cursor, src)?;
-                    statement.add_clause(clause);
-                }
-                "limit_clause" => {
-                    let clause = self.visit_limit_clause(cursor, src)?;
-                    statement.add_clause(clause);
-                }
-                "offset_clause" => {
-                    let clause = self.visit_offset_clause(cursor, src)?;
-                    statement.add_clause(clause);
-                }
-                "for_update_clause" => {
-                    let clause = self.visit_for_update_clause(cursor, src)?;
-                    statement.add_clauses(clause);
-                }
-                COMMENT => {
-                    statement.add_comment_to_child(Comment::new(cursor.node(), src))?;
-                }
-                "ERROR" => {
-                    return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                        "visit_select_stmt: ERROR node appeared \n{}",
-                        error_annotation_from_cursor(cursor, src)
-                    )));
-                }
-                _ => {
-                    break;
-                }
-            }
+            //         // cursorはselect_statementになっているはずである
+            //     }
+            //     "group_by_clause" => {
+            //         let clauses = self.visit_group_by_clause(cursor, src)?;
+            //         clauses.into_iter().for_each(|c| statement.add_clause(c));
+            //     }
+            //     "order_by_clause" => {
+            //         let clause = self.visit_order_by_clause(cursor, src)?;
+            //         statement.add_clause(clause);
+            //     }
+            //     "limit_clause" => {
+            //         let clause = self.visit_limit_clause(cursor, src)?;
+            //         statement.add_clause(clause);
+            //     }
+            //     "offset_clause" => {
+            //         let clause = self.visit_offset_clause(cursor, src)?;
+            //         statement.add_clause(clause);
+            //     }
+            //     "for_update_clause" => {
+            //         let clause = self.visit_for_update_clause(cursor, src)?;
+            //         statement.add_clauses(clause);
+            //     }
+            //     COMMENT => {
+            //         statement.add_comment_to_child(Comment::new(cursor.node(), src))?;
+            //     }
+            //     "ERROR" => {
+            //         return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
+            //             "visit_select_stmt: ERROR node appeared \n{}",
+            //             error_annotation_from_cursor(cursor, src)
+            //         )));
+            //     }
+            //     _ => {
+            //         break;
+            //     }
+            // }
         }
 
         cursor.goto_parent();
-        ensure_kind(cursor, "select_statement", src)?;
+        pg_ensure_kind(cursor, SyntaxKind::SelectStmt, src)?;
 
         Ok(statement)
     }


### PR DESCRIPTION
## Summary

以下のケースをサポートしました
### 1. select キーワードのみ
```sql
select
```
### 2. select とセミコロン
```sql
select;
```
### 3. 複数のselect文
```sql
select;
select;
```