### PR TITLE
コメント対応の拡充

### DIFF
--- a/crates/uroborosql-fmt/src/new_visitor/clause/returning.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/returning.rs
@@ -38,6 +38,7 @@ impl Visitor {
         let mut clause = pg_create_clause!(cursor, SyntaxKind::RETURNING);
 
         cursor.goto_next_sibling();
+        self.pg_consume_comments_in_clause(cursor, &mut clause)?;
 
         // cursor -> target_list
         pg_ensure_kind!(cursor, SyntaxKind::target_list, src);

--- a/crates/uroborosql-fmt/src/new_visitor/statement/delete.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/statement/delete.rs
@@ -57,6 +57,8 @@ impl Visitor {
         let mut from_clause = pg_create_clause!(cursor, SyntaxKind::FROM);
         cursor.goto_next_sibling();
 
+        self.pg_consume_comments_in_clause(cursor, &mut from_clause)?;
+
         // cursor -> relation_expr_opt_alias
         let body = self.visit_relation_expr_opt_alias(cursor, src)?;
 

--- a/crates/uroborosql-fmt/test_normal_cases/dst/059_new_joins.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/059_new_joins.sql
@@ -75,6 +75,8 @@ from
 		left outer join
 		-- left join comment
 			t3	-- table 3
+		-- after right comment 1
+		-- after right comment 2
 		on
 		/* on keyword comment */
 			t2.id	=	t3.id	-- on comment
@@ -104,6 +106,8 @@ inner join
 -- after keyword
 -- another comment 
 	t2	-- after table
+-- after right comment 1
+-- after right comment 2
 on
 	t1.num	=	t2.num	-- cond
 -- comment 1

--- a/crates/uroborosql-fmt/test_normal_cases/dst/062_simple_delete.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/062_simple_delete.sql
@@ -10,3 +10,9 @@ from
 where
 	tbl1.value	=	1
 ;
+delete
+from
+/* comment */
+-- comment
+	tbl1
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/064_delete_returning.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/064_delete_returning.sql
@@ -6,3 +6,12 @@ where
 returning
 	*
 ;
+delete
+from
+	products
+where
+	obsoletion_date	=	'today'
+returning
+-- comment
+	*
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/101_function_common_subexpr_substring.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/101_function_common_subexpr_substring.sql
@@ -1,16 +1,17 @@
 select
-	substring('Hello World', 1, 5)	as	basic_substring
-,	substring(column_name, 2, 10)	as	column_substring
-,	substring('test string', 6)		as	substring_from_position
+	substring('Hello World', 1, 5)		as	basic_substring
+,	substring(column_name, 2, 10)		as	column_substring
+,	substring('test string', 6)			as	substring_from_position
+,	substring(/*bind_param*/'test', 6)	as	bind_param_substring
 ,	substring(
 		concat(first_name, ' ', last_name)
 	,	1
 	,	20
-	)								as	complex_substring
+	)									as	complex_substring
 ,	substring(
 		description
 	,	length(description)	-	10
-	)								as	end_substring
+	)									as	end_substring
 from
 	users
 where

--- a/crates/uroborosql-fmt/test_normal_cases/dst/102_multiple_for_update_and_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/102_multiple_for_update_and_comment.sql
@@ -1,0 +1,35 @@
+select
+	*
+from
+	t1
+where
+	1	=	1
+order by
+	t1.id
+/*IF 1=1*/
+for update of
+	t1
+nowait
+/*ELSE*/
+for update of
+	t1
+/*END*/
+;
+select
+	*
+from
+	t2
+where
+	1	=	1
+order by
+	t2.id
+/*IF 1=1*/
+for update of
+	t2
+nowait
+-- comment
+/*ELSE*/
+for update of
+	t2
+/*END*/
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/059_new_joins.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/059_new_joins.sql
@@ -40,20 +40,21 @@ select * from t1, t2, t3;
 -- after join keyword comment
 select
 	*
