### PR TITLE
partition by で複数パーティションキーがある場合にカンマが欠落するバグを修正

### DIFF
--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr.rs
@@ -6,7 +6,7 @@ use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 use crate::{
     cst::{AlignedExpr, Body, Clause, Expr, SeparatedLines},
     error::UroboroSQLFmtError,
-    new_visitor::{pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor},
+    new_visitor::{pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor, COMMA},
     util::convert_keyword_case,
 };
 
@@ -257,8 +257,13 @@ impl Visitor {
 
         // expr_list (Vec<AlignedExpr>) を Body::SepLines に変換し Clause に追加する
         let mut separated_lines = SeparatedLines::new();
-        for expr in exprs {
-            separated_lines.add_expr(expr, None, vec![]);
+        if let Some((first, rest)) = exprs.split_first() {
+            // 最初の要素だけカンマ無し
+            separated_lines.add_expr(first.clone(), None, vec![]);
+
+            for expr in rest {
+                separated_lines.add_expr(expr.clone(), Some(COMMA.to_string()), vec![]);
+            }
         }
         clause.set_body(Body::SepLines(separated_lines));
 

--- a/crates/uroborosql-fmt/test_normal_cases/dst/091_window_function_partition_by_multiple_keys.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/091_window_function_partition_by_multiple_keys.sql
@@ -1,0 +1,17 @@
+select
+	id			as	id
+,	category	as	category
+,	subcategory	as	subcategory
+,	region		as	region
+,	value		as	value
+,	row_number() over(
+		partition by
+			category
+		,	subcategory
+		,	region
+		order by
+			value
+	)			as	rn
+from
+	test_table
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/091_window_function_partition_by_multiple_keys.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/091_window_function_partition_by_multiple_keys.sql
@@ -1,0 +1,8 @@
+select 
+    id,
+    category,
+    subcategory,
+    region,
+    value,
+    row_number() over (partition by category, subcategory, region order by value) as rn
+from test_table;


### PR DESCRIPTION
## Summary

`over` 句の `partition by` でパーティションキーが複数ある場合にカンマが欠落するバグを修正しました。

```sql
select
	id			as	id
,	category	as	category
,	subcategory	as	subcategory
,	region		as	region
,	value		as	value
,	row_number() over(
		partition by
			category
		,	subcategory
		,	region
		order by
			value
	)			as	rn
from
	test_table
;
```