### PR TITLE
コメント対応

### DIFF
--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
@@ -7,7 +7,7 @@ mod unary;
 
 use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 
-use crate::{cst::Expr, error::UroboroSQLFmtError};
+use crate::{cst::{Comment, Expr}, error::UroboroSQLFmtError};
 
 use super::{pg_ensure_kind, pg_error_annotation_from_cursor, Visitor};
 
@@ -150,11 +150,18 @@ impl Visitor {
             }
             SyntaxKind::a_expr => {
                 // cursor -> a_expr
-                let lhs = self.visit_a_expr(cursor, src)?;
+                let mut lhs = self.visit_a_expr(cursor, src)?;
 
                 cursor.goto_next_sibling();
-                // cursor -> 算術演算子 | 比較演算子 | 論理演算子 | TYPECAST | COLLATE | AT | LIKE | ILIKE | SIMILAR | IS | ISNULL | NOTNULL | IN | サブクエリ
+                // cursor -> comment?
+                if cursor.node().is_comment() {
+                    let comment = Comment::pg_new(cursor.node());
+                    lhs.add_comment_to_child(comment)?;
+                    
+                    cursor.goto_next_sibling();
+                }
 
+                // cursor -> 算術演算子 | 比較演算子 | 論理演算子 | TYPECAST | COLLATE | AT | LIKE | ILIKE | SIMILAR | IS | ISNULL | NOTNULL | IN | サブクエリ
                 let expr = self.handle_nodes_after_a_expr(cursor, src, lhs)?;
 
                 Ok(expr)

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
@@ -7,7 +7,10 @@ mod unary;
 
 use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 
-use crate::{cst::{Comment, Expr}, error::UroboroSQLFmtError};
+use crate::{
+    cst::{Comment, Expr},
+    error::UroboroSQLFmtError,
+};
 
 use super::{pg_ensure_kind, pg_error_annotation_from_cursor, Visitor};
 
@@ -157,7 +160,7 @@ impl Visitor {
                 if cursor.node().is_comment() {
                     let comment = Comment::pg_new(cursor.node());
                     lhs.add_comment_to_child(comment)?;
-                    
+
                     cursor.goto_next_sibling();
                 }
 

--- a/crates/uroborosql-fmt/src/new_visitor/statement/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/statement/select.rs
@@ -80,6 +80,10 @@ impl Visitor {
                 // - group_clause
                 // - having_clause
                 // - window_clause
+                SyntaxKind::C_COMMENT | SyntaxKind::SQL_COMMENT => {
+                    let comment = Comment::pg_new(cursor.node());
+                    statement.add_comment_to_child(comment)?;
+                }
                 SyntaxKind::into_clause => {
                     return Err(UroboroSQLFmtError::Unimplemented(format!(
                         "visit_select_stmt(): into_clause is not implemented\n{}",

--- a/crates/uroborosql-fmt/test_normal_cases/dst/029_select_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/029_select_comment.sql
@@ -1,0 +1,8 @@
+-- testfiles/src/select/asterisk.sql
+select
+	tab.*					-- asterisk
+,	tab2.hoge	as	hoge	-- hoge
+from
+	tab
+,	tab2
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/030_in_expr_comments.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/030_in_expr_comments.sql
@@ -1,0 +1,12 @@
+select
+	a	as	a
+from
+	tab1
+where
+	tab1.num	=	1
+and	tbl.ab		in	(/*param_a*/'A', /*param_b*/'B')
+and	tbl.ab		in	(
+		/*param_a*/'A'	-- comment 
+	,	/*param_b*/'B'	-- comment
+	)
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/031_bind_param.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/031_bind_param.sql
@@ -1,0 +1,13 @@
+select
+	a				as	a
+,	/*param*/'1'	as	b
+from
+	t
+where
+	t.a			=	/*var*/1
+and	/*var2*/1	=	t.c
+;
+select /* _SQL_ID_ */
+	/*x*/'x'	as	x
+,	/*y*/'y'	as	y
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/032_col_list_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/032_col_list_comment.sql
@@ -1,0 +1,31 @@
+select
+	*
+from
+	tbl
+where
+	tbl.xy	in	/*var*/('X', 'Y')
+;
+select
+	*
+from
+	tbl
+where
+	tbl.xy	in	(/*var_a*/'A', /*var_b*/'B')	-- ab
+and	tbl.xy	in	/*var*/('X', 'Y')				-- xy
+and	tbl.st	in	(
+		'S'	-- s
+	,	'T'	-- t
+	)											-- st
+;
+select
+	*
+from
+	tbl	t
+where
+	t.id	in	(
+		-- after opening paren
+		-- another comment
+		/*firstId*/0
+	,	/*secondId*/1
+	)
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/029_select_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/029_select_comment.sql
@@ -1,0 +1,5 @@
+-- testfiles/src/select/asterisk.sql
+select tab.* -- asterisk
+, tab2.hoge AS hoge -- hoge
+from tab, tab2
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/030_in_expr_comments.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/030_in_expr_comments.sql
@@ -1,0 +1,7 @@
+select a from tab1
+where tab1.num = 1
+and	tbl.ab	in (/*param_a*/'A', /*param_b*/'B') 
+and	tbl.ab	in (/*param_a*/'A', --comment 
+/*param_b*/'B' -- comment
+) 
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/031_bind_param.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/031_bind_param.sql
@@ -1,0 +1,8 @@
+select a, /*param*/'1' as b
+from t
+where t.a = /*var*/1
+and /*var2*/1 = t.c;
+
+select /* _SQL_ID_ */
+/*x*/'x' as	x
+, /*y*/'y' as	y ;

--- a/crates/uroborosql-fmt/test_normal_cases/src/032_col_list_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/032_col_list_comment.sql
@@ -1,0 +1,14 @@
+select * from tbl
+where tbl.xy in /*var*/('X', 'Y');
+select * from tbl
+where tbl.xy in  (/*var_a*/'A', /*var_b*/'B') -- ab
+and tbl.xy in /*var*/('X', 'Y') -- xy
+and tbl.st in ('S' -- s
+, 'T' -- t
+) -- st
+;
+select * from tbl t
+where t.id in ( -- after opening paren
+        -- another comment
+/*firstId*/0, /*secondId*/1
+); 


### PR DESCRIPTION
## Summary
複数の箇所のコメントに対応しました

### target_list 末尾のコメント
```sql
select
	tab.*					
,	tab2.hoge	as	hoge	-- comment
from
	tab
;
```

### IN におけるコメント
括弧内部のコメント
```sql
select
	*
from
	tab1
where
	tab1.num	=	1
and	tbl.ab		in	(/*param_a*/'A', /*param_b*/'B')
and	tbl.ab		in	(
		/*param_a*/'A'	-- comment 
	,	/*param_b*/'B'	-- comment
	)
and	t.id	in	(
		-- after opening paren
		-- another comment
		/*firstId*/0
	,	/*secondId*/1
	)
;
```

括弧の外のコメント
```sql
select
	*
from
	tbl
where
	tbl.xy	in	/*var*/('X', 'Y')	-- xy
;
```

### 比較演算におけるバインドパラメータ
```sql
select
	*
from
	t
where
	t.a			=	/*var*/1
and	/*var2*/1	=	t.c
;
```