### PR TITLE
sort 句（order by 句） に対応

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "postgresql-cst-parser"
 version = "0.1.0"
-source = "git+https://github.com/future-architect/postgresql-cst-parser#04f969847fbf089f5b7a60d52d40fb6c3201f159"
+source = "git+https://github.com/future-architect/postgresql-cst-parser#ca9592c9236db3840fe6c8b170c96e260604d897"
 dependencies = [
  "cstree",
  "miniz_oxide",

--- a/crates/uroborosql-fmt/src/new_visitor/clause.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause.rs
@@ -1,3 +1,4 @@
 mod from;
 mod select;
+mod sort;
 mod where_clause;

--- a/crates/uroborosql-fmt/src/new_visitor/clause/sort.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/sort.rs
@@ -1,0 +1,191 @@
+use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
+
+use crate::{
+    cst::{AlignedExpr, Body, Clause, Comment, Expr, Location, PrimaryExpr, SeparatedLines},
+    error::UroboroSQLFmtError,
+    new_visitor::{pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor, COMMA},
+    util::convert_keyword_case,
+    NewVisitor as Visitor,
+};
+
+// sort_clause
+// - ORDER BY sortby_list
+
+// sortby_list
+// - sortby ( ',' sortby )*
+// flattened: https://github.com/future-architect/postgresql-cst-parser/pull/13
+
+// sortby
+// - a_expr USING qual_all_Op opt_nulls_order
+// - a_expr opt_asc_desc opt_nulls_order
+
+impl Visitor {
+    pub(crate) fn visit_sort_clause(
+        &mut self,
+        cursor: &mut TreeCursor,
+        src: &str,
+    ) -> Result<Clause, UroboroSQLFmtError> {
+        // sort_clause
+        // - ORDER BY sortby_list
+
+        cursor.goto_first_child();
+        // cursor -> ORDER
+        let mut clause = pg_create_clause(cursor, SyntaxKind::ORDER)?;
+        cursor.goto_next_sibling();
+
+        // curosr -> BY
+        clause.pg_extend_kw(cursor.node());
+        cursor.goto_next_sibling();
+
+        // cursor -> sortby_list
+        let sortby_list = self.visit_sortby_list(cursor, src)?;
+        clause.set_body(Body::SepLines(sortby_list));
+
+        cursor.goto_parent();
+        pg_ensure_kind(cursor, SyntaxKind::sort_clause, src)?;
+
+        Ok(clause)
+    }
+
+    fn visit_sortby_list(
+        &mut self,
+        cursor: &mut TreeCursor,
+        src: &str,
+    ) -> Result<SeparatedLines, UroboroSQLFmtError> {
+        // sortby_list
+        // - sortby ( ',' sortby )*
+
+        cursor.goto_first_child();
+        let mut sep_lines = SeparatedLines::new();
+
+        // cursor -> sortby
+        let first_element = self.visit_sortby(cursor, src)?;
+        sep_lines.add_expr(first_element, None, vec![]);
+
+        let mut is_preceding_comment_area = false;
+        let mut preceding_comments = vec![];
+
+        while cursor.goto_next_sibling() {
+            match cursor.node().kind() {
+                SyntaxKind::sortby => {
+                    sep_lines.add_expr(
+                        self.visit_sortby(cursor, src)?,
+                        Some(COMMA.to_string()),
+                        preceding_comments.clone(),
+                    );
+                    preceding_comments.clear();
+                    is_preceding_comment_area = false;
+                }
+                SyntaxKind::Comma => is_preceding_comment_area = true,
+                SyntaxKind::C_COMMENT | SyntaxKind::SQL_COMMENT => {
+                    let comment = Comment::pg_new(cursor.node());
+                    if is_preceding_comment_area {
+                        preceding_comments.push(comment);
+                    } else {
+                        sep_lines.add_comment_to_child(comment)?;
+                    }
+                }
+                _ => {
+                    return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
+                        "visit_sortby_list(): unexpected node\nnode kind: {}\n{}",
+                        cursor.node().kind(),
+                        pg_error_annotation_from_cursor(cursor, src)
+                    )))
+                }
+            }
+        }
+
+        cursor.goto_parent();
+        pg_ensure_kind(cursor, SyntaxKind::sortby_list, src)?;
+
+        Ok(sep_lines)
+    }
+
+    /// ORDER BY句の本体に現れる式を AlignedExpr で返す
+    /// AlignedExpr の左辺にカラム名(式)、右辺にオプション (ASC, DESC, NULLS FIRST...)を持ち、演算子は常に空にする
+    fn visit_sortby(
+        &mut self,
+        cursor: &mut TreeCursor,
+        src: &str,
+    ) -> Result<AlignedExpr, UroboroSQLFmtError> {
+        // sortby
+        // - a_expr opt_asc_desc? opt_nulls_order?
+        // - a_expr USING qual_all_Op opt_nulls_order?
+
+        cursor.goto_first_child();
+
+        let expr = self.visit_a_expr_or_b_expr(cursor, src)?;
+        let mut aligned_expr = AlignedExpr::new(expr);
+
+        cursor.goto_next_sibling();
+
+        // 式以降のオプション部分の要素を順番に収集する
+        let mut order_option = vec![];
+        let mut order_option_loc = vec![];
+
+        // cursor -> (opt_asc_desc | USING)?
+        if cursor.node().kind() == SyntaxKind::opt_asc_desc {
+            // opt_asc_desc
+            // - ASC | DESC
+
+            let asc_or_desc = cursor.node().text();
+            order_option.push(asc_or_desc);
+            order_option_loc.push(Location::from(cursor.node().range()));
+
+            cursor.goto_next_sibling();
+        } else if cursor.node().kind() == SyntaxKind::USING {
+            // USING qual_all_Op
+
+            // USING
+            let using = cursor.node().text();
+            order_option.push(using);
+            order_option_loc.push(Location::from(cursor.node().range()));
+
+            cursor.goto_next_sibling();
+
+            // cursor -> qual_all_Op
+            let op = cursor.node().text();
+            order_option.push(op);
+            order_option_loc.push(Location::from(cursor.node().range()));
+
+            cursor.goto_next_sibling();
+        }
+
+        // cursor -> opt_nulls_order?
+        if cursor.node().kind() == SyntaxKind::opt_nulls_order {
+            // opt_nulls_order
+            // - NULLS_LA (FIRST_P | LAST_P)
+
+            cursor.goto_first_child();
+
+            // cursor -> NULLS_LA
+            let nulls = cursor.node().text();
+            order_option.push(nulls);
+            order_option_loc.push(Location::from(cursor.node().range()));
+
+            cursor.goto_next_sibling();
+
+            // cursor -> FIRST_P | LAST_P
+            let first_or_last = cursor.node().text();
+            order_option.push(first_or_last);
+            order_option_loc.push(Location::from(cursor.node().range()));
+
+            cursor.goto_parent();
+            pg_ensure_kind(cursor, SyntaxKind::opt_nulls_order, src)?;
+        }
+
+        // 要素をスペース区切りで PrimaryExpr に変換し、 AlignedExpr の右辺に追加
+        if !order_option.is_empty() {
+            let mut loc = order_option_loc[0].clone();
+            order_option_loc.into_iter().for_each(|l| loc.append(l));
+
+            let order = PrimaryExpr::new(convert_keyword_case(&order_option.join(" ")), loc);
+            aligned_expr.add_rhs(None, Expr::Primary(Box::new(order)));
+        }
+
+        cursor.goto_parent();
+        pg_ensure_kind(cursor, SyntaxKind::sortby, src)?;
+
+        Ok(aligned_expr)
+    }
+}

