### PR TITLE
パーサ側で回復できる 2way SQL に対応

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "postgresql-cst-parser"
 version = "0.1.0"
-source = "git+https://github.com/future-architect/postgresql-cst-parser?branch=tree-sitter%2F2way#65c79e13f1e945f94590619990acc8a3deff8d98"
+source = "git+https://github.com/future-architect/postgresql-cst-parser?branch=tree-sitter%2F2way#83679ff24ff2c2eb4bfebfe38531832c1b5f6063"
 dependencies = [
  "cstree",
  "miniz_oxide",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "postgresql-cst-parser"
 version = "0.1.0"
-source = "git+https://github.com/future-architect/postgresql-cst-parser#6622c98c6732d4b687ba84d8a952a044a2532698"
+source = "git+https://github.com/future-architect/postgresql-cst-parser?branch=tree-sitter%2F2way#65c79e13f1e945f94590619990acc8a3deff8d98"
 dependencies = [
  "cstree",
  "miniz_oxide",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "postgresql-cst-parser"
 version = "0.1.0"
-source = "git+https://github.com/future-architect/postgresql-cst-parser?branch=tree-sitter%2F2way#83679ff24ff2c2eb4bfebfe38531832c1b5f6063"
+source = "git+https://github.com/future-architect/postgresql-cst-parser#f728f573e1f0b8a2db77c4ec0b017fa8dad138f3"
 dependencies = [
  "cstree",
  "miniz_oxide",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "postgresql-cst-parser"
 version = "0.1.0"
-source = "git+https://github.com/future-architect/postgresql-cst-parser#f728f573e1f0b8a2db77c4ec0b017fa8dad138f3"
+source = "git+https://github.com/future-architect/postgresql-cst-parser#bfd2ff29a69cac736ec917e49bbec5768182173e"
 dependencies = [
  "cstree",
  "miniz_oxide",

--- a/crates/uroborosql-fmt/Cargo.toml
+++ b/crates/uroborosql-fmt/Cargo.toml
@@ -23,7 +23,7 @@ tree-sitter = "~0.20.3"
 
 # git config --global core.longpaths true を管理者権限で実行しないといけない
 tree-sitter-sql = { git = "https://github.com/future-architect/tree-sitter-sql" }
-postgresql-cst-parser = { git = "https://github.com/future-architect/postgresql-cst-parser", branch = "tree-sitter/2way" }
+postgresql-cst-parser = { git = "https://github.com/future-architect/postgresql-cst-parser" }
 
 [dev-dependencies]
 console = "0.15.10"

--- a/crates/uroborosql-fmt/Cargo.toml
+++ b/crates/uroborosql-fmt/Cargo.toml
@@ -23,7 +23,7 @@ tree-sitter = "~0.20.3"
 
 # git config --global core.longpaths true を管理者権限で実行しないといけない
 tree-sitter-sql = { git = "https://github.com/future-architect/tree-sitter-sql" }
-postgresql-cst-parser = { git = "https://github.com/future-architect/postgresql-cst-parser" }
+postgresql-cst-parser = { git = "https://github.com/future-architect/postgresql-cst-parser", branch = "tree-sitter/2way" }
 
 [dev-dependencies]
 console = "0.15.10"

--- a/crates/uroborosql-fmt/src/config.rs
+++ b/crates/uroborosql-fmt/src/config.rs
@@ -79,6 +79,10 @@ fn default_use_pg_parser() -> bool {
     false
 }
 
+fn default_use_parser_error_recovery() -> bool {
+    true
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum Case {
@@ -162,6 +166,10 @@ pub struct Config {
     /// パーサにpostgresql-cst-parserを使用する
     #[serde(default = "default_use_pg_parser")]
     pub(crate) use_pg_parser: bool,
+
+    /// パーサのエラー回復機能を使うかどうか
+    #[serde(default = "default_use_parser_error_recovery")]
+    pub(crate) use_parser_error_recovery: bool,
 }
 
 impl Config {
@@ -226,6 +234,7 @@ impl Default for Config {
             unify_not_equal: default_unify_not_equal(),
             indent_tab: default_indent_tab(),
             use_pg_parser: default_use_pg_parser(),
+            use_parser_error_recovery: default_use_parser_error_recovery(),
         }
     }
 }
@@ -254,6 +263,7 @@ pub(crate) fn load_never_complement_settings() {
         unify_not_equal: false,
         indent_tab: true,
         use_pg_parser: default_use_pg_parser(),
+        use_parser_error_recovery: default_use_parser_error_recovery(),
     };
 
     *CONFIG.write().unwrap() = config;

--- a/crates/uroborosql-fmt/src/cst/body/separeted_lines.rs
+++ b/crates/uroborosql-fmt/src/cst/body/separeted_lines.rs
@@ -292,6 +292,13 @@ impl SeparatedLines {
         false
     }
 
+    /// 最初の要素にセパレータを追加する
+    pub(crate) fn set_first_separator(&mut self, sep: String) {
+        if let Some(first_content) = self.contents.first_mut() {
+            first_content.sep = Some(sep);
+        }
+    }
+
     /// separatorで揃えたものを返す
     pub(crate) fn render(&self, depth: usize) -> Result<String, UroboroSQLFmtError> {
         let mut result = String::new();

--- a/crates/uroborosql-fmt/src/error.rs
+++ b/crates/uroborosql-fmt/src/error.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum UroboroSQLFmtError {
+    #[error("Parse error: {0}")]
+    ParseError(String),
     #[error("Illegal operation error: {0}")]
     IllegalOperation(String),
     #[error("Unexpected syntax error: {0}")]

--- a/crates/uroborosql-fmt/src/lib.rs
+++ b/crates/uroborosql-fmt/src/lib.rs
@@ -13,7 +13,7 @@ mod pg_validate;
 use config::*;
 use error::UroboroSQLFmtError;
 use new_visitor::Visitor as NewVisitor;
-use postgresql_cst_parser::ts_parse as pg_parse;
+use postgresql_cst_parser::tree_sitter::parse_2way as pg_parse_2way;
 use visitor::Visitor;
 
 use tree_sitter::{Language, Node, Tree};
@@ -42,7 +42,8 @@ pub(crate) fn format_sql_with_config(
 ) -> Result<String, UroboroSQLFmtError> {
     if config.use_pg_parser {
         // postgresql-cst-parser を使用してパースする
-        let tree = pg_parse(src).expect("pg: Parse error");
+        let tree =
+            pg_parse_2way(src).map_err(|e| UroboroSQLFmtError::ParseError(format!("{:?}", e)))?;
 
         pg_validate_format_result(src)?;
 

--- a/crates/uroborosql-fmt/src/new_visitor/clause.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause.rs
@@ -81,10 +81,13 @@ impl Visitor {
         Ok(primary)
     }
 
+    /// target_list をフォーマットする
+    /// 直前にカンマがある場合は extra_leading_comma として渡す
     pub(crate) fn visit_target_list(
         &mut self,
         cursor: &mut postgresql_cst_parser::tree_sitter::TreeCursor,
         src: &str,
+        extra_leading_comma: Option<String>,
     ) -> Result<Body, UroboroSQLFmtError> {
         // target_list -> target_el ("," target_el)*
 
@@ -95,7 +98,7 @@ impl Visitor {
         let mut sep_lines = SeparatedLines::new();
 
         let target_el = self.visit_target_el(cursor, src)?;
-        sep_lines.add_expr(target_el, None, vec![]);
+        sep_lines.add_expr(target_el, extra_leading_comma, vec![]);
 
         while cursor.goto_next_sibling() {
             // cursor -> "," または target_el

--- a/crates/uroborosql-fmt/src/new_visitor/clause/from.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/from.rs
@@ -38,6 +38,8 @@ impl Visitor {
             None
         };
 
+        self.pg_consume_comments_in_clause(cursor, &mut clause)?;
+
         // cursor -> from_list
         pg_ensure_kind!(cursor, SyntaxKind::from_list, src);
 

--- a/crates/uroborosql-fmt/src/new_visitor/clause/returning.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/returning.rs
@@ -41,7 +41,7 @@ impl Visitor {
 
         // cursor -> target_list
         pg_ensure_kind!(cursor, SyntaxKind::target_list, src);
-        let body = self.visit_target_list(cursor, src)?;
+        let body = self.visit_target_list(cursor, src, None)?;
         clause.set_body(body);
 
         cursor.goto_parent();

--- a/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
@@ -3,7 +3,7 @@ use postgresql_cst_parser::syntax_kind::SyntaxKind;
 use crate::{
     cst::{select::SelectBody, *},
     error::UroboroSQLFmtError,
-    new_visitor::{pg_create_clause, pg_ensure_kind, Visitor},
+    new_visitor::{pg_create_clause, pg_ensure_kind, Visitor, COMMA},
 };
 
 impl Visitor {
@@ -96,9 +96,17 @@ impl Visitor {
             _ => {}
         }
 
+        let extra_leading_comma = if cursor.node().kind() == SyntaxKind::Comma {
+            cursor.goto_next_sibling();
+
+            Some(COMMA.to_string())
+        } else {
+            None
+        };
+
         // cursor -> target_list?
         if cursor.node().kind() == SyntaxKind::target_list {
-            let target_list = self.visit_target_list(cursor, src)?;
+            let target_list = self.visit_target_list(cursor, src, extra_leading_comma)?;
             // select_clause_body 部分に target_list から生成した Body をセット
             select_body.set_select_clause_body(target_list);
 

--- a/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
@@ -104,6 +104,8 @@ impl Visitor {
             None
         };
 
+        self.pg_consume_comments_in_clause(cursor, &mut clause)?;
+
         // cursor -> target_list?
         if cursor.node().kind() == SyntaxKind::target_list {
             let target_list = self.visit_target_list(cursor, src, extra_leading_comma)?;

--- a/crates/uroborosql-fmt/src/new_visitor/statement/delete.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/statement/delete.rs
@@ -113,7 +113,7 @@ impl Visitor {
 
         self.pg_consume_comments_in_clause(cursor, &mut clause)?;
 
-        let body = self.visit_from_list(cursor, src)?;
+        let body = self.visit_from_list(cursor, src, None)?;
         clause.set_body(body);
 
         cursor.goto_parent();

--- a/crates/uroborosql-fmt/src/pg_validate.rs
+++ b/crates/uroborosql-fmt/src/pg_validate.rs
@@ -1,8 +1,8 @@
 use itertools::Itertools;
 use postgresql_cst_parser::{
     syntax_kind::SyntaxKind,
+    tree_sitter::parse_2way,
     tree_sitter::{Node, Tree},
-    ts_parse,
 };
 
 use crate::{
@@ -15,7 +15,7 @@ use crate::{
 
 /// フォーマット前後でSQLに欠落が生じないかを検証する。
 pub(crate) fn validate_format_result(src: &str) -> Result<(), UroboroSQLFmtError> {
-    let src_ts_tree = ts_parse(src).unwrap();
+    let src_ts_tree = parse_2way(src).unwrap();
 
     let dbg = CONFIG.read().unwrap().debug;
 
@@ -23,7 +23,7 @@ pub(crate) fn validate_format_result(src: &str) -> Result<(), UroboroSQLFmtError
     load_never_complement_settings();
 
     let format_result = pg_format_tree(&src_ts_tree, src)?;
-    let dst_ts_tree = ts_parse(&format_result).unwrap();
+    let dst_ts_tree = parse_2way(&format_result).unwrap();
 
     let validate_result = compare_tree(&src_ts_tree, &dst_ts_tree, src, &format_result);
 
@@ -217,7 +217,7 @@ fn swap_comma_and_trailing_comment(tokens: &mut [Token]) {
 #[cfg(test)]
 mod tests {
     use super::compare_tree;
-    use postgresql_cst_parser::{syntax_kind::SyntaxKind, ts_parse};
+    use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::parse_2way as ts_parse};
 
     use crate::{
         cst::{Location, Position},

--- a/crates/uroborosql-fmt/test_normal_cases/dst/077_2way_select_without_sample_value.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/077_2way_select_without_sample_value.sql
@@ -1,0 +1,6 @@
+select
+	/*foo*/
+,	/*bar*/
+from
+	t
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/078_2way_from_without_sample_value.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/078_2way_from_without_sample_value.sql
@@ -1,0 +1,6 @@
+select
+	*
+from
+	/*#table_1*/
+,	/*#table_2*/
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/079_table_ref_bind_param.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/079_table_ref_bind_param.sql
@@ -1,0 +1,5 @@
+select
+	*
+from
+	/*$table_name*/t
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/080_2way_extra_leading_comma_select.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/080_2way_extra_leading_comma_select.sql
@@ -4,3 +4,28 @@ select
 from
 	t
 ;
+select
+	all
+,	c1	as	c1
+,	c2	as	c2
+from
+	t
+;
+select
+	distinct
+,	c1	as	c1
+,	c2	as	c2
+from
+	t
+;
+select
+	distinct on
+		(
+			c1
+		,	c2
+		)
+,	c1	as	c1
+,	c2	as	c2
+from
+	t
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/080_2way_extra_leading_comma_select.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/080_2way_extra_leading_comma_select.sql
@@ -1,0 +1,6 @@
+select
+,	c1	as	c1
+,	c2	as	c2
+from
+	t
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/081_2way_extra_leading_comma_from.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/081_2way_extra_leading_comma_from.sql
@@ -1,0 +1,6 @@
+select
+	*
+from
+,	t1
+,	t2
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/082_2way_extra_leading_comma_order_by.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/082_2way_extra_leading_comma_order_by.sql
@@ -1,0 +1,8 @@
+select
+	*
+from
+	foo	t
+order by
+,	t.bar1
+,	t.bar2
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/083_2way_extra_leading_and_or.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/083_2way_extra_leading_and_or.sql
@@ -1,0 +1,16 @@
+select
+	*
+from
+	foo	t
+where
+and	t.bar1	=	1
+and	t.bar2	=	2
+;
+select
+	*
+from
+	foo	t
+where
+or	t.bar1	=	1
+and	t.bar2	=	2
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/084_2way_all.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/084_2way_all.sql
@@ -1,0 +1,13 @@
+select
+,	/*foo*/
+,	/*bar*/
+from
+,	/*#baz*/
+,	/*#qux*/
+where
+and	1	=	1
+and	2	=	2
+order by
+,	1
+,	2
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/077_2way_select_without_sample_value.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/077_2way_select_without_sample_value.sql
@@ -1,0 +1,5 @@
+select
+    /*foo*/
+,   /*bar*/
+from t
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/078_2way_from_without_sample_value.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/078_2way_from_without_sample_value.sql
@@ -1,0 +1,6 @@
+select
+	*
+from
+	/*#table_1*/
+,	/*#table_2*/
+; 

--- a/crates/uroborosql-fmt/test_normal_cases/src/079_table_ref_bind_param.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/079_table_ref_bind_param.sql
@@ -1,0 +1,1 @@
+select * from /*$table_name*/t; 

--- a/crates/uroborosql-fmt/test_normal_cases/src/080_2way_extra_leading_comma_select.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/080_2way_extra_leading_comma_select.sql
@@ -3,3 +3,25 @@ select
 ,	c2
 from t
 ;
+select all
+,	c1	as	c1
+,	c2	as	c2
+from
+	t
+;
+select distinct
+,	c1	as	c1
+,	c2	as	c2
+from
+	t
+;
+select distinct on
+	(
+		c1
+	,	c2
+	)
+,	c1	as	c1
+,	c2	as	c2
+from
+	t
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/080_2way_extra_leading_comma_select.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/080_2way_extra_leading_comma_select.sql
@@ -1,0 +1,5 @@
+select
+,	c1
+,	c2
+from t
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/081_2way_extra_leading_comma_from.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/081_2way_extra_leading_comma_from.sql
@@ -1,0 +1,6 @@
+select
+	*
+from
+,	t1
+,	t2
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/082_2way_extra_leading_comma_order_by.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/082_2way_extra_leading_comma_order_by.sql
@@ -1,0 +1,8 @@
+select
+	*
+from
+	foo	t
+order by
+,	t.bar1
+,	t.bar2
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/083_2way_extra_leading_and_or.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/083_2way_extra_leading_and_or.sql
@@ -1,0 +1,16 @@
+select
+	*
+from
+	foo	t
+where
+and	t.bar1 = 1
+and	t.bar2 = 2
+;
+select
+	*
+from
+	foo	t
+where
+or	t.bar1 = 1
+and	t.bar2 = 2
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/084_2way_all.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/084_2way_all.sql
@@ -1,0 +1,13 @@
+select
+,	/*foo*/
+,	/*bar*/
+from
+,	/*#baz*/
+,	/*#qux*/
+where
+and	1 = 1
+and	2 = 2
+order by
+,	1
+,	2
+;

--- a/crates/uroborosql-fmt/tests/pgcst_coverage.rs
+++ b/crates/uroborosql-fmt/tests/pgcst_coverage.rs
@@ -208,6 +208,7 @@ fn print_coverage_report(results: &[TestResult], config: &TestReportConfig) {
         println!("\nFailed Cases (by error type):");
 
         // エラーの種類でグループ化して出力
+        let mut parse_errors = Vec::new();
         let mut syntax_errors = Vec::new();
         let mut validation_errors = Vec::new();
         let mut unimplemented_errors = Vec::new();
@@ -223,7 +224,9 @@ fn print_coverage_report(results: &[TestResult], config: &TestReportConfig) {
                     (error_msg.clone(), None)
                 };
 
-                if error_msg.contains("Syntax error:") {
+                if error_msg.contains("Parse error:") {
+                    parse_errors.push((result.file_path.clone(), message, _annotation));
+                } else if error_msg.contains("Syntax error:") {
                     syntax_errors.push((result.file_path.clone(), message, _annotation));
                 } else if error_msg.contains("Validation error:") {
                     validation_errors.push((result.file_path.clone(), message, _annotation));

--- a/crates/uroborosql-fmt/tests/pgcst_coverage.rs
+++ b/crates/uroborosql-fmt/tests/pgcst_coverage.rs
@@ -93,6 +93,7 @@ fn try_format_with_new_parser(file_path: &str) -> Result<String, String> {
         Err(e) => {
             // エラーの種類に応じてメッセージを詳細化
             let error_detail = match e {
+                UroboroSQLFmtError::ParseError(msg) => format!("Parse error: {}", msg),
                 UroboroSQLFmtError::IllegalOperation(msg) => format!("Illegal operation: {}", msg),
                 UroboroSQLFmtError::UnexpectedSyntax(msg) => format!("Syntax error: {}", msg),
                 UroboroSQLFmtError::Unimplemented(msg) => format!("Unimplemented: {}", msg),


### PR DESCRIPTION
## Summary
SQL としては不正な2waySQLのうち、パーサ側で回復できるSQLに対応しました
併せて、これまで未対応であった「テーブル名に対する置換文字列」に対応しました。（ https://github.com/future-architect/uroborosql-fmt/pull/178/commits/872926e5af9030a6c0999fd195703af07480ea47 ）

- バインドパラメータ・置換文字列のサンプル値抜け（select 句・from 句）
  - コード上の修正なし
  - テストケースのみ追加： https://github.com/future-architect/uroborosql-fmt/pull/178/commits/4a340ec69493a63e323e7c7ce0771a5911c852be
- 先頭の余計な Comma
  - select 句 https://github.com/future-architect/uroborosql-fmt/pull/178/commits/0c23947ba8c9e2acb9dfed05dd3f5a674322389d
  - from 句 https://github.com/future-architect/uroborosql-fmt/pull/178/commits/48cb211ca11ee92d3355d950289c0edbecc7a16e
  - sort (order by) 句 https://github.com/future-architect/uroborosql-fmt/pull/178/commits/2d7106823e73a742db946cdad2a98e46af4a31bb
- 先頭の余計な and/or
  - where 句 https://github.com/future-architect/uroborosql-fmt/pull/178/commits/8d652d3f71f63c8d24872751f99f371d64ee281e

## Notes
`use_parser_error_recovery` オプションを追加しました。
オプション値に応じて以下のパーサが利用されます。
- `true` (default): **エラー回復あり**のパーサ
  - `postgresql_cst_parser::tree_sitter::parse_2way`
- `false`: エラー回復なしのパーサ
  - `postgresql_cst_parser::tree_sitter::parse`

現状では、このオプションが影響するのは postgresql-cst-parser が利用される場合（`use_pg_parser` が true の場合）のみです。
正常系のテスト (`test_normal_cases`) については、 `test_normal_cases/use_new_parser.json` の内容をオプションとして利用できます。
