### PR TITLE
Coverage report のテスト失敗時出力を改善

### DIFF
--- a/crates/uroborosql-fmt/tests/README.md
+++ b/crates/uroborosql-fmt/tests/README.md
@@ -1,0 +1,96 @@
+# uroborosql-fmt テスト構成
+
+このディレクトリには、uroborosql-fmtのテストコードが含まれています。テストは主に以下の3つのカテゴリに分かれています。
+
+## テストの種類
+
+### 1. test_all.rs
+
+テストケース名：`test_all`
+
+元々存在するテストで、`testfiles`ディレクトリ内のSQLファイルを対象に、`tree-sitter`を使用したバージョンのテストを実行します。このテストは、既存の機能が正しく動作することを確認するためのものです。
+
+```bash
+# 実行方法
+cargo test test_all
+```
+```bash
+# もしくは
+cargo test -- --exact test_all
+```
+
+### 2. pgcst_coverage.rs
+
+テストケース名：`test_with_coverage`
+
+パーサ移行用のテストで、`testfiles`ディレクトリ内のSQLファイルを対象に新パーサー(`postgresql-cst-parser`)を使用してテストを実行します。このテストは、既存のテストケースに対する新パーサーの実装カバレッジを報告するためのものです。
+
+テスト結果が合わなくてもテストは失敗しません。新パーサーでどの程度のSQLがサポートされているかを確認するために使用します。
+
+```bash
+# 実行方法
+cargo test -- --exact test_with_coverage
+```
+
+また、このテストでは出力する情報をカスタマイズできます。失敗したテストケースを表示する場合等は、テスト部分で Config を書き換えて実行してください。
+
+```rust
+// pgcst_coverage.rs
+#[test]
+fn test_with_coverage() {
+    let results = run_test_suite();
+
+    // before(default):
+    // let config = TestReportConfig::default();
+
+    // after:
+    let mut config = TestReportConfig::default();
+    config.show_failed_cases = true; // 失敗したケースを表示
+    config.show_error_annotations = true; // アノテーションを表示
+
+    print_coverage_report(&results, &config);
+}
+```
+
+また、このときの結果は基本的にstdoutへと出力されます。確認する場合は`--nocapture`オプションをつけて実行してください。
+
+```bash
+# 実行方法
+cargo test -- --exact test_with_coverage --nocapture
+```
+
+### 3. pgcst_normal_cases.rs
+
+テストケース名：`test_normal_cases`
+
+パーサ移行用のテストで、`test_normal_cases`ディレクトリ内のSQLファイルを対象に新パーサーでのテストを実行します。このテストは、段階的に機能を増やしたSQLを用意し、リグレッションを管理しながら移行を進めるために使用します。
+
+```bash
+# 実行方法
+cargo test -- --exact test_normal_cases
+```
+```bash
+# 各ケースの実行結果を確認する場合
+cargo test -- --exact test_normal_cases --nocapture
+```
+
+## ユーティリティ
+
+### pgcst_util.rs
+
+テスト結果の差分表示などの共通ユーティリティ関数を提供します。主に以下の機能があります：
+
+- `print_diff`: 期待値と実際の結果の差分を色付きで表示するユーティリティ関数
+
+## テストケースの種類
+
+### 1. testfiles
+
+元々のフォーマッターのテストケースで、`tree-sitter`を使用して開発していた際に追加されたものです。様々なSQLパターンを網羅しています。
+
+### 2. test_normal_cases
+
+移行用のテストケースで、新パーサーでのサポート範囲を増やすために段階的に機能を追加していくためのものです。少しずつ置き換えていくための正常系テストとして使用します。
+
+## 注意事項
+`pgcst` というprefixがついたテストおよびファイルは、パーサ移行タスクのために用意されたものです。そのためこれらはパーサ移行の終了に伴い削除される予定です。

--- a/crates/uroborosql-fmt/tests/pgcst_coverage.rs
+++ b/crates/uroborosql-fmt/tests/pgcst_coverage.rs
@@ -1,5 +1,5 @@
-mod pgcst_normal_cases;
-use pgcst_normal_cases::print_diff;
+mod pgcst_util;
+use pgcst_util::print_diff;
 
 #[derive(Debug)]
 enum TestStatus {

--- a/crates/uroborosql-fmt/tests/pgcst_normal_cases.rs
+++ b/crates/uroborosql-fmt/tests/pgcst_normal_cases.rs
@@ -45,7 +45,7 @@ impl TestCase {
     }
 }
 
-struct Line(Option<usize>);
+pub struct Line(Option<usize>);
 
 impl std::fmt::Display for Line {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -56,7 +56,7 @@ impl std::fmt::Display for Line {
     }
 }
 
