### PR TITLE
all, distinct に対応

### DIFF
--- a/crates/uroborosql-fmt/src/cst/clause.rs
+++ b/crates/uroborosql-fmt/src/cst/clause.rs
@@ -65,6 +65,15 @@ impl Clause {
         ));
     }
 
+    /// postgresql-cst-parser の Node でキーワードを延長する (延長にはスペースを使用)
+    /// この時、キーワードの大文字小文字を設定に合わせて自動で変換する
+    pub(crate) fn pg_extend_kw(&mut self, node: postgresql_cst_parser::tree_sitter::Node) {
+        let loc = Location::from(node.range());
+        self.loc.append(loc);
+        self.keyword.push(' ');
+        self.keyword.push_str(&convert_keyword_case(node.text()));
+    }
+
     /// 文字列を受け取ってキーワードを延長する
     /// この時、キーワードの大文字小文字を設定に合わせて自動で変換する
     pub(crate) fn extend_kw_with_string(&mut self, kw: &str) {

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr.rs
@@ -5,7 +5,7 @@ use postgresql_cst_parser::syntax_kind::SyntaxKind;
 use postgresql_cst_parser::tree_sitter::TreeCursor;
 
 use crate::{
-    cst::{AlignedExpr, Comment, Expr},
+    cst::{AlignedExpr, ColumnList, Comment, Expr, Location},
     error::UroboroSQLFmtError,
 };
 
@@ -110,5 +110,78 @@ impl Visitor {
         // cursor -> expr_list
 
         Ok(exprs)
+    }
+
+    /// 括弧で囲まれた式リストを処理するメソッド
+    pub(crate) fn visit_parenthesized_expr_list(
+        &mut self,
+        cursor: &mut TreeCursor,
+        src: &str,
+    ) -> Result<ColumnList, UroboroSQLFmtError> {
+        // cursor -> '('
+        pg_ensure_kind(cursor, SyntaxKind::LParen, src)?;
+
+        cursor.goto_next_sibling();
+        // cursor -> comment?
+
+        // 開き括弧と式との間にあるコメントを保持
+        // 最後の要素はバインドパラメータの可能性があるので、最初の式を処理した後で付け替える
+        let mut start_comments = vec![];
+        while cursor.node().is_comment() {
+            let comment = Comment::pg_new(cursor.node());
+            start_comments.push(comment);
+            cursor.goto_next_sibling();
+        }
+
+        // cursor -> expr_list
+        pg_ensure_kind(cursor, SyntaxKind::expr_list, src)?;
+        let mut exprs = self.visit_expr_list(cursor, src)?;
+
+        // start_comments のうち最後のものは、 expr_list の最初の要素のバインドパラメータの可能性がある
+        if let Some(comment) = start_comments.last() {
+            // 定義上、 expr_list は必ず一つ以上の要素を持つ
+            let first_expr = exprs.first_mut().unwrap();
+
+            if comment.is_block_comment() && comment.loc().is_next_to(&first_expr.loc()) {
+                // ブロックコメントかつ式に隣接していればバインドパラメータなので、式に付与する
+                first_expr.set_head_comment(comment.clone());
+
+                // start_comments からも削除
+                start_comments.pop().unwrap();
+            }
+        }
+
+        cursor.goto_next_sibling();
+        // cursor -> comment?
+
+        if cursor.node().is_comment() {
+            // 行末コメントを想定する
+            let comment = Comment::pg_new(cursor.node());
+
+            // exprs は必ず1つ以上要素を持っている
+            let last = exprs.last_mut().unwrap();
+            if last.loc().is_same_line(&comment.loc()) {
+                last.set_trailing_comment(comment)?;
+            } else {
+                // 行末コメント以外のコメントは想定していない
+                return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
+                    "visit_parenthesized_expr_list(): Unexpected comment\n{}",
+                    pg_error_annotation_from_cursor(cursor, src)
+                )));
+            }
+
+            cursor.goto_next_sibling();
+        }
+
+        // cursor -> ')'
+        pg_ensure_kind(cursor, SyntaxKind::RParen, src)?;
+
+        let parent = cursor
+            .node()
+            .parent()
+            .expect("visit_parenthesized_expr_list(): parent not found");
+        let loc = Location::from(parent.range());
+
+        Ok(ColumnList::new(exprs, loc, start_comments))
     }
 }

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr.rs
@@ -120,6 +120,7 @@ impl Visitor {
     ) -> Result<ColumnList, UroboroSQLFmtError> {
         // cursor -> '('
         pg_ensure_kind(cursor, SyntaxKind::LParen, src)?;
+        let mut loc = Location::from(cursor.node().range());
 
         cursor.goto_next_sibling();
         // cursor -> comment?
@@ -175,12 +176,8 @@ impl Visitor {
 
         // cursor -> ')'
         pg_ensure_kind(cursor, SyntaxKind::RParen, src)?;
-
-        let parent = cursor
-            .node()
-            .parent()
-            .expect("visit_parenthesized_expr_list(): parent not found");
-        let loc = Location::from(parent.range());
+        // Location が括弧全体を指すよう更新
+        loc.append(Location::from(cursor.node().range()));
 
         Ok(ColumnList::new(exprs, loc, start_comments))
     }

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/in_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/in_expr.rs
@@ -1,7 +1,7 @@
 use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 
 use crate::{
-    cst::{AlignedExpr, ColumnList, Comment, Expr, Location},
+    cst::{AlignedExpr, Comment, Expr},
     error::UroboroSQLFmtError,
     util::convert_keyword_case,
 };
@@ -116,78 +116,5 @@ impl Visitor {
                 )));
             }
         }
