### PR TITLE
Typecast の構文に対応

### DIFF
--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
@@ -4,6 +4,7 @@ mod in_expr;
 mod is_expr;
 mod like;
 mod logical;
+mod type_cast;
 mod unary;
 
 use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
@@ -234,11 +235,8 @@ impl Visitor {
             }
             // 型変換
             SyntaxKind::TYPECAST => {
-                return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_a_expr(): {} is not implemented.\n{}",
-                    cursor.node().kind(),
-                    pg_error_annotation_from_cursor(cursor, src)
-                )))
+                let expr = self.handle_typecast_nodes(cursor, src, lhs)?;
+                Ok(expr)
             }
             // 属性関連
             SyntaxKind::COLLATE | SyntaxKind::AT => {

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/type_cast.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/type_cast.rs
@@ -1,0 +1,80 @@
+use crate::{
+    cst::{
+        type_cast::TypeCast, Expr, FunctionCall, FunctionCallArgs, FunctionCallKind, PrimaryExpr,
+        PrimaryExprKind,
+    },
+    error::UroboroSQLFmtError,
+    new_visitor::pg_ensure_kind,
+    util::convert_keyword_case,
+    CONFIG,
+};
+use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
+
+use super::Visitor;
+
+impl Visitor {
+    /// 式を受け取り、型変換のノード群を走査する
+    ///
+    /// 呼出時、 cursor は TYPECAST を指している
+    /// 呼出後、 cursor は Typename を指している
+    ///
+    pub fn handle_typecast_nodes(
+        &mut self,
+        cursor: &mut TreeCursor,
+        src: &str,
+        expr: Expr,
+    ) -> Result<Expr, UroboroSQLFmtError> {
+        // a_expr TYPECAST Typename
+        // ^      ^        ^
+        // expr   │        │
+        //        └ 呼出時  └ 呼出後
+
+        // cursor -> TYPECAST (`::`)
+        pg_ensure_kind(cursor, SyntaxKind::TYPECAST, src)?;
+
+        cursor.goto_next_sibling();
+        // cursor -> Typename
+        let type_name = self.visit_typename(cursor, src)?;
+        pg_ensure_kind(cursor, SyntaxKind::Typename, src)?;
+
+        // 親の a_expr が、 Type cast 全体の式にあたる
+        let loc = cursor.node().parent().unwrap().range().into();
+
+        if CONFIG.read().unwrap().convert_double_colon_cast {
+            // CAST関数に変換
+
+            let cast_keyword = convert_keyword_case("CAST");
+
+            let as_keyword = CONFIG.read().unwrap().keyword_case.format("AS");
+            let mut aligned = expr.to_aligned();
+            aligned.add_rhs(Some(as_keyword), Expr::Primary(Box::new(type_name)));
+
+            let function = FunctionCall::new(
+                cast_keyword,
+                FunctionCallArgs::new(vec![aligned], expr.loc()),
+                FunctionCallKind::BuiltIn,
+                loc,
+            );
+
+            Ok(Expr::FunctionCall(Box::new(function)))
+        } else {
+            let type_cast = TypeCast::new(expr, type_name, loc);
+            Ok(Expr::TypeCast(Box::new(type_cast)))
+        }
+    }
+
+    fn visit_typename(
+        &mut self,
+        cursor: &mut TreeCursor,
+        src: &str,
+    ) -> Result<PrimaryExpr, UroboroSQLFmtError> {
+        // Typename
+        // - SETOF? SimpleTypename opt_array_bounds
+        // - SETOF? SimpleTypename ARRAY ('[' Iconst ']')?
+
+        pg_ensure_kind(cursor, SyntaxKind::Typename, src)?;
+        // とりあえずはシンプルなキーワードのみの型名を想定
+        let typename = PrimaryExpr::with_pg_node(cursor.node(), PrimaryExprKind::Keyword)?;
+        Ok(typename)
+    }
+}

--- a/crates/uroborosql-fmt/test_normal_cases/dst/034_null_type_cast.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/034_null_type_cast.sql
@@ -1,0 +1,4 @@
+select
+	cast(null	as	text)	as	"test"
+,	cast('Y'	as	text)
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/034_null_type_cast.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/034_null_type_cast.sql
@@ -1,0 +1,4 @@
+select
+	null::text	AS	"test"
+,	'Y'::text
+;


### PR DESCRIPTION
## Summary
`::` によるタイプキャストの構文に対応しました

型名にあたる `Typename` ノードは複雑な表現を持ちますが、現在はuroboroSQL-fmt が対応しているシンプルな型名のみを考慮しています。

### 対応している表現
```sql
'123'::integer
42.5::text
null::text
```
### 対応していない（考慮していない）表現
```sql
-- 配列型へのキャスト
expression::integer[]

-- 特定の長さを持つ文字列型へのキャスト
expression::varchar(10)

-- 複数の型キャストを連鎖
'123'::text::varchar(10)

-- 集合型へのキャスト
expression::SETOF text
```