### PR TITLE
Correct case conversion for SET clause targets

### DIFF
--- a/crates/uroborosql-fmt/src/new_visitor/clause/set.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/set.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     error::UroboroSQLFmtError,
     new_visitor::{pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor, COMMA},
-    util::convert_keyword_case,
+    util::convert_identifier_case,
     NewVisitor as Visitor,
 };
 
@@ -153,7 +153,7 @@ impl Visitor {
             .filter(|c| !c.is_whitespace())
             .collect::<String>();
 
-        let expr = PrimaryExpr::new(convert_keyword_case(&whitespace_removed_text), location);
+        let expr = PrimaryExpr::new(convert_identifier_case(&whitespace_removed_text), location);
 
         Ok(Expr::Primary(Box::new(expr)))
     }


### PR DESCRIPTION
## Summary

set target の大文字小文字変換を identifier として扱うべきところを keyword として扱っていたため、それを修正しました

（下例の `(TEMP_LO, TEMP_HI, PRCP)` の部分）
```diff
  set
-  	(TEMP_LO, TEMP_HI, PRCP)	=	(temp_lo	+	1, temp_lo	+	15, DEFAULT)
+ 	(temp_lo, temp_hi, prcp)	=	(temp_lo	+	1, temp_lo	+	15, DEFAULT)

```