### PR TITLE
AS 直前のコメントに対応

### DIFF
--- a/crates/uroborosql-fmt/test_normal_cases/dst/076_lhs_trailing_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/076_lhs_trailing_comment.sql
@@ -1,0 +1,7 @@
+select
+	t.id	-- コメント1
+				as	id				-- コメント2
+,	t.column	as	column_alias	-- コメント3
+from
+	tbl	t
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/076_lhs_trailing_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/076_lhs_trailing_comment.sql
@@ -1,0 +1,7 @@
+SELECT
+	t.id -- コメント1
+		as	id  -- コメント2
+,	t.column as column_alias  -- コメント3
+FROM
+	tbl t
+;


### PR DESCRIPTION
## Summary

エイリアスの AS キーワード直前のコメントに対応しました

```sql
select
	t.id	-- コメント1
				as	id
;
```
