### PR TITLE
select サブクエリに対応

### DIFF
--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr.rs
@@ -2,6 +2,7 @@ mod aexpr_const;
 mod case_expr;
 mod columnref;
 mod func_expr;
+mod select_with_parens;
 
 use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 
@@ -110,10 +111,8 @@ impl Visitor {
             }
             SyntaxKind::func_expr => self.visit_func_expr(cursor, src)?,
             SyntaxKind::select_with_parens => {
-                return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_c_expr(): select_with_parens is not implemented\n{}",
-                    pg_error_annotation_from_cursor(cursor, src)
-                )))
+                let sub_expr = self.visit_select_with_parens(cursor, src)?;
+                Expr::Sub(Box::new(sub_expr))
             }
             SyntaxKind::EXISTS => {
                 return Err(UroboroSQLFmtError::Unimplemented(format!(

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr.rs
@@ -110,10 +110,7 @@ impl Visitor {
                 Expr::Cond(Box::new(cond_expr))
             }
             SyntaxKind::func_expr => self.visit_func_expr(cursor, src)?,
-            SyntaxKind::select_with_parens => {
-                let sub_expr = self.visit_select_with_parens(cursor, src)?;
-                Expr::Sub(Box::new(sub_expr))
-            }
+            SyntaxKind::select_with_parens => self.visit_select_with_parens(cursor, src)?,
             SyntaxKind::EXISTS => {
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
                     "visit_c_expr(): EXISTS is not implemented\n{}",

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/select_with_parens.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/select_with_parens.rs
@@ -1,0 +1,62 @@
+use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
+
+use crate::{
+    cst::{Comment, Location, SubExpr},
+    error::UroboroSQLFmtError,
+    new_visitor::pg_ensure_kind,
+};
+
+use super::Visitor;
+
+impl Visitor {
+    /// かっこで囲まれたSELECTサブクエリをフォーマットする
+    /// 呼び出し後、cursor は select_subexpression を指している
+    pub fn visit_select_with_parens(
+        &mut self,
+        cursor: &mut TreeCursor,
+        src: &str,
+    ) -> Result<SubExpr, UroboroSQLFmtError> {
+        // select_with_parens
+        // - '(' select_no_parens ')'
+        // - '(' select_with_parens ')'
+        //
+        // select_no_parens というノードは実際には存在しない（cst-parser で消去される）
+        // そのため、かっこの中に通常の select 文の要素が並ぶと考えればよい
+
+        let loc = Location::from(cursor.node().range());
+
+        // cursor -> select_with_parens
+
+        cursor.goto_first_child();
+        // cursor -> '('
+
+        cursor.goto_next_sibling();
+
+        // cursor -> comments?
+        let mut comment_buf: Vec<Comment> = vec![];
+        while cursor.node().is_comment() {
+            let comment = Comment::pg_new(cursor.node());
+            comment_buf.push(comment);
+            cursor.goto_next_sibling();
+        }
+
+        // cursor -> SELECT keyword
+
+        // SelectStmt の子要素にあたるノード群が並ぶ
+        // 呼出し後、cursor は ')' を指す
+        let mut select_stmt = self.visit_select_stmt_inner(cursor, src)?;
+
+        // select 文の前にコメントがあった場合、コメントを追加
+        comment_buf
+            .into_iter()
+            .for_each(|c| select_stmt.add_comment(c));
+
+        // cursor -> ')'
+        pg_ensure_kind(cursor, SyntaxKind::RParen, src)?;
+
+        cursor.goto_parent();
+        pg_ensure_kind(cursor, SyntaxKind::select_with_parens, src)?;
+
+        Ok(SubExpr::new(select_stmt, loc))
+    }
+}

--- a/crates/uroborosql-fmt/test_normal_cases/dst/039_subquery_expression.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/039_subquery_expression.sql
@@ -1,0 +1,8 @@
+select
+	(
+		select
+			a	as	a
+		from
+			b
+	)
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/040_subquery_expression_comments.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/040_subquery_expression_comments.sql
@@ -1,0 +1,10 @@
+select
+	(
+		-- comment before statement
+		select
+			a	as	a
+		from
+			b
+		-- comment after statement
+	)
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/041_nested_select_subquery.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/041_nested_select_subquery.sql
@@ -1,0 +1,24 @@
+select
+	(
+		(
+			select
+				1
+		)
+	)
+;
+select
+	(
+		(
+			select
+				1
+		)
+	)
+;
+select
+	(
+		(
+			select
+				1
+		)
+	)
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/042_nested_select_subquery_comments.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/042_nested_select_subquery_comments.sql
@@ -1,0 +1,48 @@
+select
+	(
+	-- comment
+	-- comment
+		(
+			select
+				1
+		)
+	-- comment
+	-- comment
+	)
+;
+select
+	(
+	-- comment
+	-- comment
+	-- comment
+	-- comment
+		(
+			select
+				1
+		)
+	-- comment
+	-- comment
+	-- comment
+	-- comment
+	)
+;
+select
+	(
+	-- comment
+	-- comment
+	-- comment
+	-- comment
+	-- comment
+	-- comment
+		(
+			select
+				1
+		)
+	-- comment
+	-- comment
+	-- comment
+	-- comment
+	-- comment
+	-- comment
+	)
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/043_subquery_as_table.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/043_subquery_as_table.sql
@@ -1,0 +1,10 @@
+select
+	*
+from
+	(
+		select
+			*
+		from
+			table1
+	)
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/044_subquery_as_table_aliased.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/044_subquery_as_table_aliased.sql
@@ -8,3 +8,14 @@ from
 			table1
 	)	subquery
 ;
+select
+	*
+from
+	(
+		select
+			*
+		from
+			table1
+	)	-- comment
+	subquery
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/044_subquery_as_table_aliased.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/044_subquery_as_table_aliased.sql
@@ -1,0 +1,10 @@
+select
+	*
+from
+	(
+		select
+			*
+		from
+			table1
+	)	subquery
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/039_subquery_expression.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/039_subquery_expression.sql
@@ -1,0 +1,1 @@
+select (select a from b);

--- a/crates/uroborosql-fmt/test_normal_cases/src/040_subquery_expression_comments.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/040_subquery_expression_comments.sql
@@ -1,0 +1,10 @@
+select
+	(
+		-- comment before statement
+		select
+			a	as	a
+		from
+			b
+		-- comment after statement
+	)
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/041_nested_select_subquery.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/041_nested_select_subquery.sql
@@ -1,0 +1,3 @@
+select ((select 1));
+select (((select 1)));
+select ((((select 1))));

--- a/crates/uroborosql-fmt/test_normal_cases/src/042_nested_select_subquery_comments.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/042_nested_select_subquery_comments.sql
@@ -1,0 +1,41 @@
+select (
+    -- comment
+    -- comment
+    (select 1)
+    -- comment
+    -- comment
+    );
+
+select (
+    -- comment
+    -- comment
+    (
+        -- comment
+        -- comment
+        (select 1)
+        -- comment
+        -- comment
+    )
+    -- comment
+    -- comment
+    );
+
+select (
+    -- comment
+    -- comment
+    (
+        -- comment
+        -- comment
+        (
+            -- comment
+            -- comment
+            (select 1)
+            -- comment
+            -- comment
+        )
+        -- comment
+        -- comment
+    )
+    -- comment
+    -- comment
+);

--- a/crates/uroborosql-fmt/test_normal_cases/src/043_subquery_as_table.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/043_subquery_as_table.sql
@@ -1,0 +1,1 @@
+select * from (select * from table1);

--- a/crates/uroborosql-fmt/test_normal_cases/src/044_subquery_as_table_aliased.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/044_subquery_as_table_aliased.sql
@@ -1,0 +1,2 @@
+select *
+from (select * from table1) as subquery;

--- a/crates/uroborosql-fmt/test_normal_cases/src/044_subquery_as_table_aliased.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/044_subquery_as_table_aliased.sql
@@ -1,2 +1,6 @@
 select *
 from (select * from table1) as subquery;
+
+select *
+from (select * from table1) -- comment
+subquery;


### PR DESCRIPTION
## Summary
select サブクエリに対応しました
- 括弧がネストする場合や、テーブル参照におけるサブクエリにも対応しています。 
- EXISTS クエリおよび IN サブクエリには未対応です。

```sql
select
	(
		-- comment before statement
		select
			a	as	a
		from
			b
		-- comment after statement
	)
;
```

```sql
select
	*
from
	(
		select
			*
		from
			table1
	)	subquery
;
```