-    }
-
-    /// 括弧で囲まれた式リストを処理するメソッド
-    fn visit_parenthesized_expr_list(
-        &mut self,
-        cursor: &mut TreeCursor,
-        src: &str,
-    ) -> Result<ColumnList, UroboroSQLFmtError> {
-        // cursor -> '('
-        pg_ensure_kind(cursor, SyntaxKind::LParen, src)?;
-
-        cursor.goto_next_sibling();
-        // cursor -> comment?
-
-        // 開き括弧と式との間にあるコメントを保持
-        // 最後の要素はバインドパラメータの可能性があるので、最初の式を処理した後で付け替える
-        let mut start_comments = vec![];
-        while cursor.node().is_comment() {
-            let comment = Comment::pg_new(cursor.node());
-            start_comments.push(comment);
-            cursor.goto_next_sibling();
-        }
-
-        // cursor -> expr_list
-        pg_ensure_kind(cursor, SyntaxKind::expr_list, src)?;
-        let mut exprs = self.visit_expr_list(cursor, src)?;
-
-        // start_comments のうち最後のものは、 expr_list の最初の要素のバインドパラメータの可能性がある
-        if let Some(comment) = start_comments.last() {
-            // 定義上、 expr_list は必ず一つ以上の要素を持つ
-            let first_expr = exprs.first_mut().unwrap();
-
-            if comment.is_block_comment() && comment.loc().is_next_to(&first_expr.loc()) {
-                // ブロックコメントかつ式に隣接していればバインドパラメータなので、式に付与する
-                first_expr.set_head_comment(comment.clone());
-
-                // start_comments からも削除
-                start_comments.pop().unwrap();
-            }
-        }
-
-        cursor.goto_next_sibling();
-        // cursor -> comment?
-
-        if cursor.node().is_comment() {
-            // 行末コメントを想定する
-            let comment = Comment::pg_new(cursor.node());
-
-            // exprs は必ず1つ以上要素を持っている
-            let last = exprs.last_mut().unwrap();
-            if last.loc().is_same_line(&comment.loc()) {
-                last.set_trailing_comment(comment)?;
-            } else {
-                // 行末コメント以外のコメントは想定していない
-                return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                    "visit_parenthesized_expr_list(): Unexpected comment\n{}",
-                    pg_error_annotation_from_cursor(cursor, src)
-                )));
-            }
-
-            cursor.goto_next_sibling();
-        }
-
-        // cursor -> ')'
-        pg_ensure_kind(cursor, SyntaxKind::RParen, src)?;
-
-        let parent = cursor
-            .node()
-            .parent()
-            .expect("visit_parenthesized_expr_list(): parent not found");
-        let loc = Location::from(parent.range());
-
-        Ok(ColumnList::new(exprs, loc, start_comments))
     }
 }

--- a/crates/uroborosql-fmt/test_normal_cases/dst/035_all_distinct.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/035_all_distinct.sql
@@ -1,0 +1,23 @@
+-- all keyword
+select
+	all
+	itemid		as	itemid
+,	itemname	as	itemname
+;
+-- distinct keyword
+select
+	distinct
+	itemid		as	itemid
+,	itemname	as	itemname
+;
+-- distinct clause
+select
+	distinct on
+		(
+			quantity
+		,	itemname
+		,	area
+		)
+	itemid		as	itemid
+,	itemname	as	itemname
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/035_all_distinct.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/035_all_distinct.sql
@@ -1,0 +1,24 @@
+-- all keyword
+SELECT
+    ALL
+    itemid
+,   itemname
+; 
+
+-- distinct keyword
+SELECT
+    DISTINCT
+    itemid
+,   itemname
+;
+
+-- distinct clause
+SELECT
+    DISTINCT ON (
+        quantity
+    ,   itemname
+    ,       area
+    )
+    itemid
+,   itemname
+;


### PR DESCRIPTION
## Summary
`select` キーワード後の `all`, `distinct` キーワードおよび `distinct` 句に対応しました

```sql
-- all keyword
select
	all
	itemid		as	itemid
,	itemname	as	itemname
;
-- distinct keyword
select
	distinct
	itemid		as	itemid
,	itemname	as	itemname
;
-- distinct clause
select
	distinct on
		(
			quantity
		,	itemname
		,	area
		)
	itemid		as	itemid
,	itemname	as	itemname
;
```