--- a/crates/uroborosql-fmt/src/new_visitor/statement/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/statement/select.rs
@@ -158,6 +158,10 @@ impl Visitor {
                         pg_error_annotation_from_cursor(cursor, src)
                     )));
                 }
+                SyntaxKind::sort_clause => {
+                    let sort_clause = self.visit_sort_clause(cursor, src)?;
+                    statement.add_clause(sort_clause);
+                }
                 SyntaxKind::RParen => {
                     // select_with_parens をフォーマットする場合
                     break;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/049_order_by.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/049_order_by.sql
@@ -1,0 +1,44 @@
+select
+	a	as	a
+from
+	t
+order by
+	a
+,	b
+;
+select
+	*
+from
+	t
+order by
+	c	using <
+;
+select
+	col	as	col
+from
+	tab
+order by
+	col			asc					-- 昇順
+,	long_col	desc nulls first	-- 降順
+,	null_col	nulls first			-- NULL先
+;
+select
+	*
+from
+	foo	t
+order by
+	t.bar1
+,	/* after comma */
+	t.bar2
+,	t.bar3
+;
+select
+	*
+from
+	foo	t
+order by
+	t.bar1
+/* before comma */
+,	t.bar2
+,	t.bar3
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/049_order_by.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/049_order_by.sql
@@ -1,0 +1,35 @@
+select a from t order by a, b;
+
+SELECT * FROM t ORDER BY c USING <;
+
+SELECT
+    col
+FROM
+    tab
+ORDER BY
+    col ASC -- 昇順
+    , long_col DESC NULLS FIRST -- 降順
+    , null_col NULLS FIRST -- NULL先
+;
+
+SELECT
+    *
+FROM
+    foo t
+ORDER BY
+    t.bar1
+    ,   /* after comma */
+    t.bar2
+    ,   t.bar3
+;
+
+SELECT
+    *
+FROM
+    foo t
+ORDER BY
+    t.bar1
+    /* before comma */
+    ,   t.bar2
+    ,   t.bar3
+;


### PR DESCRIPTION
## Summary
`sort_clause` の処理を実装し、 order by を含むSQLがフォーマットできるようになりました。

```sql
select
	col	as	col
from
	tab
order by
	col			asc					-- 昇順
,	long_col	desc nulls first	-- 降順
,	null_col	nulls first			-- NULL先
;
```