### PR TITLE
CASE 式のコメント対応を修正

### DIFF
--- a/crates/uroborosql-fmt/test_normal_cases/dst/060_case_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/060_case_comment.sql
@@ -1,0 +1,24 @@
+select
+	a	as	a
+,	case
+		-- case trailing
+		/* case */
+		when
+		-- cond_1
+			a	=	1	-- a equals 1
+		then
+		-- cond_1 == true
+			'one'	-- one
+		when
+		-- cond_2
+			a	=	2	-- a equals 2
+		then
+		-- cond_2 == true
+			'two'	-- two
+		else
+		-- forall i: cond_i == false
+			'other'	-- other
+	end
+from
+	test	-- test table 
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/060_case_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/060_case_comment.sql
@@ -1,0 +1,16 @@
+SELECT a,
+        CASE -- case trailing
+        /* case */
+        WHEN -- cond_1
+        a=1 -- a equals 1
+        THEN -- cond_1 == true
+        'one' -- one
+        WHEN -- cond_2
+        a=2 -- a equals 2
+        THEN -- cond_2 == true
+        'two' -- two
+        ELSE -- forall i: cond_i == false
+        'other' -- other
+       END
+    FROM test -- test table 
+;


### PR DESCRIPTION
CASE 式でエラーがあったコメントに対応しました

1. `CASE` キーワード後の複数コメント
2. `THEN a_expr` の後の行末コメント


```sql
select
	a	as	a
,	case
		-- comment pattern 1
		/* comment pattern 1 */
		when
		-- cond_1
			a	=	1
		then
			'one'	-- comment pattern 2
		when
			a	=	2
		then
			'two'	-- comment pattern 2
		else
			'other'
	end
from
	test
;
```