### PR TITLE
単項演算子をサポート

### DIFF
--- a/crates/uroborosql-fmt/src/cst/expr/unary.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/unary.rs
@@ -52,7 +52,8 @@ impl UnaryExpr {
 
         result.push_str(&self.operator);
         // `NOT` のときは空白が必要
-        if self.operator.to_uppercase() == "NOT" {
+        // `@`（絶対値）のときも空白が必要（PostgreSQLでは、`@-` とすると一つのトークンとして扱われてしまうため）
+        if self.operator.to_uppercase() == "NOT" || self.operator.to_uppercase() == "@" {
             add_single_space(&mut result);
         }
         result.push_str(&self.operand.render(depth)?);

--- a/crates/uroborosql-fmt/src/cst/expr/unary.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/unary.rs
@@ -53,7 +53,7 @@ impl UnaryExpr {
         result.push_str(&self.operator);
         // `NOT` のときは空白が必要
         // `@`（絶対値）のときも空白が必要（PostgreSQLでは、`@-` とすると一つのトークンとして扱われてしまうため）
-        if self.operator.to_uppercase() == "NOT" || self.operator.to_uppercase() == "@" {
+        if self.operator.to_uppercase() == "NOT" || self.operator == "@" {
             add_single_space(&mut result);
         }
         result.push_str(&self.operand.render(depth)?);

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr.rs
@@ -1,3 +1,5 @@
+mod a_expr;
+
 use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 
 use crate::{
@@ -32,30 +34,6 @@ use super::{pg_ensure_kind, pg_error_annotation_from_cursor, Visitor};
         - GROUPING '(' expr_list ')'
 */
 impl Visitor {
-    // 呼び出した後、cursorは a_expr を指している
-    pub(crate) fn visit_a_expr(
-        &mut self,
-        cursor: &mut TreeCursor,
-        src: &str,
-    ) -> Result<Expr, UroboroSQLFmtError> {
-        cursor.goto_first_child();
-
-        let expr = match cursor.node().kind() {
-            SyntaxKind::c_expr => self.visit_c_expr(cursor, src)?,
-            _ => {
-                return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_a_expr(): unimplemented expression\n{}",
-                    pg_error_annotation_from_cursor(cursor, src)
-                )));
-            }
-        };
-
-        cursor.goto_parent();
-        pg_ensure_kind(cursor, SyntaxKind::a_expr, src)?;
-
-        Ok(expr)
-    }
-
     fn visit_b_expr(
         &mut self,
         cursor: &mut TreeCursor,

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
@@ -1,0 +1,169 @@
+use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
+
+use crate::{
+    cst::{unary::UnaryExpr, Expr, Location},
+    error::UroboroSQLFmtError,
+};
+
+use super::{pg_ensure_kind, pg_error_annotation_from_cursor, Visitor};
+
+/*
+ * a_expr の構造
+ *
+ * 1. 基本式
+ * - c_expr
+ * - DEFAULT
+ *
+ * 2. 単項演算子
+ * - '+' a_expr
+ * - '-' a_expr
+ * - NOT a_expr
+ * - NOT_LA a_expr
+ * - qual_Op a_expr
+ *
+ * 3. 二項算術演算子
+ * - a_expr '+' a_expr
+ * - a_expr '-' a_expr
+ * - a_expr '*' a_expr
+ * - a_expr '/' a_expr
+ * - a_expr '%' a_expr
+ * - a_expr '^' a_expr
+ *
+ * 4. 比較演算子
+ * - a_expr '<' a_expr
+ * - a_expr '>' a_expr
+ * - a_expr '=' a_expr
+ * - a_expr LESS_EQUALS a_expr
+ * - a_expr GREATER_EQUALS a_expr
+ * - a_expr NOT_EQUALS a_expr
+ * - a_expr qual_Op a_expr
+ * - a_expr IS DISTINCT FROM a_expr
+ * - a_expr IS NOT DISTINCT FROM a_expr
+ *
+ * 5. 論理演算子
+ * - a_expr AND a_expr
+ * - a_expr OR a_expr
+ *
+ * 6. 型変換・属性関連
+ * - a_expr TYPECAST Typename
+ * - a_expr COLLATE any_name
+ * - a_expr AT TIME ZONE a_expr
+ * - a_expr AT LOCAL
+ *
+ * 7. パターンマッチング
+ * - a_expr LIKE a_expr
+ * - a_expr LIKE a_expr ESCAPE a_expr
+ * - a_expr NOT_LA LIKE a_expr
+ * - a_expr NOT_LA LIKE a_expr ESCAPE a_expr
+ * - a_expr ILIKE a_expr
+ * - a_expr ILIKE a_expr ESCAPE a_expr
+ * - a_expr NOT_LA ILIKE a_expr
+ * - a_expr NOT_LA ILIKE a_expr ESCAPE a_expr
+ * - a_expr SIMILAR TO a_expr
+ * - a_expr SIMILAR TO a_expr ESCAPE a_expr
+ * - a_expr NOT_LA SIMILAR TO a_expr
+ * - a_expr NOT_LA SIMILAR TO a_expr ESCAPE a_expr
+ *
+ * 8. NULL関連
+ * - a_expr IS NULL_P
+ * - a_expr ISNULL
+ * - a_expr IS NOT NULL_P
+ * - a_expr NOTNULL
+ *
+ * 9. 真偽値関連
+ * - a_expr IS TRUE_P
+ * - a_expr IS NOT TRUE_P
+ * - a_expr IS FALSE_P
+ * - a_expr IS NOT FALSE_P
+ * - a_expr IS UNKNOWN
+ * - a_expr IS NOT UNKNOWN
+ *
+ * 10. 範囲・集合関連
+ * - a_expr BETWEEN opt_asymmetric b_expr AND a_expr
+ * - a_expr NOT_LA BETWEEN opt_asymmetric b_expr AND a_expr
+ * - a_expr BETWEEN SYMMETRIC b_expr AND a_expr
+ * - a_expr NOT_LA BETWEEN SYMMETRIC b_expr AND a_expr
+ * - a_expr IN_P in_expr
+ * - a_expr NOT_LA IN_P in_expr
+ * - a_expr row OVERLAPS row
+ *
+ * 11. サブクエリ関連
+ * - a_expr subquery_Op sub_type select_with_parens
+ * - a_expr subquery_Op sub_type '(' a_expr ')'
+ * - UNIQUE opt_unique_null_treatment select_with_parens
+ *
+ * 12. ドキュメント・正規化・JSON関連
+ * - a_expr IS DOCUMENT_P
+ * - a_expr IS NOT DOCUMENT_P
+ * - a_expr IS NORMALIZED
+ * - a_expr IS unicode_normal_form NORMALIZED
+ * - a_expr IS NOT NORMALIZED
+ * - a_expr IS NOT unicode_normal_form NORMALIZED
+ * - a_expr IS json_predicate_type_constraint json_key_uniqueness_constraint_opt
+ * - a_expr IS NOT json_predicate_type_constraint json_key_uniqueness_constraint_opt
+ */
+
+impl Visitor {
+    // 呼び出した後、cursorは a_expr を指している
+    pub(crate) fn visit_a_expr(
+        &mut self,
+        cursor: &mut TreeCursor,
+        src: &str,
+    ) -> Result<Expr, UroboroSQLFmtError> {
+        cursor.goto_first_child();
+
+        // cursor -> c_expr | DEFAULT | Plus | Minus | NOT | qual_Op | a_expr | UNIQUE
+        let expr = match cursor.node().kind() {
+            SyntaxKind::c_expr => self.visit_c_expr(cursor, src)?,
+            SyntaxKind::DEFAULT => {
+                return Err(UroboroSQLFmtError::Unimplemented(
+                    "visit_a_expr(): DEFAULT is not implemented".to_string(),
+                ))
+            }
+            // Unary Expression
+            SyntaxKind::Plus | SyntaxKind::Minus | SyntaxKind::NOT | SyntaxKind::qual_Op => {
+                // op a_expr
+
+                // cursor -> op
+                let operator = cursor.node().text();
+                let mut loc = Location::from(cursor.node().range());
+
+                cursor.goto_next_sibling();
+                // cursor -> a_expr
+
+                let operand = self.visit_a_expr(cursor, src)?;
+                loc.append(operand.loc());
+
+                Expr::Unary(Box::new(UnaryExpr::new(operator, operand, loc)))
+            }
+            SyntaxKind::NOT_LA => {
+                // NOT キーワードのうち、 NOT LIKE, NOT ILIKE, NOT SIMILAR TO 等のケース
+                return Err(UroboroSQLFmtError::Unimplemented(
+                    "visit_a_expr(): Not_LA is not implemented".to_string(),
+                ));
+            }
+            SyntaxKind::a_expr => {
+                return Err(UroboroSQLFmtError::Unimplemented(
+                    "visit_a_expr(): a_expr is not implemented".to_string(),
+                ))
+            }
+            SyntaxKind::UNIQUE => {
+                return Err(UroboroSQLFmtError::Unimplemented(
+                    "visit_a_expr(): UNIQUE is not implemented".to_string(),
+                ))
+            }
+            _ => {
+                return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
+                    "visit_a_expr(): Unexpected syntax. node: {}\n{}",
+                    cursor.node().kind(),
+                    pg_error_annotation_from_cursor(cursor, src)
+                )));
+            }
+        };
+
+        cursor.goto_parent();
+        pg_ensure_kind(cursor, SyntaxKind::a_expr, src)?;
+
+        Ok(expr)
+    }
+}

--- a/crates/uroborosql-fmt/test_normal_cases/dst/019_unary_expr.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/019_unary_expr.sql
@@ -1,0 +1,41 @@
+-- Plus
+select
+	+5	as	positive_value
+;
+select
+	+5	as	positive_value
+;
+-- Minus
+select
+	-10	as	negative_value
+;
+select
+	-10	as	negative_value
+;
+-- NOT
+select
+	not	true	as	not_true
+;
+-- qual_Op
+select
+	~5	as	bitwise_not
+;
+select
+	~5	as	bitwise_not
+;
+select
+	|/25	as	square_root
+;
+select
+	|/25	as	square_root
+;
+select
+	||/8	as	cube_root
+;
+select
+	||/8	as	cube_root
+;
+-- select @-5 as absolute_value; : PostgreSQLでは、`@-5` と書くと `@-` が一つのトークンとして扱われるため無効なSQLになる
+select
+	@	-5	as	absolute_value
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/019_unary_expr.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/019_unary_expr.sql
@@ -1,0 +1,20 @@
+-- Plus
+select +5 as positive_value;
+select + 5 as positive_value;
+
+-- Minus
+select -10 as negative_value;
+select - 10 as negative_value;
+
+-- NOT
+select not true as not_true;
+
+-- qual_Op
+select ~5 as bitwise_not;
+select ~ 5 as bitwise_not;
+select |/25 as square_root;
+select |/ 25 as square_root;
+select ||/8 as cube_root;
+select ||/ 8 as cube_root;
+-- select @-5 as absolute_value; : PostgreSQLでは、`@-5` と書くと `@-` が一つのトークンとして扱われるため無効なSQLになる
+select @ -5 as absolute_value;

--- a/crates/uroborosql-fmt/testfiles/dst/select/unary.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/unary.sql
@@ -27,7 +27,7 @@ select
 ;
 -- select @-5 as absolute_value; : PostgreSQLでは、`@-5` と書くと `@-` が一つのトークンとして扱われるため無効なSQLになる
 select
-	@-5	as	absolute_value
+	@	-5	as	absolute_value
 ;
 select
 	||/8	as	cube_root


### PR DESCRIPTION
## Summary 
式のうち、単項の演算子をサポートしました

## Note
PostgreSQLの絶対値演算子(`@`)について、`@-5` のように他の演算子と並べて記述すると `@-` という一つの演算子と認識される挙動がありますが、現行フォーマッタのテストケースではこの点を考慮しないフォーマットをしていたため挙動を変更しました。
commit: https://github.com/future-architect/uroborosql-fmt/pull/131/commits/baae3244b917eaa4833732c68a7857ff42d71312

パーサ移行によって解消される問題としてIssueに起こしました：https://github.com/future-architect/uroborosql-fmt/issues/132