+from (
+select
+    *
 from
-	(
-		select
-			*
-		from
-			t1
-		cross join
-		-- comment 1
-		-- comment 2
-			t2
-        left join -- left join comment
-            t3 -- table 3
-        on /* on keyword comment */ t2.id = t3.id -- on comment
-	)	a
+    t1
+cross join
+-- comment 1
+-- comment 2
+    t2
+left join -- left join comment
+    t3 -- table 3
+-- after right comment 1
+-- after right comment 2
+on /* on keyword comment */ t2.id = t3.id -- on comment
+)	a
 ;
 
 select * from t1 -- table 1
@@ -71,6 +72,8 @@ from
 inner join -- after keyword
 -- another comment 
     t2 -- after table
+    -- after right comment 1
+-- after right comment 2
 on t1.num = t2.num -- cond
 -- comment 1
 -- comment 2

--- a/crates/uroborosql-fmt/test_normal_cases/src/062_simple_delete.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/062_simple_delete.sql
@@ -3,3 +3,9 @@ where tbl1.value = 1;
 
 delete from table1 tbl1 -- テーブル1
 where tbl1.value = 1;
+
+delete from
+/* comment */
+-- comment
+tbl1
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/064_delete_returning.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/064_delete_returning.sql
@@ -1,3 +1,7 @@
 DELETE FROM products
   WHERE obsoletion_date = 'today'
   RETURNING *;
+DELETE FROM products
+  WHERE obsoletion_date = 'today'
+  RETURNING -- comment
+   *;

--- a/crates/uroborosql-fmt/test_normal_cases/src/101_function_common_subexpr_substring.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/101_function_common_subexpr_substring.sql
@@ -2,6 +2,7 @@ SELECT
     SUBSTRING('Hello World', 1, 5) as basic_substring,
     SUBSTRING(column_name, 2, 10) as column_substring,
     SUBSTRING('test string', 6) as substring_from_position,
+    SUBSTRING(/*bind_param*/'test', 6) as bind_param_substring,
     SUBSTRING(CONCAT(first_name, ' ', last_name), 1, 20) as complex_substring,
     SUBSTRING(description, LENGTH(description) - 10) as end_substring
 FROM users

--- a/crates/uroborosql-fmt/test_normal_cases/src/102_multiple_for_update_and_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/102_multiple_for_update_and_comment.sql
@@ -1,0 +1,19 @@
+select * from t1
+where 1=1
+order by t1.id
+/*IF 1=1*/
+for update of t1 nowait
+/*ELSE*/
+for update of t1
+/*END*/
+;
+select * from t2
+where 1=1
+order by t2.id
+/*IF 1=1*/
+for update of t2 nowait -- comment
+/*ELSE*/
+for update of t2
+/*END*/
+;
+


### PR DESCRIPTION

## Summary
以下に示す箇所のコメントに対応しました。

### 1. `for update` と並ぶコメント
commit: https://github.com/future-architect/uroborosql-fmt/pull/189/commits/21220c06cab9ad0751cbfa3cdbf5133cf9b271c0

```sql
select * from t2
where 1=1
order by t2.id
/*IF 1=1*/
for update of t2 nowait -- comment
/*ELSE*/
for update of t2
/*END*/
;
```

### 2. `substring` 関数におけるバインドパラメータ
commit: https://github.com/future-architect/uroborosql-fmt/pull/189/commits/20e6f8c7db282e6e033879ac2c02b51d09ade266

```sql
select substring(/*bind_param*/'test', 1)
;
```

### 3. JoinedTable の右辺の後（`qualifier` の前）のコメント
commit: https://github.com/future-architect/uroborosql-fmt/pull/189/commits/66291b00cdf500970bb3531947ce7d6e51489251

```sql
select
	*
from
	t1	-- after table
inner join
	t2
-- here
-- here
on
	t1.num	=	t2.num
;
```

### 4. `from` キーワード後のコメント
commit: https://github.com/future-architect/uroborosql-fmt/pull/189/commits/ef48bd1e9948550406330adcee8de516e71dd609

```sql
delete
from
-- here
	tbl1
;
```

### 5. `returning` キーワード後のコメント
commit: https://github.com/future-architect/uroborosql-fmt/pull/189/commits/b58b99b9bd236c6522ed65b393cc056eb6999ad2

```sql
delete
from
	products
where
	obsoletion_date	=	'today'
returning
-- here
	*
;
```

