### PR TITLE
カラムリスト部分のバインドパラメータ・SQL_ID・select キーワード後コメントに対応

### DIFF
--- a/crates/uroborosql-fmt/src/new_visitor.rs
+++ b/crates/uroborosql-fmt/src/new_visitor.rs
@@ -406,7 +406,6 @@ fn pg_create_clause(
     // TODO: 複数の語からなるキーワードについて検討
     // とりあえず一つの語からなるキーワードをカバー
     let clause = Clause::from_pg_node(cursor.node());
-    cursor.goto_next_sibling();
 
     Ok(clause)
 }

--- a/crates/uroborosql-fmt/src/new_visitor.rs
+++ b/crates/uroborosql-fmt/src/new_visitor.rs
@@ -4,7 +4,7 @@ mod pg_expr;
 mod statement;
 
 use postgresql_cst_parser::syntax_kind::SyntaxKind;
-use tree_sitter::{Node, TreeCursor};
+use tree_sitter::TreeCursor;
 
 pub(crate) const COMMENT: &str = "comment";
 pub(crate) const COMMA: &str = ",";
@@ -285,6 +285,33 @@ impl Visitor {
         }
     }
 
+    /// カーソルが指すノードがSQL_IDであれば、clauseに追加する
+    /// もし (_SQL_ID_が存在していない) && (_SQL_ID_がまだ出現していない) && (_SQL_ID_の補完がオン)
+    /// の場合は補完する
+    fn pg_consume_or_complement_sql_id(
+        &mut self,
+        cursor: &mut postgresql_cst_parser::tree_sitter::TreeCursor,
+        clause: &mut Clause,
+    ) {
+        if cursor.node().kind() == SyntaxKind::C_COMMENT {
+            let text = cursor.node().text();
+
+            if SqlID::is_sql_id(text) {
+                clause.set_sql_id(SqlID::new(text.to_string()));
+                cursor.goto_next_sibling();
+                self.should_complement_sql_id = false;
+
+                return;
+            }
+        }
+
+        // SQL_IDがない、かつSQL補完フラグがtrueの場合、補完する
+        if self.should_complement_sql_id {
+            clause.set_sql_id(SqlID::new("/* _SQL_ID_ */".to_string()));
+            self.should_complement_sql_id = false;
+        }
+    }
+
     /// カーソルが指すノードがコメントであれば、コメントを消費してclauseに追加する
     fn consume_comment_in_clause(
         &mut self,
@@ -294,6 +321,21 @@ impl Visitor {
     ) -> Result<(), UroboroSQLFmtError> {
         while cursor.node().kind() == COMMENT {
             let comment = Comment::new(cursor.node(), src);
+            clause.add_comment_to_child(comment)?;
+            cursor.goto_next_sibling();
+        }
+
+        Ok(())
+    }
+
+    /// カーソルが指すノードがコメントであれば、コメントを消費してclauseに追加する
+    fn pg_consume_comments_in_clause(
+        &mut self,
+        cursor: &mut postgresql_cst_parser::tree_sitter::TreeCursor,
+        clause: &mut Clause,
+    ) -> Result<(), UroboroSQLFmtError> {
+        while cursor.node().is_comment() {
+            let comment = Comment::pg_new(cursor.node());
             clause.add_comment_to_child(comment)?;
             cursor.goto_next_sibling();
         }

--- a/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
@@ -4,8 +4,8 @@ use crate::{
     cst::{select::SelectBody, *},
     error::UroboroSQLFmtError,
     new_visitor::{
-        create_alias, create_alias_from_expr, pg_create_clause, pg_ensure_kind,
-        pg_error_annotation_from_cursor, Visitor, COMMA,
+        create_alias_from_expr, pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor,
+        Visitor, COMMA,
     },
     util::convert_keyword_case,
     CONFIG,
@@ -97,9 +97,9 @@ impl Visitor {
         let mut clause = pg_create_clause(cursor, SyntaxKind::SELECT)?;
         cursor.goto_next_sibling();
 
-        // // SQL_IDとコメントを消費
-        // self.consume_or_complement_sql_id(cursor, src, &mut clause);
-        // self.consume_comment_in_clause(cursor, src, &mut clause)?;
+        // SQL_IDとコメントを消費
+        self.pg_consume_or_complement_sql_id(cursor, &mut clause);
+        self.pg_consume_comments_in_clause(cursor, &mut clause)?;
 
         let mut select_body = SelectBody::new();
 

--- a/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
@@ -215,7 +215,9 @@ impl Visitor {
 
                     // コメントノードがバインドパラメータであるかを判定
                     // バインドパラメータならば式として処理し、そうでなければコメントとして処理する
-                    if comment.loc().is_next_to(&next_sibling.range().into()) {
+                    if comment.loc().is_next_to(&next_sibling.range().into())
+                        && next_sibling.kind() == SyntaxKind::target_el
+                    {
                         cursor.goto_next_sibling();
 
                         let mut target_el =

--- a/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
@@ -202,8 +202,11 @@ impl Visitor {
                     let comment_node = cursor.node();
                     let comment = Comment::pg_new(comment_node);
 
+                    // バインドパラメータ判定のためにコメントの次のノードを取得する
                     let Some(next_sibling) = cursor.node().next_sibling() else {
-                        // コメントは最後の子供にならない
+                        // 最後の要素の行末にあるコメントは、 target_list の直下に現れず target_list と同階層の要素になる
+                        // そのためコメントが最後の子供になることはなく、次のノードを必ず取得できる
+
                         return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
                             "visit_target_list(): unexpected node kind\n{}",
                             pg_error_annotation_from_cursor(cursor, src)

--- a/crates/uroborosql-fmt/test_normal_cases/dst/015_sql_id_and_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/015_sql_id_and_comment.sql
@@ -1,0 +1,20 @@
+select /* _SQL_ID_ */
+	a	as	a
+;
+select /* _SQL_ID_ */
+-- comment
+	a	as	a
+;
+select
+-- comment
+	a	as	a
+;
+select
+/* comment */
+	a	as	a
+;
+select
+/* comment */
+-- comment
+	a	as	a
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/016_bind_param_target_list.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/016_bind_param_target_list.sql
@@ -9,3 +9,8 @@ select /* _SQL_ID_ */
 	/*x*/'x'	as	x
 ,	/*y*/'y'	as	y
 ;
+select
+	a	as	a
+/* comment */
+,	b	as	b
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/016_bind_param_target_list.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/016_bind_param_target_list.sql
@@ -1,0 +1,11 @@
+select /* _SQL_ID_ */
+	/*a*/a	as	a
+;
+select
+	a				as	a
+,	/*param*/'1'	as	b
+;
+select /* _SQL_ID_ */
+	/*x*/'x'	as	x
+,	/*y*/'y'	as	y
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/015_sql_id_and_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/015_sql_id_and_comment.sql
@@ -1,0 +1,18 @@
+select /* _SQL_ID_ */
+    a;
+
+select /* _SQL_ID_ */
+-- comment
+a;
+
+select -- comment
+a;
+
+select /* comment */
+a;
+
+
+select
+/* comment */ -- comment
+a
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/016_bind_param_target_list.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/016_bind_param_target_list.sql
@@ -6,3 +6,8 @@ select a, /*param*/'1' as b;
 select /* _SQL_ID_ */
 /*x*/'x' as	x
 , /*y*/'y' as	y;
+
+select 
+a /* comment */,
+b
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/016_bind_param_target_list.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/016_bind_param_target_list.sql
@@ -1,0 +1,8 @@
+select /* _SQL_ID_ */
+/*a*/a;
+
+select a, /*param*/'1' as b;
+
+select /* _SQL_ID_ */
+/*x*/'x' as	x
+, /*y*/'y' as	y;


### PR DESCRIPTION
## Summary
- カラムリスト部分のバインドパラメータ
- SQL_ID
- select キーワード後コメント

に対応しました

```sql
select /* _SQL_ID_ */
	/*x*/'x'	as	x
,	/*y*/'y'	as	y
;
select
/* comment */
-- comment
	a	as	a
;
```