### PR TITLE
BETWEEN 述語に対応

### DIFF
--- a/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
@@ -5,7 +5,7 @@ use crate::{
     error::UroboroSQLFmtError,
     new_visitor::{
         create_alias_from_expr, pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor,
-        pg_expr::AExprOrBExpr, Visitor, COMMA,
+        Visitor, COMMA,
     },
     util::convert_keyword_case,
     CONFIG,
@@ -228,7 +228,7 @@ impl Visitor {
         };
 
         let lhs_expr = match cursor.node().kind() {
-            SyntaxKind::a_expr => self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?,
+            SyntaxKind::a_expr => self.visit_a_expr_or_b_expr(cursor, src)?,
             SyntaxKind::Star => {
                 // Star は postgresql-cst-parser の語彙で、uroborosql-fmt::cst では AsteriskExpr として扱う
                 // Star は postgres の文法上 Expression ではないが、 cst モジュールの Expr に変換する

--- a/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
@@ -5,7 +5,7 @@ use crate::{
     error::UroboroSQLFmtError,
     new_visitor::{
         create_alias_from_expr, pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor,
-        Visitor, COMMA,
+        pg_expr::AExprOrBExpr, Visitor, COMMA,
     },
     util::convert_keyword_case,
     CONFIG,
@@ -228,7 +228,7 @@ impl Visitor {
         };
 
         let lhs_expr = match cursor.node().kind() {
-            SyntaxKind::a_expr => self.visit_a_expr(cursor, src)?,
+            SyntaxKind::a_expr => self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?,
             SyntaxKind::Star => {
                 // Star は postgresql-cst-parser の語彙で、uroborosql-fmt::cst では AsteriskExpr として扱う
                 // Star は postgres の文法上 Expression ではないが、 cst モジュールの Expr に変換する

--- a/crates/uroborosql-fmt/src/new_visitor/clause/where_clause.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/where_clause.rs
@@ -4,10 +4,7 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    new_visitor::{
-        create_clause, ensure_kind, pg_create_clause, pg_ensure_kind, pg_expr::AExprOrBExpr,
-        Visitor,
-    },
+    new_visitor::{create_clause, ensure_kind, pg_create_clause, pg_ensure_kind, Visitor},
 };
 
 impl Visitor {
@@ -52,7 +49,7 @@ impl Visitor {
         self.pg_consume_comments_in_clause(cursor, &mut clause)?;
 
         // cursor -> a_expr
-        let expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+        let expr = self.visit_a_expr_or_b_expr(cursor, src)?;
 
         // 結果として得られた式をBodyに変換する
         let body = Body::from(expr);

--- a/crates/uroborosql-fmt/src/new_visitor/clause/where_clause.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/where_clause.rs
@@ -4,7 +4,10 @@ use tree_sitter::TreeCursor;
 use crate::{
     cst::*,
     error::UroboroSQLFmtError,
-    new_visitor::{create_clause, ensure_kind, pg_create_clause, pg_ensure_kind, Visitor},
+    new_visitor::{
+        create_clause, ensure_kind, pg_create_clause, pg_ensure_kind, pg_expr::AExprOrBExpr,
+        Visitor,
+    },
 };
 
 impl Visitor {
@@ -49,7 +52,7 @@ impl Visitor {
         self.pg_consume_comments_in_clause(cursor, &mut clause)?;
 
         // cursor -> a_expr
-        let expr = self.visit_a_expr(cursor, src)?;
+        let expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
 
         // 結果として得られた式をBodyに変換する
         let body = Body::from(expr);

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr.rs
@@ -26,7 +26,8 @@ impl AExprOrBExpr {
 
 impl Visitor {
     /// a_expr または b_expr を走査する
-    /// 引数に a_expr か b_expr のどちらを走査するかを指定する
+    /// 引数で a_expr か b_expr のどちらを走査するかを指定する
+    /// 呼出し時の cursor がコメントを指している場合、バインドパラメータとして隣の兄弟ノードに付加する
     /// 呼出し後、cursor は呼出し時の位置に戻る
     pub(crate) fn visit_a_expr_or_b_expr(
         &mut self,
@@ -36,9 +37,36 @@ impl Visitor {
     ) -> Result<Expr, UroboroSQLFmtError> {
         // b_expr は a_expr のサブセットであるため、a_expr および b_expr の走査には a_expr 用の visitor をそのまま使う
 
+        // 式の直前にあるコメントを処理する
+        // この位置のコメントはバインドパラメータを想定するため、ブロックコメント（C_COMMENT）のみを処理する
+        let head_comment_node = if cursor.node().kind() == SyntaxKind::C_COMMENT {
+            let comment = cursor.node();
+            cursor.goto_next_sibling();
+            // 式の直前に複数コメントが来る場合は想定していない
+            Some(comment)
+        } else {
+            None
+        };
+
         cursor.goto_first_child();
+
         // cursor -> c_expr | DEFAULT | Plus | Minus | NOT | qual_Op | a_expr | UNIQUE
-        let expr = self.handle_a_expr_inner(cursor, src)?;
+        let mut expr = self.handle_a_expr_inner(cursor, src)?;
+
+        // バインドパラメータの追加
+        if let Some(comment_node) = head_comment_node {
+            let comment = Comment::pg_new(comment_node.clone());
+            if comment.loc().is_next_to(&expr.loc()) {
+                // 式に隣接していればバインドパラメータ
+                expr.set_head_comment(comment);
+            } else {
+                // TODO: 隣接していないコメント
+                return Err(UroboroSQLFmtError::Unimplemented(format!(
+                    "visit_a_expr_or_b_expr(): (bind parameter) separated comment\n{}",
+                    pg_error_annotation_from_cursor(&comment_node.walk(), src)
+                )));
+            }
+        }
 
         // cursor -> (last_node)
         assert!(

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr.rs
@@ -41,7 +41,10 @@ impl Visitor {
         let expr = self.handle_a_expr_inner(cursor, src)?;
 
         // cursor -> (last_node)
-        assert!(!cursor.goto_next_sibling());
+        assert!(
+            !cursor.goto_next_sibling(),
+            "visit_a_expr_or_b_expr(): cursor is not at the last node."
+        );
 
         cursor.goto_parent();
         // cursor -> a_expr or b_expr (parent)

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
@@ -14,129 +14,13 @@ use crate::{
     error::UroboroSQLFmtError,
 };
 
-use super::{pg_ensure_kind, pg_error_annotation_from_cursor, Visitor};
-
-/*
- * a_expr の構造
- *
- * 1. 基本式
- * - c_expr
- * - DEFAULT
- *
- * 2. 単項演算子
- * - '+' a_expr
- * - '-' a_expr
- * - NOT a_expr
- * - qual_Op a_expr
- *
- * 3. 二項算術演算子
- * - a_expr '+' a_expr
- * - a_expr '-' a_expr
- * - a_expr '*' a_expr
- * - a_expr '/' a_expr
- * - a_expr '%' a_expr
- * - a_expr '^' a_expr
- *
- * 4. 比較演算子
- * - a_expr '<' a_expr
- * - a_expr '>' a_expr
- * - a_expr '=' a_expr
- * - a_expr LESS_EQUALS a_expr
- * - a_expr GREATER_EQUALS a_expr
- * - a_expr NOT_EQUALS a_expr
- * - a_expr qual_Op a_expr
- * - a_expr IS DISTINCT FROM a_expr
- * - a_expr IS NOT DISTINCT FROM a_expr
- *
- * 5. 論理演算子
- * - a_expr AND a_expr
- * - a_expr OR a_expr
- *
- * 6. 型変換・属性関連
- * - a_expr TYPECAST Typename
- * - a_expr COLLATE any_name
- * - a_expr AT TIME ZONE a_expr
- * - a_expr AT LOCAL
- *
- * 7. パターンマッチング
- * - a_expr LIKE a_expr
- * - a_expr LIKE a_expr ESCAPE a_expr
- * - a_expr NOT_LA LIKE a_expr
- * - a_expr NOT_LA LIKE a_expr ESCAPE a_expr
- * - a_expr ILIKE a_expr
- * - a_expr ILIKE a_expr ESCAPE a_expr
- * - a_expr NOT_LA ILIKE a_expr
- * - a_expr NOT_LA ILIKE a_expr ESCAPE a_expr
- * - a_expr SIMILAR TO a_expr
- * - a_expr SIMILAR TO a_expr ESCAPE a_expr
- * - a_expr NOT_LA SIMILAR TO a_expr
- * - a_expr NOT_LA SIMILAR TO a_expr ESCAPE a_expr
- *
- * 8. NULL関連
- * - a_expr IS NULL_P
- * - a_expr ISNULL
- * - a_expr IS NOT NULL_P
- * - a_expr NOTNULL
- *
- * 9. 真偽値関連
- * - a_expr IS TRUE_P
- * - a_expr IS NOT TRUE_P
- * - a_expr IS FALSE_P
- * - a_expr IS NOT FALSE_P
- * - a_expr IS UNKNOWN
- * - a_expr IS NOT UNKNOWN
- *
- * 10. 範囲・集合関連
- * - a_expr BETWEEN opt_asymmetric b_expr AND a_expr
- * - a_expr NOT_LA BETWEEN opt_asymmetric b_expr AND a_expr
- * - a_expr BETWEEN SYMMETRIC b_expr AND a_expr
- * - a_expr NOT_LA BETWEEN SYMMETRIC b_expr AND a_expr
- * - a_expr IN_P in_expr
- * - a_expr NOT_LA IN_P in_expr
- * - a_expr row OVERLAPS row
- *
- * 11. サブクエリ関連
- * - a_expr subquery_Op sub_type select_with_parens
- * - a_expr subquery_Op sub_type '(' a_expr ')'
- * - UNIQUE opt_unique_null_treatment select_with_parens
- *
- * 12. ドキュメント・正規化・JSON関連
- * - a_expr IS DOCUMENT_P
- * - a_expr IS NOT DOCUMENT_P
- * - a_expr IS NORMALIZED
- * - a_expr IS unicode_normal_form NORMALIZED
- * - a_expr IS NOT NORMALIZED
- * - a_expr IS NOT unicode_normal_form NORMALIZED
- * - a_expr IS json_predicate_type_constraint json_key_uniqueness_constraint_opt
- * - a_expr IS NOT json_predicate_type_constraint json_key_uniqueness_constraint_opt
- */
+use super::{pg_error_annotation_from_cursor, AExprOrBExpr, Visitor};
 
 impl Visitor {
-    /// 呼び出した後、cursorは a_expr を指している
-    pub(crate) fn visit_a_expr(
-        &mut self,
-        cursor: &mut TreeCursor,
-        src: &str,
-    ) -> Result<Expr, UroboroSQLFmtError> {
-        cursor.goto_first_child();
-
-        // cursor -> c_expr | DEFAULT | Plus | Minus | NOT | qual_Op | a_expr | UNIQUE
-        let expr = self.handle_a_expr_inner(cursor, src)?;
-
-        // cursor -> (last_node)
-        assert!(!cursor.goto_next_sibling());
-
-        cursor.goto_parent();
-        // cursor -> a_expr (parent)
-        pg_ensure_kind(cursor, SyntaxKind::a_expr, src)?;
-
-        Ok(expr)
-    }
-
     /// a_expr の 子ノードを走査する
     /// 呼出し時、cursor は a_expr の最初の子ノードを指している
     /// 呼出し後、cursor は a_expr の最後の子ノードを指している
-    fn handle_a_expr_inner(
+    pub fn handle_a_expr_inner(
         &mut self,
         cursor: &mut TreeCursor,
         src: &str,
@@ -156,7 +40,7 @@ impl Visitor {
             }
             SyntaxKind::a_expr => {
                 // cursor -> a_expr
-                let mut lhs = self.visit_a_expr(cursor, src)?;
+                let mut lhs = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
 
                 cursor.goto_next_sibling();
                 // cursor -> comment?

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
@@ -15,13 +15,13 @@ use crate::{
     error::UroboroSQLFmtError,
 };
 
-use super::{pg_error_annotation_from_cursor, AExprOrBExpr, Visitor};
+use super::{pg_error_annotation_from_cursor, Visitor};
 
 impl Visitor {
-    /// a_expr の 子ノードを走査する
-    /// 呼出し時、cursor は a_expr の最初の子ノードを指している
-    /// 呼出し後、cursor は a_expr の最後の子ノードを指している
-    pub fn handle_a_expr_inner(
+    /// a_expr または b_expr の 子ノードを走査する
+    /// 呼出し時、cursor は a_expr または b_expr の最初の子ノードを指している
+    /// 呼出し後、cursor は a_expr または b_expr の最後の子ノードを指している
+    pub fn handle_a_expr_or_b_expr_inner(
         &mut self,
         cursor: &mut TreeCursor,
         src: &str,
@@ -41,7 +41,7 @@ impl Visitor {
             }
             SyntaxKind::a_expr => {
                 // cursor -> a_expr
-                let mut lhs = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+                let mut lhs = self.visit_a_expr_or_b_expr(cursor, src)?;
 
                 cursor.goto_next_sibling();
                 // cursor -> comment?

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
@@ -30,7 +30,7 @@ impl Visitor {
             SyntaxKind::c_expr => self.visit_c_expr(cursor, src),
             SyntaxKind::DEFAULT => {
                 return Err(UroboroSQLFmtError::Unimplemented(
-                    "visit_a_expr(): DEFAULT is not implemented".to_string(),
+                    "visit_a_expr_or_b_expr(): DEFAULT is not implemented".to_string(),
                 ))
             }
             // Unary Expression
@@ -58,21 +58,21 @@ impl Visitor {
             }
             SyntaxKind::row => {
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_a_expr(): {} is not implemented.\n{}",
+                    "visit_a_expr_or_b_expr(): {} is not implemented.\n{}",
                     cursor.node().kind(),
                     pg_error_annotation_from_cursor(cursor, src)
                 )));
             }
             SyntaxKind::UNIQUE => {
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_a_expr(): {} is not implemented.\n{}",
+                    "visit_a_expr_or_b_expr(): {} is not implemented.\n{}",
                     cursor.node().kind(),
                     pg_error_annotation_from_cursor(cursor, src)
                 )));
             }
             _ => {
                 return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                    "visit_a_expr(): Unexpected syntax. node: {}\n{}",
+                    "visit_a_expr_or_b_expr(): Unexpected syntax. node: {}\n{}",
                     cursor.node().kind(),
                     pg_error_annotation_from_cursor(cursor, src)
                 )));
@@ -125,7 +125,7 @@ impl Visitor {
             // 属性関連
             SyntaxKind::COLLATE | SyntaxKind::AT => {
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_a_expr(): {} is not implemented.\n{}",
+                    "visit_a_expr_or_b_expr(): {} is not implemented.\n{}",
                     cursor.node().kind(),
                     pg_error_annotation_from_cursor(cursor, src)
                 )))
@@ -137,7 +137,7 @@ impl Visitor {
             }
             SyntaxKind::SIMILAR => {
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_a_expr(): {} is not implemented.\n{}",
+                    "visit_a_expr_or_b_expr(): {} is not implemented.\n{}",
                     cursor.node().kind(),
                     pg_error_annotation_from_cursor(cursor, src)
                 )))
@@ -149,7 +149,7 @@ impl Visitor {
             }
             SyntaxKind::ISNULL | SyntaxKind::NOTNULL => {
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_a_expr(): {} is not implemented.\n{}",
+                    "visit_a_expr_or_b_expr(): {} is not implemented.\n{}",
                     cursor.node().kind(),
                     pg_error_annotation_from_cursor(cursor, src)
                 )))
@@ -171,7 +171,7 @@ impl Visitor {
             // サブクエリ
             SyntaxKind::subquery_Op => {
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_a_expr(): {} is not implemented.\n{}",
+                    "visit_a_expr_or_b_expr(): {} is not implemented.\n{}",
                     cursor.node().kind(),
                     pg_error_annotation_from_cursor(cursor, src)
                 )))
@@ -211,14 +211,14 @@ impl Visitor {
                     SyntaxKind::SIMILAR => {
                         // NOT_LA SIMILAR
                         return Err(UroboroSQLFmtError::Unimplemented(format!(
-                            "visit_a_expr(): {} is not implemented.\n{}",
+                            "visit_a_expr_or_b_expr(): {} is not implemented.\n{}",
                             cursor.node().kind(),
                             pg_error_annotation_from_cursor(cursor, src)
                         )));
                     }
                     _ => {
                         return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                            "visit_a_expr(): Unexpected syntax. node: {}\n{}",
+                            "visit_a_expr_or_b_expr(): Unexpected syntax. node: {}\n{}",
                             cursor.node().kind(),
                             pg_error_annotation_from_cursor(cursor, src)
                         )));
@@ -227,7 +227,7 @@ impl Visitor {
             }
             _ => {
                 return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                    "visit_a_expr(): Unexpected syntax. node: {}\n{}",
+                    "visit_a_expr_or_b_expr(): Unexpected syntax. node: {}\n{}",
                     cursor.node().kind(),
                     pg_error_annotation_from_cursor(cursor, src)
                 )));

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
@@ -1,4 +1,5 @@
 mod arithmetic;
+mod between;
 mod comparison;
 mod in_expr;
 mod is_expr;
@@ -162,11 +163,8 @@ impl Visitor {
             }
             // BETWEEN
             SyntaxKind::BETWEEN => {
-                return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_a_expr(): {} is not implemented.\n{}",
-                    cursor.node().kind(),
-                    pg_error_annotation_from_cursor(cursor, src)
-                )))
+                let aligned = self.handle_between_expr_nodes(cursor, src, lhs, None)?;
+                Ok(Expr::Aligned(Box::new(aligned)))
             }
             // サブクエリ
             SyntaxKind::subquery_Op => {
@@ -187,11 +185,9 @@ impl Visitor {
                 match cursor.node().kind() {
                     SyntaxKind::BETWEEN => {
                         // NOT_LA BETWEEN
-                        return Err(UroboroSQLFmtError::Unimplemented(format!(
-                            "visit_a_expr(): {} is not implemented.\n{}",
-                            cursor.node().kind(),
-                            pg_error_annotation_from_cursor(cursor, src)
-                        )));
+                        let aligned =
+                            self.handle_between_expr_nodes(cursor, src, lhs, Some(not_text))?;
+                        Ok(Expr::Aligned(Box::new(aligned)))
                     }
                     SyntaxKind::IN_P => {
                         // NOT_LA IN_P

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/arithmetic.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/arithmetic.rs
@@ -3,6 +3,7 @@ use postgresql_cst_parser::tree_sitter::TreeCursor;
 use crate::{
     cst::{Expr, ExprSeq, PrimaryExpr, PrimaryExprKind},
     error::UroboroSQLFmtError,
+    new_visitor::pg_expr::AExprOrBExpr,
 };
 
 use super::Visitor;
@@ -30,7 +31,7 @@ impl Visitor {
 
         // cursor -> a_expr
         cursor.goto_next_sibling();
-        let rhs = self.visit_a_expr(cursor, src)?;
+        let rhs = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
 
         // 演算子を PrimaryExpr として扱う
         let op = PrimaryExpr::with_pg_node(op_node, PrimaryExprKind::Expr)?;

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/arithmetic.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/arithmetic.rs
@@ -3,7 +3,6 @@ use postgresql_cst_parser::tree_sitter::TreeCursor;
 use crate::{
     cst::{Expr, ExprSeq, PrimaryExpr, PrimaryExprKind},
     error::UroboroSQLFmtError,
-    new_visitor::pg_expr::AExprOrBExpr,
 };
 
 use super::Visitor;
@@ -31,7 +30,7 @@ impl Visitor {
 
         // cursor -> a_expr
         cursor.goto_next_sibling();
-        let rhs = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+        let rhs = self.visit_a_expr_or_b_expr(cursor, src)?;
 
         // 演算子を PrimaryExpr として扱う
         let op = PrimaryExpr::with_pg_node(op_node, PrimaryExprKind::Expr)?;

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/between.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/between.rs
@@ -1,0 +1,97 @@
+use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
+
+use crate::{
+    cst::{AlignedExpr, Comment, Expr},
+    error::UroboroSQLFmtError,
+    new_visitor::{pg_ensure_kind, pg_error_annotation_from_cursor, pg_expr::AExprOrBExpr},
+    util::convert_keyword_case,
+};
+
+use super::Visitor;
+
+impl Visitor {
+    pub fn handle_between_expr_nodes(
+        &mut self,
+        cursor: &mut TreeCursor,
+        src: &str,
+        first_expr: Expr,
+        not_keyword: Option<&str>,
+    ) -> Result<AlignedExpr, UroboroSQLFmtError> {
+        // a_expr NOT_LA? BETWEEN (opt_asymmetric|SYMMETRIC)? b_expr AND a_expr
+        // ^      ^       ^                                             ^
+        // |      |       |                                             |
+        // |      |       cursor (呼出し時)                              cursor (呼出し後)
+        // |      |
+        // |     not_keyword
+        // first_expr
+
+        let mut operator = String::new();
+
+        if let Some(not_keyword) = not_keyword {
+            operator += &convert_keyword_case(not_keyword);
+            operator += " "; // betweenの前に空白を入れる
+        }
+
+        // cursor -> BETWEEN
+        pg_ensure_kind(cursor, SyntaxKind::BETWEEN, src)?;
+        let between_keyword = cursor.node().text();
+        operator += &convert_keyword_case(between_keyword);
+        cursor.goto_next_sibling();
+
+        // cursor -> (opt_asymmetric|SYMMETRIC)?
+        if cursor.node().kind() == SyntaxKind::SYMMETRIC {
+            return Err(UroboroSQLFmtError::Unimplemented(format!(
+                "handle_between_expr_nodes(): SYMMETRIC keyword is not implemented.\n{}",
+                pg_error_annotation_from_cursor(cursor, src)
+            )));
+        } else if cursor.node().kind() == SyntaxKind::opt_asymmetric {
+            return Err(UroboroSQLFmtError::Unimplemented(format!(
+                "handle_between_expr_nodes(): ASYMMETRIC keyword is not implemented.\n{}",
+                pg_error_annotation_from_cursor(cursor, src)
+            )));
+        }
+
+        // cursor -> b_expr
+        let from_expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::BExpr)?;
+        cursor.goto_next_sibling();
+
+        // AND の直前に現れる行末コメントを処理する
+        // 行末コメント以外のコメントは想定しない
+        // TODO: 左辺に行末コメントが現れた場合のコメント縦ぞろえ
+        let start_trailing_comment = if cursor.node().is_comment() {
+            let comment = Comment::pg_new(cursor.node());
+            cursor.goto_next_sibling();
+            Some(comment)
+        } else {
+            None
+        };
+
+        // cursor -> AND
+        pg_ensure_kind(cursor, SyntaxKind::AND, src)?;
+        let and_keyword = cursor.node().text();
+        cursor.goto_next_sibling();
+
+        // cursor -> a_expr
+        let to_expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+
+        // (from_expr AND to_expr) をAlignedExprにまとめる
+        let mut rhs = AlignedExpr::new(from_expr);
+        rhs.add_rhs(Some(convert_keyword_case(and_keyword)), to_expr);
+
+        if let Some(comment) = start_trailing_comment {
+            rhs.set_lhs_trailing_comment(comment)?;
+        }
+
+        // (expr BETWEEN rhs) をAlignedExprにまとめる
+        let mut aligned = AlignedExpr::new(first_expr);
+        aligned.add_rhs(Some(operator), Expr::Aligned(Box::new(rhs)));
+
+        // cursor -> (last node)
+        assert!(
+            !cursor.goto_next_sibling(),
+            "handle_between_expr_nodes(): cursor is not at the last node."
+        );
+
+        Ok(aligned)
+    }
+}

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/between.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/between.rs
@@ -3,7 +3,7 @@ use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 use crate::{
     cst::{AlignedExpr, Comment, Expr},
     error::UroboroSQLFmtError,
-    new_visitor::{pg_ensure_kind, pg_error_annotation_from_cursor, pg_expr::AExprOrBExpr},
+    new_visitor::{pg_ensure_kind, pg_error_annotation_from_cursor},
     util::convert_keyword_case,
 };
 
@@ -52,7 +52,7 @@ impl Visitor {
         }
 
         // cursor -> b_expr
-        let from_expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::BExpr)?;
+        let from_expr = self.visit_a_expr_or_b_expr(cursor, src)?;
         cursor.goto_next_sibling();
 
         // AND の直前に現れる行末コメントを処理する
@@ -72,7 +72,7 @@ impl Visitor {
         cursor.goto_next_sibling();
 
         // cursor -> a_expr
-        let to_expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+        let to_expr = self.visit_a_expr_or_b_expr(cursor, src)?;
 
         // (from_expr AND to_expr) をAlignedExprにまとめる
         let mut rhs = AlignedExpr::new(from_expr);

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/comparison.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/comparison.rs
@@ -3,7 +3,7 @@ use postgresql_cst_parser::tree_sitter::TreeCursor;
 use crate::{
     cst::{AlignedExpr, Comment, Expr},
     error::UroboroSQLFmtError,
-    new_visitor::pg_error_annotation_from_cursor,
+    new_visitor::{pg_error_annotation_from_cursor, pg_expr::AExprOrBExpr},
     CONFIG,
 };
 
@@ -50,7 +50,7 @@ impl Visitor {
         };
 
         // cursor -> a_expr
-        let mut rhs = self.visit_a_expr(cursor, src)?;
+        let mut rhs = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
 
         // バインドパラメータなら付与
         if let Some(comment) = bind_param {

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/comparison.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/comparison.rs
@@ -3,7 +3,7 @@ use postgresql_cst_parser::tree_sitter::TreeCursor;
 use crate::{
     cst::{AlignedExpr, Comment, Expr},
     error::UroboroSQLFmtError,
-    new_visitor::{pg_error_annotation_from_cursor, pg_expr::AExprOrBExpr},
+    new_visitor::pg_error_annotation_from_cursor,
     CONFIG,
 };
 
@@ -50,7 +50,7 @@ impl Visitor {
         };
 
         // cursor -> a_expr
-        let mut rhs = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+        let mut rhs = self.visit_a_expr_or_b_expr(cursor, src)?;
 
         // バインドパラメータなら付与
         if let Some(comment) = bind_param {

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/like.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/like.rs
@@ -3,7 +3,7 @@ use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 use crate::{
     cst::{AlignedExpr, Comment, Expr, ExprSeq, PrimaryExpr, PrimaryExprKind},
     error::UroboroSQLFmtError,
-    new_visitor::pg_ensure_kind,
+    new_visitor::{pg_ensure_kind, pg_expr::AExprOrBExpr},
 };
 
 use super::Visitor;
@@ -44,7 +44,7 @@ impl Visitor {
         cursor.goto_next_sibling();
 
         // cursor -> a_expr
-        let pattern = self.visit_a_expr(cursor, src)?;
+        let pattern = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
         cursor.goto_next_sibling();
 
         let mut comments_after_pattern = Vec::new();
@@ -63,7 +63,7 @@ impl Visitor {
             let escape_keyword = Expr::Primary(Box::new(escape_keyword));
 
             cursor.goto_next_sibling();
-            let escape_character = self.visit_a_expr(cursor, src)?;
+            let escape_character = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
 
             exprs.push(escape_keyword);
             exprs.push(escape_character);

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/like.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/like.rs
@@ -3,7 +3,7 @@ use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 use crate::{
     cst::{AlignedExpr, Comment, Expr, ExprSeq, PrimaryExpr, PrimaryExprKind},
     error::UroboroSQLFmtError,
-    new_visitor::{pg_ensure_kind, pg_expr::AExprOrBExpr},
+    new_visitor::pg_ensure_kind,
 };
 
 use super::Visitor;
@@ -44,7 +44,7 @@ impl Visitor {
         cursor.goto_next_sibling();
 
         // cursor -> a_expr
-        let pattern = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+        let pattern = self.visit_a_expr_or_b_expr(cursor, src)?;
         cursor.goto_next_sibling();
 
         let mut comments_after_pattern = Vec::new();
@@ -63,7 +63,7 @@ impl Visitor {
             let escape_keyword = Expr::Primary(Box::new(escape_keyword));
 
             cursor.goto_next_sibling();
-            let escape_character = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+            let escape_character = self.visit_a_expr_or_b_expr(cursor, src)?;
 
             exprs.push(escape_keyword);
             exprs.push(escape_character);

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/logical.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/logical.rs
@@ -3,7 +3,6 @@ use postgresql_cst_parser::tree_sitter::TreeCursor;
 use crate::{
     cst::{Comment, Expr, SeparatedLines},
     error::UroboroSQLFmtError,
-    new_visitor::pg_expr::AExprOrBExpr,
     util::convert_keyword_case,
 };
 
@@ -53,7 +52,7 @@ impl Visitor {
             cursor.goto_next_sibling();
         }
 
-        let right = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+        let right = self.visit_a_expr_or_b_expr(cursor, src)?;
 
         if let Expr::Boolean(boolean) = right {
             // 右辺がbooleanの場合はマージ処理を行う

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/logical.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/logical.rs
@@ -3,6 +3,7 @@ use postgresql_cst_parser::tree_sitter::TreeCursor;
 use crate::{
     cst::{Comment, Expr, SeparatedLines},
     error::UroboroSQLFmtError,
+    new_visitor::pg_expr::AExprOrBExpr,
     util::convert_keyword_case,
 };
 
@@ -52,7 +53,7 @@ impl Visitor {
             cursor.goto_next_sibling();
         }
 
-        let right = self.visit_a_expr(cursor, src)?;
+        let right = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
 
         if let Expr::Boolean(boolean) = right {
             // 右辺がbooleanの場合はマージ処理を行う

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/unary.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/unary.rs
@@ -1,9 +1,8 @@
 use postgresql_cst_parser::tree_sitter::TreeCursor;
 
 use crate::{
-    cst::{unary::UnaryExpr, Expr, Location},
+    cst::{unary::UnaryExpr, Location},
     error::UroboroSQLFmtError,
-    new_visitor::pg_expr::AExprOrBExpr,
 };
 
 use super::Visitor;
@@ -32,7 +31,7 @@ impl Visitor {
         cursor.goto_next_sibling();
         // cursor -> a_expr
 
-        let operand = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+        let operand = self.visit_a_expr_or_b_expr(cursor, src)?;
         loc.append(operand.loc());
 
         Ok(UnaryExpr::new(operator, operand, loc))

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/unary.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/unary.rs
@@ -3,6 +3,7 @@ use postgresql_cst_parser::tree_sitter::TreeCursor;
 use crate::{
     cst::{unary::UnaryExpr, Expr, Location},
     error::UroboroSQLFmtError,
+    new_visitor::pg_expr::AExprOrBExpr,
 };
 
 use super::Visitor;
@@ -31,7 +32,7 @@ impl Visitor {
         cursor.goto_next_sibling();
         // cursor -> a_expr
 
-        let operand = self.visit_a_expr(cursor, src)?;
+        let operand = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
         loc.append(operand.loc());
 
         Ok(UnaryExpr::new(operator, operand, loc))

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr.rs
@@ -10,7 +10,7 @@ use crate::{
     error::UroboroSQLFmtError,
 };
 
-use super::{pg_ensure_kind, pg_error_annotation_from_cursor, AExprOrBExpr, Visitor};
+use super::{pg_ensure_kind, pg_error_annotation_from_cursor, Visitor};
 
 /*
  * c_expr の構造
@@ -66,7 +66,7 @@ impl Visitor {
 
                 // cursor -> expr
                 pg_ensure_kind(cursor, SyntaxKind::a_expr, src)?;
-                let expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+                let expr = self.visit_a_expr_or_b_expr(cursor, src)?;
                 // TODO: remove_redundant_nest
 
                 cursor.goto_next_sibling();

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr.rs
@@ -10,7 +10,7 @@ use crate::{
     error::UroboroSQLFmtError,
 };
 
-use super::{pg_ensure_kind, pg_error_annotation_from_cursor, Visitor};
+use super::{pg_ensure_kind, pg_error_annotation_from_cursor, AExprOrBExpr, Visitor};
 
 /*
  * c_expr の構造
@@ -66,7 +66,7 @@ impl Visitor {
 
                 // cursor -> expr
                 pg_ensure_kind(cursor, SyntaxKind::a_expr, src)?;
-                let expr = self.visit_a_expr(cursor, src)?;
+                let expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
                 // TODO: remove_redundant_nest
 
                 cursor.goto_next_sibling();

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/case_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/case_expr.rs
@@ -3,9 +3,7 @@ use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 use crate::{
     cst::{Body, Comment, CondExpr, Location},
     error::UroboroSQLFmtError,
-    new_visitor::{
-        pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor, pg_expr::AExprOrBExpr,
-    },
+    new_visitor::{pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor},
     util::convert_keyword_case,
 };
 
@@ -150,7 +148,7 @@ impl Visitor {
         cursor.goto_first_child();
 
         // cursor -> a_expr
-        let mut expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+        let mut expr = self.visit_a_expr_or_b_expr(cursor, src)?;
 
         // コメントノードがバインドパラメータであるかを判定する
         // バインドパラメータならば式として処理し、そうでなければエラー
@@ -199,7 +197,7 @@ impl Visitor {
         self.pg_consume_comments_in_clause(cursor, &mut when_clause)?;
 
         // cursor -> a_expr
-        let when_expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+        let when_expr = self.visit_a_expr_or_b_expr(cursor, src)?;
         when_clause.set_body(Body::from(when_expr));
 
         cursor.goto_next_sibling();
@@ -213,7 +211,7 @@ impl Visitor {
         self.pg_consume_comments_in_clause(cursor, &mut then_clause)?;
 
         // cursor -> a_expr
-        let then_expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+        let then_expr = self.visit_a_expr_or_b_expr(cursor, src)?;
         then_clause.set_body(Body::from(then_expr));
 
         cond_expr.add_when_then_clause(when_clause, then_clause);
@@ -247,7 +245,7 @@ impl Visitor {
         self.pg_consume_comments_in_clause(cursor, &mut else_clause)?;
 
         // cursor -> a_expr
-        let else_expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+        let else_expr = self.visit_a_expr_or_b_expr(cursor, src)?;
         else_clause.set_body(Body::from(else_expr));
 
         cond_expr.set_else_clause(else_clause);

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/case_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/case_expr.rs
@@ -3,7 +3,9 @@ use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 use crate::{
     cst::{Body, Comment, CondExpr, Location},
     error::UroboroSQLFmtError,
-    new_visitor::{pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor},
+    new_visitor::{
+        pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor, pg_expr::AExprOrBExpr,
+    },
     util::convert_keyword_case,
 };
 
@@ -148,7 +150,7 @@ impl Visitor {
         cursor.goto_first_child();
 
         // cursor -> a_expr
-        let mut expr = self.visit_a_expr(cursor, src)?;
+        let mut expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
 
         // コメントノードがバインドパラメータであるかを判定する
         // バインドパラメータならば式として処理し、そうでなければエラー
@@ -197,7 +199,7 @@ impl Visitor {
         self.pg_consume_comments_in_clause(cursor, &mut when_clause)?;
 
         // cursor -> a_expr
-        let when_expr = self.visit_a_expr(cursor, src)?;
+        let when_expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
         when_clause.set_body(Body::from(when_expr));
 
         cursor.goto_next_sibling();
@@ -211,7 +213,7 @@ impl Visitor {
         self.pg_consume_comments_in_clause(cursor, &mut then_clause)?;
 
         // cursor -> a_expr
-        let then_expr = self.visit_a_expr(cursor, src)?;
+        let then_expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
         then_clause.set_body(Body::from(then_expr));
 
         cond_expr.add_when_then_clause(when_clause, then_clause);
@@ -245,7 +247,7 @@ impl Visitor {
         self.pg_consume_comments_in_clause(cursor, &mut else_clause)?;
 
         // cursor -> a_expr
-        let else_expr = self.visit_a_expr(cursor, src)?;
+        let else_expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
         else_clause.set_body(Body::from(else_expr));
 
         cond_expr.set_else_clause(else_clause);

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_application.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_application.rs
@@ -5,7 +5,9 @@ use crate::{
         AlignedExpr, AsteriskExpr, Comment, Expr, FunctionCall, FunctionCallArgs, FunctionCallKind,
     },
     error::UroboroSQLFmtError,
-    new_visitor::{pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor},
+    new_visitor::{
+        pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor, pg_expr::AExprOrBExpr,
+    },
     util::convert_keyword_case,
 };
 
@@ -203,7 +205,7 @@ impl Visitor {
 
         let arg = match cursor.node().kind() {
             SyntaxKind::a_expr => {
-                let expr = self.visit_a_expr(cursor, src)?;
+                let expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
                 expr.to_aligned()
             }
             // 名前付き引数

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_application.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_application.rs
@@ -5,9 +5,7 @@ use crate::{
         AlignedExpr, AsteriskExpr, Comment, Expr, FunctionCall, FunctionCallArgs, FunctionCallKind,
     },
     error::UroboroSQLFmtError,
-    new_visitor::{
-        pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor, pg_expr::AExprOrBExpr,
-    },
+    new_visitor::{pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor},
     util::convert_keyword_case,
 };
 
@@ -205,7 +203,7 @@ impl Visitor {
 
         let arg = match cursor.node().kind() {
             SyntaxKind::a_expr => {
-                let expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+                let expr = self.visit_a_expr_or_b_expr(cursor, src)?;
                 expr.to_aligned()
             }
             // 名前付き引数

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_expr_common_subexpr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_expr_common_subexpr.rs
@@ -6,7 +6,7 @@ use crate::{
         PrimaryExprKind,
     },
     error::UroboroSQLFmtError,
-    new_visitor::{pg_ensure_kind, pg_error_annotation_from_cursor, pg_expr::AExprOrBExpr},
+    new_visitor::{pg_ensure_kind, pg_error_annotation_from_cursor},
     util::convert_keyword_case,
 };
 
@@ -103,7 +103,7 @@ impl Visitor {
         cursor.goto_next_sibling();
         // cursor -> a_expr
         pg_ensure_kind(cursor, SyntaxKind::a_expr, src)?;
-        let expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
+        let expr = self.visit_a_expr_or_b_expr(cursor, src)?;
 
         cursor.goto_next_sibling();
         // cursor -> AS

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_expr_common_subexpr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_expr_common_subexpr.rs
@@ -6,7 +6,7 @@ use crate::{
         PrimaryExprKind,
     },
     error::UroboroSQLFmtError,
-    new_visitor::{pg_ensure_kind, pg_error_annotation_from_cursor},
+    new_visitor::{pg_ensure_kind, pg_error_annotation_from_cursor, pg_expr::AExprOrBExpr},
     util::convert_keyword_case,
 };
 
@@ -103,7 +103,7 @@ impl Visitor {
         cursor.goto_next_sibling();
         // cursor -> a_expr
         pg_ensure_kind(cursor, SyntaxKind::a_expr, src)?;
-        let expr = self.visit_a_expr(cursor, src)?;
+        let expr = self.visit_a_expr_or_b_expr(cursor, src, AExprOrBExpr::AExpr)?;
 
         cursor.goto_next_sibling();
         // cursor -> AS

--- a/crates/uroborosql-fmt/test_normal_cases/dst/037_between.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/037_between.sql
@@ -1,0 +1,36 @@
+-- between
+select
+	std.grade	as	grade
+from
+	student	std
+where
+	grade	between	60	and	70
+or	grade	between	80	and	90
+;
+-- not between
+select
+	std.grade	as	grade
+from
+	student	std
+where
+	grade	between		60	and	100
+and	grade	not between	70	and	80
+;
+-- bind params
+select
+	std.grade	as	grade
+from
+	student	std
+where
+	grade	between		/*start1*/60	and	/*end1*/100
+and	grade	not between	/*start2*/70	and	/*end2*/80
+;
+-- comments
+select
+	std.grade	as	grade
+from
+	student	std
+where
+	grade	between		/*start1*/60	and	/*end1*/100	-- between
+and	grade	not between	/*start2*/70	and	/*end2*/80	-- not between
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/037_between.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/037_between.sql
@@ -1,0 +1,27 @@
+-- between
+select std.grade as grade 
+from student std
+where grade between 60 and 70
+or grade between 80 and 90
+;
+
+-- not between
+select std.grade as grade 
+from student std
+where grade between 60 and 100
+and grade not between 70 and 80
+;
+
+-- bind params
+select std.grade as grade 
+from student std
+where grade between /*start1*/60 and /*end1*/100
+and grade not between /*start2*/70 and /*end2*/80
+;
+
+-- comments
+select std.grade as grade 
+from student std
+where grade between /*start1*/60 and /*end1*/100 -- between
+and grade not between /*start2*/70 and /*end2*/80 -- not between
+;


### PR DESCRIPTION
## Summary
BETWEEN に対応しました
```sql
select
	std.grade	as	grade
from
	student	std
where
	grade	between		/*start1*/60	and	/*end1*/100	-- between
and	grade	not between	/*start2*/70	and	/*end2*/80	-- not between
;
```

## b_expr の visitor について
PostgreSQL の構文における `b_expr` は、特定の場所で shift/reduce の競合を避けるために利用される式の構文です。
例えば、 BETWEEN 述語は `a_expr BETWEEN b_expr AND a_expr` のように定義され、BETWEEN における`AND` が論理演算における `AND` と競合するのを防いでいます。

以上のような構文解析の事情で `a_expr` と `b_expr` は別々のノードになっていますが、構造としては `b_expr` が  `a_expr` のサブセットになっているため、 visitor を共有できます。

そのため、これまで 利用していた `visit_a_expr` を `visit_a_expr_or_b_expr` として、visitor を共有する実装を採用しました。





