### PR TITLE
clippy を適用

### DIFF
--- a/crates/uroborosql-fmt/src/two_way_sql/tree.rs
+++ b/crates/uroborosql-fmt/src/two_way_sql/tree.rs
@@ -126,8 +126,8 @@ impl TreeNode {
 ///     1. 子供がENDのみの場合 -> 分岐の末尾まで進んだことを意味するので、結果とENDのidを返して終了
 ///     2. 子供がPLAINのみの場合 -> 通常のテキストなので、子供を現在のノードとして、1に戻る
 ///     3. 子供がIF/ELSE分岐の場合
-///         -> 各子供に対して traverse() を再帰的に呼び出し、ENDの手前まで走査を進める。
-///         結果に子供の結果を結合し、ENDノードを現在のノードとして、1に戻る
+///        -> 各子供に対して traverse() を再帰的に呼び出し、ENDの手前まで走査を進める。
+///        結果に子供の結果を結合し、ENDノードを現在のノードとして、1に戻る
 /// 3. 子供がいなくなったら、結果を返して終了   
 fn traverse(dag: &Dag, node_id: usize) -> Result<(TreeNode, usize), UroboroSQLFmtError> {
     let mut current_node = dag.get(&node_id)?;

--- a/crates/uroborosql-fmt/src/visitor.rs
+++ b/crates/uroborosql-fmt/src/visitor.rs
@@ -318,7 +318,7 @@ fn create_alias(lhs: &Expr) -> Option<Expr> {
             let element = prim.element();
             element
                 .split('.')
-                .last()
+                .next_back()
                 .map(|s| Expr::Primary(Box::new(PrimaryExpr::new(convert_identifier_case(s), loc))))
         }
         _ => None,


### PR DESCRIPTION
## Summary 
Clippy の新ルール追加により CI が落ちていたので直しました

2025-04-03 の Clippy リリースで追加されたルールでした
- [`doc_overindented_list_items`](https://github.com/rust-lang/rust-clippy/blob/cf9cffa114ce5a780aa8283096bf85c51be7a4f5/CHANGELOG.md?plain=1#L20)
  - doc: https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items
- [`double_ended_iterator_last`](https://github.com/rust-lang/rust-clippy/blob/cf9cffa114ce5a780aa8283096bf85c51be7a4f5/CHANGELOG.md?plain=1#L25)
  - doc: https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last