### PR TITLE
Fix negative number alignment

### DIFF
--- a/crates/uroborosql-fmt/src/cst/expr/unary.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/unary.rs
@@ -35,9 +35,12 @@ impl UnaryExpr {
     pub(crate) fn last_line_len_from_left(&self, acc: usize) -> usize {
         if self.operand.is_multi_line() {
             self.operand.last_line_len()
-        } else {
-            // ( 演算子 '\t' 式 ) の長さ
+        } else if self.operator.to_uppercase() == "NOT" {
+            // 演算子が `NOT` の場合、operandの前にタブ文字を挿入する
             to_tab_num(self.operator.len() + acc) * tab_size() + self.operand.last_line_len()
+        } else {
+            // (演算子 式) の長さ
+            to_tab_num(acc) * tab_size() + self.operator.len() + self.operand.last_line_len()
         }
     }
 

--- a/crates/uroborosql-fmt/testfiles/dst/select/unary.sql
+++ b/crates/uroborosql-fmt/testfiles/dst/select/unary.sql
@@ -35,3 +35,10 @@ select
 select
 	||/8	as	cube_root
 ;
+-- 単項演算子がある場合の縦揃え
+select
+	1		as	positive_value	-- 式
+,	-2		as	negative_value	-- 1文字
+,	|/4		as	square_root		-- 2文字
+,	||/8	as	cube_root		-- 3文字
+;

--- a/crates/uroborosql-fmt/testfiles/src/select/unary.sql
+++ b/crates/uroborosql-fmt/testfiles/src/select/unary.sql
@@ -17,3 +17,11 @@ select @ -5 as absolute_value;
 
 select ||/8 as cube_root;
 select ||/ 8 as cube_root;
+
+-- 単項演算子がある場合の縦揃え
+select
+1 as positive_value -- 式
+,-2 as negative_value -- 1文字
+,|/4 as square_root -- 2文字
+,||/8 as cube_root -- 3文字
+;


### PR DESCRIPTION
closes #106 

単項演算がある場合の縦ぞろえがずれている問題を修正しました

input
```sql
select
    -1 as c1
,   1 as c2
```

result (before fix)
```sql
select
	-1	as	c1
,	1		as	c2
```

result (after fix)
```sql
select
	-1	as	c1
,	1	as	c2
```