### PR TITLE
Pgcst  insert select

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "postgresql-cst-parser"
 version = "0.1.0"
-source = "git+https://github.com/future-architect/postgresql-cst-parser#92b440cc49b3b4a369b647c17bd53be72023f9a7"
+source = "git+https://github.com/future-architect/postgresql-cst-parser?branch=tree-sitter--preserve-select-no-parens#294cc54240852b512accbdd6a7f5132211ac9878"
 dependencies = [
  "cstree",
  "miniz_oxide",

--- a/crates/uroborosql-fmt/Cargo.toml
+++ b/crates/uroborosql-fmt/Cargo.toml
@@ -23,7 +23,7 @@ tree-sitter = "~0.20.3"
 
 # git config --global core.longpaths true を管理者権限で実行しないといけない
 tree-sitter-sql = { git = "https://github.com/future-architect/tree-sitter-sql" }
-postgresql-cst-parser = { git = "https://github.com/future-architect/postgresql-cst-parser" }
+postgresql-cst-parser = { git = "https://github.com/future-architect/postgresql-cst-parser", branch = "tree-sitter--preserve-select-no-parens"}
 
 [dev-dependencies]
 console = "0.15.10"

--- a/crates/uroborosql-fmt/src/cst/expr.rs
+++ b/crates/uroborosql-fmt/src/cst/expr.rs
@@ -165,7 +165,7 @@ impl Expr {
             Expr::Boolean(boolean) => {
                 boolean.add_comment_to_child(comment)?;
             }
-            Expr::Sub(sub) => sub.add_comment_to_child(comment),
+            Expr::Sub(sub) => sub.add_comment_to_child(comment)?,
             Expr::ParenExpr(paren_expr) => {
                 paren_expr.add_comment_to_child(comment)?;
             }

--- a/crates/uroborosql-fmt/src/cst/expr/subquery.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/subquery.rs
@@ -19,8 +19,18 @@ impl SubExpr {
         self.loc.clone()
     }
 
-    pub(crate) fn add_comment_to_child(&mut self, _comment: Comment) {
-        unimplemented!()
+    pub(crate) fn add_comment_to_child(
+        &mut self,
+        comment: Comment,
+    ) -> Result<(), UroboroSQLFmtError> {
+        self.stmt.add_comment_to_child(comment)
+    }
+
+    /// 開き括弧と文の間にあるコメントを追加する
+    pub(crate) fn add_start_comment(&mut self, comment: Comment) -> Result<(), UroboroSQLFmtError> {
+        self.stmt.add_comment(comment);
+
+        Ok(())
     }
 
     pub(crate) fn render(&self, depth: usize) -> Result<String, UroboroSQLFmtError> {

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/select_with_parens.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/select_with_parens.rs
@@ -1,4 +1,4 @@
-use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
+use postgresql_cst_parser::syntax_kind::SyntaxKind;
 
 use crate::{
     cst::{Comment, Expr, Location, ParenExpr, SubExpr},
@@ -10,26 +10,21 @@ use crate::{
 use super::Visitor;
 
 impl Visitor {
-    /// かっこで囲まれたSELECT文をフォーマットする
-    /// 呼び出し後、cursor は select_subexpression を指している
-    pub fn visit_select_with_parens(
+    pub(crate) fn visit_select_with_parens(
         &mut self,
-        cursor: &mut TreeCursor,
+        cursor: &mut postgresql_cst_parser::tree_sitter::TreeCursor,
         src: &str,
     ) -> Result<Expr, UroboroSQLFmtError> {
         // select_with_parens
-        // - '(' select_no_parens ')'
-        // - '(' select_with_parens ')'
-        //
-        // select_no_parens というノードは実際には存在しない（cst-parser で消去される）
-        // そのため、かっこの中に通常の select 文の要素が並ぶと考えればよい
+        //  ├ '(' select_no_parens ')'
+        //  └ '(' select_with_parens ')'
 
+        // 全体の位置情報を保持
         let loc = Location::from(cursor.node().range());
-
-        // cursor -> select_with_parens
 
         cursor.goto_first_child();
         // cursor -> '('
+        pg_ensure_kind!(cursor, SyntaxKind::LParen, src);
 
         cursor.goto_next_sibling();
 
@@ -41,32 +36,35 @@ impl Visitor {
             cursor.goto_next_sibling();
         }
 
-        // cursor -> SELECT keyword | select_with_parens
-        let expr = match cursor.node().kind() {
-            SyntaxKind::SELECT => {
-                // SelectStmt の子要素にあたるノード群が並ぶ
-                // 呼出し後、cursor は ')' を指す
-                let mut select_stmt = self.visit_select_stmt_inner(cursor, src)?;
-                pg_ensure_kind!(cursor, SyntaxKind::RParen, src);
+        // cursor -> select_no_parens | select_with_parens
+        pg_ensure_kind!(
+            cursor,
+            SyntaxKind::select_no_parens | SyntaxKind::select_with_parens,
+            src
+        );
+        let mut expr = match cursor.node().kind() {
+            SyntaxKind::select_no_parens => {
+                let statement = self.visit_select_no_parens(cursor, src)?;
+                let mut sub_expr = SubExpr::new(statement, loc);
 
-                // select 文の前にコメントがあった場合、コメントを追加
-                comment_buf
-                    .into_iter()
-                    .for_each(|c| select_stmt.add_comment(c));
+                // 開きかっことSELECT文の間にあるコメントを追加
+                for comment in comment_buf {
+                    sub_expr.add_start_comment(comment)?;
+                }
 
-                // 閉じかっこの前にあるコメントは visit_select_stmt_inner で処理済み
-                let sub_expr = SubExpr::new(select_stmt, loc);
+                cursor.goto_next_sibling();
 
                 Expr::Sub(Box::new(sub_expr))
             }
-            // ネストした select_with_parens は ParenExpr で表現する
             SyntaxKind::select_with_parens => {
+                // ネストした select_with_parens は ParenExpr で表現する
                 let select_with_parens = self.visit_select_with_parens(cursor, src)?;
+
+                // remove_redundant_nest オプションが有効のとき、 ParenExpr をネストさせない
                 let mut paren_expr = match select_with_parens {
                     Expr::ParenExpr(mut paren_expr)
                         if CONFIG.read().unwrap().remove_redundant_nest =>
                     {
-                        // remove_redundant_nest オプションが有効のとき、 ParenExpr をネストさせない
                         paren_expr.set_loc(loc);
                         *paren_expr
                     }
@@ -80,22 +78,23 @@ impl Visitor {
 
                 cursor.goto_next_sibling();
 
-                // cursor -> comments?
-                // 閉じかっこの前にあるコメントを追加
-                while cursor.node().is_comment() {
-                    paren_expr.add_comment_to_child(Comment::pg_new(cursor.node()))?;
-                    cursor.goto_next_sibling();
-                }
-
                 Expr::ParenExpr(Box::new(paren_expr))
             }
             _ => {
                 return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
-                    "visit_select_with_parens(): unexpected syntax kind\n{}",
+                    "visit_select_with_parens(): {} node appeared. This node is not considered yet.\n{}",
+                    cursor.node().kind(),
                     pg_error_annotation_from_cursor(cursor, src)
-                )))
+                )));
             }
         };
+
+        // 閉じ括弧の前にあるコメントを追加
+        while cursor.node().is_comment() {
+            let comment = Comment::pg_new(cursor.node());
+            expr.add_comment_to_child(comment)?;
+            cursor.goto_next_sibling();
+        }
 
         // cursor -> ')'
         pg_ensure_kind!(cursor, SyntaxKind::RParen, src);

--- a/crates/uroborosql-fmt/src/new_visitor/statement.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/statement.rs
@@ -12,6 +12,8 @@ use crate::{
     NewVisitor as Visitor, CONFIG,
 };
 
+pub use select::SelectStmtOutput;
+
 impl Visitor {
     pub(crate) fn visit_relation_expr_opt_alias(
         &mut self,

--- a/crates/uroborosql-fmt/src/new_visitor/statement/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/statement/select.rs
@@ -129,7 +129,7 @@ impl Visitor {
 
         // cursor -> select_with_parens
         if cursor.node().kind() == SyntaxKind::select_with_parens {
-            return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
+            return Err(UroboroSQLFmtError::Unimplemented(format!(
                 "visit_select_no_parens(): select_with_parens node appeared. This node is not considered yet.\n{}",
                 pg_error_annotation_from_cursor(cursor, src)
             )));


### PR DESCRIPTION
- [ ] update postgresql-cst-parser

## Summary
`select_no_parens` がある場合のCSTに対応しました

## 基本方針
`visit_select_stmt` が Statement または Expr を表すEnumを返すよう変更を加えています。`visit_select_stmt` の呼び出し側で cst モジュールの構造体へ詰め替える処理を入れることで、フォーマット処理との互換性を保つ方針をとっています。