-fn print_diff(expected: impl Into<String>, got: impl Into<String>) {
+pub fn print_diff(expected: impl Into<String>, got: impl Into<String>) {
     let expected = expected.into();
     let got = got.into();
     let diff = TextDiff::from_lines(&expected, &got);

--- a/crates/uroborosql-fmt/tests/pgcst_normal_cases.rs
+++ b/crates/uroborosql-fmt/tests/pgcst_normal_cases.rs
@@ -1,8 +1,8 @@
 use std::fs;
 use std::path::Path;
 
-use console::{style, Style};
-use similar::{ChangeTag, TextDiff};
+mod pgcst_util;
+use pgcst_util::print_diff;
 
 #[derive(Debug)]
 struct TestCase {
@@ -42,54 +42,6 @@ impl TestCase {
             sql,
             expected,
         })
-    }
-}
-
-pub struct Line(Option<usize>);
-
-impl std::fmt::Display for Line {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self.0 {
-            None => write!(f, "    "),
-            Some(idx) => write!(f, "{:<4}", idx + 1),
-        }
-    }
-}
-
-pub fn print_diff(expected: impl Into<String>, got: impl Into<String>) {
-    let expected = expected.into();
-    let got = got.into();
-    let diff = TextDiff::from_lines(&expected, &got);
-
-    for (idx, group) in diff.grouped_ops(3).iter().enumerate() {
-        if idx > 0 {
-            println!("{:-^1$}", "-", 80);
-        }
-        for op in group {
-            for change in diff.iter_inline_changes(op) {
-                let (sign, s) = match change.tag() {
-                    ChangeTag::Delete => ("-", Style::new().red()),
-                    ChangeTag::Insert => ("+", Style::new().green()),
-                    ChangeTag::Equal => (" ", Style::new().dim()),
-                };
-                print!(
-                    "{}{} |{}",
-                    style(Line(change.old_index())).dim(),
-                    style(Line(change.new_index())).dim(),
-                    s.apply_to(sign).bold(),
-                );
-                for (emphasized, value) in change.iter_strings_lossy() {
-                    if emphasized {
-                        print!("{}", s.apply_to(value).underlined().on_black());
-                    } else {
-                        print!("{}", s.apply_to(value));
-                    }
-                }
-                if change.missing_newline() {
-                    println!();
-                }
-            }
-        }
     }
 }
 

--- a/crates/uroborosql-fmt/tests/pgcst_util.rs
+++ b/crates/uroborosql-fmt/tests/pgcst_util.rs
@@ -1,0 +1,51 @@
+use console::{style, Style};
+use similar::{ChangeTag, TextDiff};
+
+struct Line(Option<usize>);
+
+impl std::fmt::Display for Line {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self.0 {
+            None => write!(f, "    "),
+            Some(idx) => write!(f, "{:<4}", idx + 1),
+        }
+    }
+}
+
+#[cfg(test)]
+pub fn print_diff(expected: impl Into<String>, got: impl Into<String>) {
+    let expected = expected.into();
+    let got = got.into();
+    let diff = TextDiff::from_lines(&expected, &got);
+
+    for (idx, group) in diff.grouped_ops(3).iter().enumerate() {
+        if idx > 0 {
+            println!("{:-^1$}", "-", 80);
+        }
+        for op in group {
+            for change in diff.iter_inline_changes(op) {
+                let (sign, s) = match change.tag() {
+                    ChangeTag::Delete => ("-", Style::new().red()),
+                    ChangeTag::Insert => ("+", Style::new().green()),
+                    ChangeTag::Equal => (" ", Style::new().dim()),
+                };
+                print!(
+                    "{}{} |{}",
+                    style(Line(change.old_index())).dim(),
+                    style(Line(change.new_index())).dim(),
+                    s.apply_to(sign).bold(),
+                );
+                for (emphasized, value) in change.iter_strings_lossy() {
+                    if emphasized {
+                        print!("{}", s.apply_to(value).underlined().on_black());
+                    } else {
+                        print!("{}", s.apply_to(value));
+                    }
+                }
+                if change.missing_newline() {
+                    println!();
+                }
+            }
+        }
+    }
+}

--- a/crates/uroborosql-fmt/tests/test_all.rs
+++ b/crates/uroborosql-fmt/tests/test_all.rs
@@ -10,7 +10,7 @@ use uroborosql_fmt::error::UroboroSQLFmtError;
 
 // 並列実行するとグローバル変数の問題が発生するため並列実行しない
 #[test]
-fn test() {
+fn test_all() {
     let result_all_files = test_all_files();
     let result_config_file = test_config_file();
     assert!(result_all_files);


### PR DESCRIPTION
## 概要
カバレッジレポートで Unsupported なケースの理由を出力するオプションを追加

### カバレッジレポートの実行方法例
```
cargo test -- --exact test_with_coverage
```
失敗ケースを出力したい場合は 該当のテストにおけるConfigを書き換えて実行します：
```rs
// pgcst_coverage.rs
#[test]
fn test_with_coverage() {
    let results = run_test_suite();

    // before(default):
    // let config = TestReportConfig::default();

    // after:
    let mut config = TestReportConfig::default();
    config.show_failed_cases = true; // 失敗したケースを表示
    config.show_error_annotations = true; // アノテーションを表示

    print_coverage_report(&results, &config);
}
```


例：
![image](https://github.com/user-attachments/assets/3e1e37e8-9b9f-4ebf-98b9-e139c1de7f63)
