### PR TITLE
ALL, SOME, ANY サブクエリに対応

### DIFF
--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr.rs
@@ -1,3 +1,4 @@
+mod all_some_any_subquery;
 mod arithmetic;
 mod between;
 mod comparison;
@@ -166,13 +167,10 @@ impl Visitor {
                 let aligned = self.handle_between_expr_nodes(cursor, src, lhs, None)?;
                 Ok(Expr::Aligned(Box::new(aligned)))
             }
-            // サブクエリ
+            // ALL, ANY, SOME 式
             SyntaxKind::subquery_Op => {
-                return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "visit_a_expr_or_b_expr(): {} is not implemented.\n{}",
-                    cursor.node().kind(),
-                    pg_error_annotation_from_cursor(cursor, src)
-                )))
+                let aligned = self.handle_all_some_any_nodes(cursor, src, lhs)?;
+                Ok(Expr::Aligned(Box::new(aligned)))
             }
             SyntaxKind::NOT_LA => {
                 // NOT キーワードのうち、 後に BETWEEN, IN, LIKE, ILIKE, SIMILAR のいずれかが続くケース

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/all_some_any_subquery.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/all_some_any_subquery.rs
@@ -1,0 +1,78 @@
+use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
+
+use crate::{
+    cst::{AlignedExpr, Expr},
+    error::UroboroSQLFmtError,
+    new_visitor::pg_error_annotation_from_cursor,
+    util::{convert_keyword_case, single_space},
+};
+
+use super::Visitor;
+
+impl Visitor {
+    /// ALL, SOME, ANY の式をフォーマットする
+    /// 呼出時、 cursor は subquery_Op を指し、引数には a_expr を受け取る
+    /// 呼出後、 cursor は 最後の要素を指す
+    pub fn handle_all_some_any_nodes(
+        &mut self,
+        cursor: &mut TreeCursor,
+        src: &str,
+        lhs: Expr,
+    ) -> Result<AlignedExpr, UroboroSQLFmtError> {
+        // a_expr subquery_Op sub_type select_with_parens
+        // a_expr subquery_Op sub_type '(' a_expr ')'
+        // ^      ^                                ^
+        // |      |                                |
+        // |      └ 呼出時                          └ 呼出し後
+        // └ lhs
+
+        // cursor -> subquery_Op
+        //
+        // TODO: 子要素までハンドリングする
+        // subquery_Op
+        // - all_Op
+        // - NOT_LA? (LIKE | ILIKE)
+        // - OPERATOR '(' any_operator ')'
+        let op = convert_keyword_case(cursor.node().text());
+
+        cursor.goto_next_sibling();
+        // cursor -> sub_type (ALL | ANY | SOME)
+        let all_some_any_keyword = convert_keyword_case(cursor.node().text());
+
+        cursor.goto_next_sibling();
+
+        let rhs = match cursor.node().kind() {
+            SyntaxKind::select_with_parens => self.visit_select_with_parens(cursor, src)?,
+            SyntaxKind::LParen => {
+                // 括弧で囲まれた式が来るパターン
+                // a_expr subquery_Op sub_type '(' a_expr ')'
+                //                             ^^^
+                return Err(UroboroSQLFmtError::Unimplemented(format!(
+                    "handle_all_some_any_nodes(): parenthesized expression is not implemented. node: {}\n{}",
+                    cursor.node().kind(),
+                    pg_error_annotation_from_cursor(cursor, src)
+                )));
+            }
+            _ => {
+                return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
+                    "handle_all_some_any_nodes(): Unexpected syntax. node: {}\n{}",
+                    cursor.node().kind(),
+                    pg_error_annotation_from_cursor(cursor, src)
+                )));
+            }
+        };
+
+        let mut all_some_any_sub = AlignedExpr::new(lhs);
+
+        let space = single_space();
+        all_some_any_sub.add_rhs(Some(format!("{op}{space}{all_some_any_keyword}")), rhs);
+
+        assert!(
+            !cursor.goto_next_sibling(),
+            "handle_all_some_any_nodes(): cursor is not at the end of the node\n{}",
+            pg_error_annotation_from_cursor(cursor, src)
+        );
+
+        Ok(all_some_any_sub)
+    }
+}

--- a/crates/uroborosql-fmt/test_normal_cases/dst/047_all_some_any_subquery.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/047_all_some_any_subquery.sql
@@ -1,0 +1,45 @@
+select
+	*
+from
+	tbl1
+where
+	col1						!=	all	(
+		select
+			col1	as	col1
+		from
+			tbl2
+		where
+			col1	is	not	null
+	)
+and	longlonglonglonglonglong	=		test
+;
+select
+	*
+from
+	tbl1
+where
+	col1						!=	some	(
+		select
+			col1	as	col1
+		from
+			tbl2
+		where
+			col1	is	not	null
+	)
+and	longlonglonglonglonglong	=		test
+;
+select
+	*
+from
+	tbl1
+where
+	col1						=	any	(
+		select
+			col1	as	col1
+		from
+			tbl2
+		where
+			col1	is	not	null
+	)
+and	longlonglonglonglonglong	=		test
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/047_all_some_any_subquery.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/047_all_some_any_subquery.sql
@@ -1,0 +1,29 @@
+select 	*
+from 	tbl1
+where 	col1 != all
+	  (select 	col1
+	   from 	tbl2
+       where 	col1 is not null)
+	   and 
+	   longlonglonglonglonglong = test
+;
+
+select 	*
+from 	tbl1
+where 	col1 != some
+	  (select 	col1
+	   from 	tbl2
+       where 	col1 is not null)
+	   and 
+	   longlonglonglonglonglong = test
+;
+
+select 	*
+from 	tbl1
+where 	col1 = any
+	  (select 	col1
+	   from 	tbl2
+       where 	col1 is not null)
+	   and 
+	   longlonglonglonglonglong = test
+;


### PR DESCRIPTION
## Summary
ALL, SOME, ANY が現れる式のうちサブクエリに対応しました
```sql
select
	*
from
	tbl1
where
	col1						!=	all	(
		select
			col1	as	col1
		from
			tbl2
		where
			col1	is	not	null
	)
and	longlonglonglonglonglong	=		test
;
```

## Notes
uroboroSQL-fmt のフォーマット機能に合わせた最低限の実装のため、以下は対応していません
- 演算子が `NOT LIKE` や `OPERATOR(any_operator)` のように、複数のノードから成る場合
  - 演算子部分のテキストがそのまま使用されます。
  - 子ノードまでハンドリングせず、親ノードから得たテキストをそのまま使っているためです。
- サブクエリが来ないパターンの式は未対応です #105 


カバレッジテストで NOT キーワードの `convert_case` が適用されない問題が発生しますが、次の PR で修正します。