### PR TITLE
partition by 句のコメントに対応

### DIFF
--- a/crates/uroborosql-fmt/src/cst.rs
+++ b/crates/uroborosql-fmt/src/cst.rs
@@ -1,11 +1,13 @@
 mod body;
 mod clause;
 mod expr;
+mod expr_list;
 mod statement;
 
 pub(crate) use body::*;
 pub(crate) use clause::*;
 pub(crate) use expr::*;
+pub(crate) use expr_list::*;
 pub(crate) use statement::*;
 
 // expr

--- a/crates/uroborosql-fmt/src/cst/body/separated_lines.rs
+++ b/crates/uroborosql-fmt/src/cst/body/separated_lines.rs
@@ -166,7 +166,7 @@ impl SeparatedLines {
         }
     }
 
-    pub(crate) fn from_expr_list(
+    pub(crate) fn try_from_expr_list(
         expr_list: &crate::cst::ExprList,
     ) -> Result<Self, crate::error::UroboroSQLFmtError> {
         let mut sep_lines = SeparatedLines::new();

--- a/crates/uroborosql-fmt/src/cst/body/separated_lines.rs
+++ b/crates/uroborosql-fmt/src/cst/body/separated_lines.rs
@@ -166,6 +166,22 @@ impl SeparatedLines {
         }
     }
 
+    pub(crate) fn from_expr_list(
+        expr_list: &crate::cst::ExprList,
+    ) -> Result<Self, crate::error::UroboroSQLFmtError> {
+        let mut sep_lines = SeparatedLines::new();
+
+        for item in expr_list.items() {
+            sep_lines.add_expr(item.expr().clone(), item.sep().clone(), vec![]);
+
+            for comment in item.following_comments() {
+                sep_lines.add_comment_to_child(comment.clone())?;
+            }
+        }
+
+        Ok(sep_lines)
+    }
+
     pub(crate) fn loc(&self) -> Option<Location> {
         self.loc.clone()
     }

--- a/crates/uroborosql-fmt/src/cst/expr/column_list.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/column_list.rs
@@ -35,6 +35,29 @@ impl ColumnList {
         }
     }
 
+    pub(crate) fn from_expr_list(
+        expr_list: &crate::cst::ExprList,
+        location: crate::cst::Location,
+        start_comments: Vec<Comment>,
+    ) -> Result<Self, crate::error::UroboroSQLFmtError> {
+        // いずれかの ExprListItem に following_comments がある場合はエラーにする
+        let mut exprs = Vec::new();
+        for item in expr_list.items() {
+            if let Some(following_comment) = item.following_comments().first() {
+                return Err(crate::error::UroboroSQLFmtError::Unimplemented(
+                    format!(
+                        "Comments following columns are not supported. Only trailing comments are supported.\ncomment: {}",
+                        following_comment.text()
+                    ),
+                ));
+            }
+
+            exprs.push(item.expr().clone());
+        }
+
+        Ok(ColumnList::new(exprs, location, start_comments))
+    }
+
     pub(crate) fn loc(&self) -> Location {
         self.loc.clone()
     }

--- a/crates/uroborosql-fmt/src/cst/expr/column_list.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/column_list.rs
@@ -184,6 +184,10 @@ impl TryFrom<ParenthesizedExprList> for ColumnList {
     type Error = UroboroSQLFmtError;
 
     fn try_from(paren_list: ParenthesizedExprList) -> Result<Self, Self::Error> {
-        ColumnList::from_expr_list(&paren_list.expr_list, paren_list.location, paren_list.start_comments)
+        ColumnList::from_expr_list(
+            &paren_list.expr_list,
+            paren_list.location,
+            paren_list.start_comments,
+        )
     }
 }

--- a/crates/uroborosql-fmt/src/cst/expr/column_list.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/column_list.rs
@@ -35,7 +35,7 @@ impl ColumnList {
         }
     }
 
-    pub(crate) fn from_expr_list(
+    pub(crate) fn try_from_expr_list(
         expr_list: &crate::cst::ExprList,
         location: crate::cst::Location,
         start_comments: Vec<Comment>,
@@ -184,7 +184,7 @@ impl TryFrom<ParenthesizedExprList> for ColumnList {
     type Error = UroboroSQLFmtError;
 
     fn try_from(paren_list: ParenthesizedExprList) -> Result<Self, Self::Error> {
-        ColumnList::from_expr_list(
+        ColumnList::try_from_expr_list(
             &paren_list.expr_list,
             paren_list.location,
             paren_list.start_comments,

--- a/crates/uroborosql-fmt/src/cst/expr/column_list.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/column_list.rs
@@ -184,22 +184,6 @@ impl TryFrom<ParenthesizedExprList> for ColumnList {
     type Error = UroboroSQLFmtError;
 
     fn try_from(paren_list: ParenthesizedExprList) -> Result<Self, Self::Error> {
-        // いずれかの ExprListItem に following_comments がある場合はエラーにする
-        let mut exprs = Vec::new();
-        for item in paren_list.expr_list.items() {
-            if let Some(following_comment) = item.following_comments().first() {
-                return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "Comments following columns are not supported. Only trailing comments are supported.\ncomment: {}",
-                    following_comment.text()
-                )));
-            }
-            exprs.push(item.expr().clone());
-        }
-
-        Ok(ColumnList::new(
-            exprs,
-            paren_list.location,
-            paren_list.start_comments,
-        ))
+        ColumnList::from_expr_list(&paren_list.expr_list, paren_list.location, paren_list.start_comments)
     }
 }

--- a/crates/uroborosql-fmt/src/cst/expr/function.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/function.rs
@@ -385,18 +385,6 @@ impl TryFrom<ParenthesizedExprList> for FunctionCallArgs {
             ));
         }
 
-        // いずれかの ExprListItem に following_comments がある場合はエラーにする
-        let mut exprs = Vec::new();
-        for item in paren_list.expr_list.items() {
-            if let Some(following_comment) = item.following_comments().first() {
-                return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "Comments following function arguments are not supported. Only trailing comments are supported.\ncomment: {}",
-                    following_comment.text()
-                )));
-            }
-            exprs.push(item.expr().clone());
-        }
-
-        Ok(FunctionCallArgs::new(exprs, paren_list.location))
+        FunctionCallArgs::from_expr_list(&paren_list.expr_list, paren_list.location)
     }
 }

--- a/crates/uroborosql-fmt/src/cst/expr/function.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/function.rs
@@ -36,7 +36,7 @@ impl FunctionCallArgs {
         }
     }
 
-    pub(crate) fn from_expr_list(
+    pub(crate) fn try_from_expr_list(
         expr_list: &crate::cst::ExprList,
         location: crate::cst::Location,
     ) -> Result<Self, crate::error::UroboroSQLFmtError> {
@@ -385,6 +385,6 @@ impl TryFrom<ParenthesizedExprList> for FunctionCallArgs {
             ));
         }
 
-        FunctionCallArgs::from_expr_list(&paren_list.expr_list, paren_list.location)
+        FunctionCallArgs::try_from_expr_list(&paren_list.expr_list, paren_list.location)
     }
 }

--- a/crates/uroborosql-fmt/src/cst/expr/function.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/function.rs
@@ -36,6 +36,27 @@ impl FunctionCallArgs {
         }
     }
 
+    pub(crate) fn from_expr_list(
+        expr_list: &crate::cst::ExprList,
+        location: crate::cst::Location,
+    ) -> Result<Self, crate::error::UroboroSQLFmtError> {
+        let mut exprs = Vec::new();
+        for item in expr_list.items() {
+            if let Some(following_comment) = item.following_comments().first() {
+                return Err(crate::error::UroboroSQLFmtError::Unimplemented(
+                    format!(
+                        "Comments following function arguments are not supported. Only trailing comments are supported.\ncomment: {}",
+                        following_comment.text()
+                    ),
+                ));
+            }
+
+            exprs.push(item.expr().clone());
+        }
+
+        Ok(FunctionCallArgs::new(exprs, location))
+    }
+
     pub(crate) fn force_multi_line(&self) -> bool {
         self.force_multi_line
     }

--- a/crates/uroborosql-fmt/src/cst/expr/function.rs
+++ b/crates/uroborosql-fmt/src/cst/expr/function.rs
@@ -281,6 +281,10 @@ impl FunctionCall {
         self.loc.clone()
     }
 
+    pub(crate) fn append_loc(&mut self, loc: Location) {
+        self.loc.append(loc)
+    }
+
     /// 引数が複数行になる場合 true を返す
     fn has_multi_line_arguments(&self) -> bool {
         self.args.is_multi_line()

--- a/crates/uroborosql-fmt/src/cst/expr_list.rs
+++ b/crates/uroborosql-fmt/src/cst/expr_list.rs
@@ -1,0 +1,189 @@
+use crate::{
+    cst::{AlignedExpr, ColumnList, Comment, FunctionCallArgs, Location, SeparatedLines},
+    error::UroboroSQLFmtError,
+};
+
+#[derive(Debug, Clone)]
+struct ExprListItem {
+    sep: Option<String>,
+    expr: AlignedExpr,
+    following_comments: Vec<Comment>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ExprList {
+    items: Vec<ExprListItem>,
+}
+
+impl ExprList {
+    pub(crate) fn new() -> Self {
+        Self { items: vec![] }
+    }
+
+    pub(crate) fn first_expr_mut(&mut self) -> Option<&mut AlignedExpr> {
+        self.items.first_mut().map(|item| &mut item.expr)
+    }
+
+    pub(crate) fn add_expr(&mut self, expr: AlignedExpr, sep: Option<String>) {
+        self.items.push(ExprListItem {
+            sep,
+            expr,
+            following_comments: vec![],
+        });
+    }
+
+    pub(crate) fn add_comment_to_last_item(
+        &mut self,
+        comment: Comment,
+    ) -> Result<(), UroboroSQLFmtError> {
+        if let Some(last) = self.items.last_mut() {
+            // 行末コメントならば最後の式に追加
+            if !comment.is_block_comment() && last.expr.loc().is_same_line(&comment.loc()) {
+                last.expr.set_trailing_comment(comment)?;
+            } else {
+                // 行末コメントでなければ式の下に追加する
+                last.following_comments.push(comment);
+            }
+
+            Ok(())
+        } else {
+            // 式がない場合はエラー
+            Err(UroboroSQLFmtError::IllegalOperation(
+                "ExprList::add_comment_to_last_item(): No expression to add comment to."
+                    .to_string(),
+            ))
+        }
+    }
+
+    pub(crate) fn to_separated_lines(&self) -> Result<SeparatedLines, UroboroSQLFmtError> {
+        let mut sep_lines = SeparatedLines::new();
+
+        for item in &self.items {
+            let ExprListItem {
+                sep,
+                expr,
+                following_comments,
+            } = item;
+
+            sep_lines.add_expr(expr.clone(), sep.clone(), vec![]);
+
+            for comment in following_comments {
+                sep_lines.add_comment_to_child(comment.clone())?;
+            }
+        }
+
+        Ok(sep_lines)
+    }
+
+    pub(crate) fn to_function_call_args(
+        &self,
+        location: Location,
+    ) -> Result<FunctionCallArgs, UroboroSQLFmtError> {
+        let mut exprs = Vec::new();
+        for item in &self.items {
+            if let Some(following_comment) = item.following_comments.first() {
+                return Err(UroboroSQLFmtError::Unimplemented(
+                    format!(
+                        "Comments following function arguments are not supported. Only trailing comments are supported.\ncomment: {}",
+                        following_comment.text()
+                    ),
+                ));
+            }
+
+            exprs.push(item.expr.clone());
+        }
+
+        Ok(FunctionCallArgs::new(exprs, location))
+    }
+
+    pub(crate) fn to_column_list(
+        &self,
+        location: Location,
+        start_comments: Vec<Comment>,
+    ) -> Result<ColumnList, UroboroSQLFmtError> {
+        // いずれかの ExprListItem に following_comments がある場合はエラーにする
+        let mut exprs = Vec::new();
+        for item in &self.items {
+            if let Some(following_comment) = item.following_comments.first() {
+                return Err(UroboroSQLFmtError::Unimplemented(
+                    format!(
+                        "Comments following columns are not supported. Only trailing comments are supported.\ncomment: {}",
+                        following_comment.text()
+                    ),
+                ));
+            }
+
+            exprs.push(item.expr.clone());
+        }
+
+        Ok(ColumnList::new(exprs, location, start_comments))
+    }
+}
+
+/// 括弧で囲まれた式リストの共通表現
+#[derive(Debug, Clone)]
+pub struct ParenthesizedExprList {
+    pub expr_list: ExprList,
+    pub location: Location,
+    pub start_comments: Vec<Comment>,
+}
+
+impl ParenthesizedExprList {
+    pub fn new(expr_list: ExprList, location: Location, start_comments: Vec<Comment>) -> Self {
+        Self {
+            expr_list,
+            location,
+            start_comments,
+        }
+    }
+}
+
+impl TryFrom<ParenthesizedExprList> for ColumnList {
+    type Error = UroboroSQLFmtError;
+
+    fn try_from(paren_list: ParenthesizedExprList) -> Result<Self, Self::Error> {
+        // いずれかの ExprListItem に following_comments がある場合はエラーにする
+        let mut exprs = Vec::new();
+        for item in paren_list.expr_list.items {
+            if let Some(following_comment) = item.following_comments.first() {
+                return Err(UroboroSQLFmtError::Unimplemented(format!(
+                    "Comments following columns are not supported. Only trailing comments are supported.\ncomment: {}",
+                    following_comment.text()
+                )));
+            }
+            exprs.push(item.expr.clone());
+        }
+
+        Ok(ColumnList::new(
+            exprs,
+            paren_list.location,
+            paren_list.start_comments,
+        ))
+    }
+}
+
+impl TryFrom<ParenthesizedExprList> for FunctionCallArgs {
+    type Error = UroboroSQLFmtError;
+
+    fn try_from(paren_list: ParenthesizedExprList) -> Result<Self, Self::Error> {
+        if !paren_list.start_comments.is_empty() {
+            return Err(UroboroSQLFmtError::Unimplemented(
+                "Comments immediately after opening parenthesis in function arguments are not supported".to_string()
+            ));
+        }
+
+        // いずれかの ExprListItem に following_comments がある場合はエラーにする
+        let mut exprs = Vec::new();
+        for item in paren_list.expr_list.items {
+            if let Some(following_comment) = item.following_comments.first() {
+                return Err(UroboroSQLFmtError::Unimplemented(format!(
+                    "Comments following function arguments are not supported. Only trailing comments are supported.\ncomment: {}",
+                    following_comment.text()
+                )));
+            }
+            exprs.push(item.expr.clone());
+        }
+
+        Ok(FunctionCallArgs::new(exprs, paren_list.location))
+    }
+}

--- a/crates/uroborosql-fmt/src/cst/expr_list.rs
+++ b/crates/uroborosql-fmt/src/cst/expr_list.rs
@@ -91,5 +91,3 @@ impl ParenthesizedExprList {
         }
     }
 }
-
-

--- a/crates/uroborosql-fmt/src/lib.rs
+++ b/crates/uroborosql-fmt/src/lib.rs
@@ -60,9 +60,9 @@ pub(crate) fn format_sql_with_config(
         let use_parser_error_recovery = config.use_parser_error_recovery;
 
         let parse_result = if use_parser_error_recovery {
-            pg_parse_2way(src).map_err(|e| UroboroSQLFmtError::ParseError(format!("{:?}", e)))
+            pg_parse_2way(src).map_err(|e| UroboroSQLFmtError::ParseError(format!("{e:?}")))
         } else {
-            pg_parse(src).map_err(|e| UroboroSQLFmtError::ParseError(format!("{:?}", e)))
+            pg_parse(src).map_err(|e| UroboroSQLFmtError::ParseError(format!("{e:?}")))
         };
 
         match parse_result {
@@ -226,9 +226,9 @@ fn pg_print_cst(node: postgresql_cst_parser::tree_sitter::Node, depth: usize) {
 
 pub(crate) fn pg_format(src: &str) -> Result<String, UroboroSQLFmtError> {
     let tree = if CONFIG.read().unwrap().use_parser_error_recovery {
-        pg_parse_2way(src).map_err(|e| UroboroSQLFmtError::ParseError(format!("{:?}", e)))?
+        pg_parse_2way(src).map_err(|e| UroboroSQLFmtError::ParseError(format!("{e:?}")))?
     } else {
-        pg_parse(src).map_err(|e| UroboroSQLFmtError::ParseError(format!("{:?}", e)))?
+        pg_parse(src).map_err(|e| UroboroSQLFmtError::ParseError(format!("{e:?}")))?
     };
 
     pg_format_cst(&tree, src)

--- a/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/select.rs
@@ -70,7 +70,7 @@ impl Visitor {
 
                     // 括弧と expr_list を ColumnList に格納
                     let mut column_list =
-                        ColumnList::from(self.handle_parenthesized_expr_list(cursor, src)?);
+                        ColumnList::try_from(self.handle_parenthesized_expr_list(cursor, src)?)?;
                     // 改行によるフォーマットを強制
                     column_list.set_force_multi_line(true);
 

--- a/crates/uroborosql-fmt/src/new_visitor/clause/values.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/clause/values.rs
@@ -30,14 +30,14 @@ impl Visitor {
         cursor.goto_next_sibling();
         // cursor -> '('
 
-        let first_row = ColumnList::from(self.handle_parenthesized_expr_list(cursor, src)?);
+        let first_row = ColumnList::try_from(self.handle_parenthesized_expr_list(cursor, src)?)?;
         let mut rows = vec![first_row];
 
         while cursor.goto_next_sibling() {
             match cursor.node().kind() {
                 SyntaxKind::LParen => {
                     let parenthesized_expr_list =
-                        ColumnList::from(self.handle_parenthesized_expr_list(cursor, src)?);
+                        ColumnList::try_from(self.handle_parenthesized_expr_list(cursor, src)?)?;
 
                     rows.push(parenthesized_expr_list);
                 }

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/in_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/a_expr/in_expr.rs
@@ -96,7 +96,7 @@ impl Visitor {
                 // Expr::ColumnList を返す
                 // '(' expr_list ')' を ColumnList に変換する
                 let column_list =
-                    ColumnList::from(self.handle_parenthesized_expr_list(cursor, src)?);
+                    ColumnList::try_from(self.handle_parenthesized_expr_list(cursor, src)?)?;
 
                 Expr::ColumnList(Box::new(column_list))
             }

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr.rs
@@ -4,7 +4,7 @@ mod func_expr_common_subexpr;
 use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 
 use crate::{
-    cst::{Body, Clause, Expr, Location},
+    cst::{Body, Clause, Expr, Location, SeparatedLines},
     error::UroboroSQLFmtError,
     new_visitor::{pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor},
     util::convert_keyword_case,
@@ -264,7 +264,7 @@ impl Visitor {
         // cursor -> expr_list
         let exprs = self.visit_expr_list(cursor, src)?;
 
-        let sep_lines = exprs.to_separated_lines()?;
+        let sep_lines = SeparatedLines::from_expr_list(&exprs)?;
         clause.set_body(Body::SepLines(sep_lines));
 
         cursor.goto_parent();

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr.rs
@@ -6,7 +6,7 @@ use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 use crate::{
     cst::{Body, Clause, Expr, Location},
     error::UroboroSQLFmtError,
-    new_visitor::{pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor, COMMA},
+    new_visitor::{pg_create_clause, pg_ensure_kind, pg_error_annotation_from_cursor},
     util::convert_keyword_case,
 };
 
@@ -264,7 +264,7 @@ impl Visitor {
         // cursor -> expr_list
         let exprs = self.visit_expr_list(cursor, src)?;
 
-        let sep_lines = exprs.to_separated_lines(Some(COMMA.to_string()))?;
+        let sep_lines = exprs.to_separated_lines()?;
         clause.set_body(Body::SepLines(sep_lines));
 
         cursor.goto_parent();

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr.rs
@@ -82,6 +82,8 @@ impl Visitor {
             let (filter_keyword, filter_clause) = self.visit_filter_clause(cursor, src)?;
             func.set_filter_keyword(&filter_keyword);
             func.set_filter_clause(filter_clause);
+
+            func.append_loc(Location::from(cursor.node().range()));
         }
 
         // cursor -> over_clause?

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr.rs
@@ -264,7 +264,7 @@ impl Visitor {
         // cursor -> expr_list
         let exprs = self.visit_expr_list(cursor, src)?;
 
-        let sep_lines = SeparatedLines::from_expr_list(&exprs)?;
+        let sep_lines = SeparatedLines::try_from_expr_list(&exprs)?;
         clause.set_body(Body::SepLines(sep_lines));
 
         cursor.goto_parent();

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_expr_common_subexpr/trim_function.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_expr_common_subexpr/trim_function.rs
@@ -52,7 +52,7 @@ impl Visitor {
 
         assert!(!cursor.goto_next_sibling());
 
-        let function_args = FunctionCallArgs::from_expr_list(&args, arg_loc)?;
+        let function_args = FunctionCallArgs::try_from_expr_list(&args, arg_loc)?;
         let function = FunctionCall::new(
             keyword_text,
             function_args,

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_expr_common_subexpr/trim_function.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_expr_common_subexpr/trim_function.rs
@@ -1,7 +1,7 @@
 use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 
 use crate::{
-    cst::{ExprList, FunctionCall, FunctionCallKind, Location},
+    cst::{ExprList, FunctionCall, FunctionCallArgs, FunctionCallKind, Location},
     error::UroboroSQLFmtError,
     new_visitor::{pg_ensure_kind, pg_error_annotation_from_cursor, Visitor},
     util::convert_keyword_case,
@@ -52,7 +52,7 @@ impl Visitor {
 
         assert!(!cursor.goto_next_sibling());
 
-        let function_args = args.to_function_call_args(arg_loc)?;
+        let function_args = FunctionCallArgs::from_expr_list(&args, arg_loc)?;
         let function = FunctionCall::new(
             keyword_text,
             function_args,

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_expr_common_subexpr/trim_function.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_expr_common_subexpr/trim_function.rs
@@ -1,11 +1,9 @@
 use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 
 use crate::{
-    cst::{FunctionCall, FunctionCallKind, Location},
+    cst::{ExprList, FunctionCall, FunctionCallKind, Location},
     error::UroboroSQLFmtError,
-    new_visitor::{
-        pg_ensure_kind, pg_error_annotation_from_cursor, pg_expr::expr_list::ExprList, Visitor,
-    },
+    new_visitor::{pg_ensure_kind, pg_error_annotation_from_cursor, Visitor},
     util::convert_keyword_case,
 };
 

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_expr_common_subexpr/trim_function.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/func_expr/func_expr_common_subexpr/trim_function.rs
@@ -1,9 +1,11 @@
 use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 
 use crate::{
-    cst::{AlignedExpr, FunctionCall, FunctionCallArgs, FunctionCallKind, Location},
+    cst::{FunctionCall, FunctionCallKind, Location},
     error::UroboroSQLFmtError,
-    new_visitor::{pg_ensure_kind, pg_error_annotation_from_cursor, Visitor},
+    new_visitor::{
+        pg_ensure_kind, pg_error_annotation_from_cursor, pg_expr::expr_list::ExprList, Visitor,
+    },
     util::convert_keyword_case,
 };
 
@@ -52,7 +54,7 @@ impl Visitor {
 
         assert!(!cursor.goto_next_sibling());
 
-        let function_args = FunctionCallArgs::new(args, arg_loc);
+        let function_args = args.to_function_call_args(arg_loc)?;
         let function = FunctionCall::new(
             keyword_text,
             function_args,
@@ -72,7 +74,7 @@ impl Visitor {
         &mut self,
         cursor: &mut TreeCursor,
         src: &str,
-    ) -> Result<Vec<AlignedExpr>, UroboroSQLFmtError> {
+    ) -> Result<ExprList, UroboroSQLFmtError> {
         // trim_list:
         // - a_expr FROM expr_list
         // - FROM expr_list

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/implicit_row.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/implicit_row.rs
@@ -65,6 +65,6 @@ impl Visitor {
         // cursor -> implicit_row
         pg_ensure_kind!(cursor, SyntaxKind::implicit_row, src);
 
-        expr_list.to_column_list(loc, start_comments)
+        ColumnList::from_expr_list(&expr_list, loc, start_comments)
     }
 }

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/implicit_row.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/implicit_row.rs
@@ -3,7 +3,7 @@ use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
 use crate::{
     cst::{ColumnList, Comment, Location},
     error::UroboroSQLFmtError,
-    new_visitor::pg_ensure_kind,
+    new_visitor::{pg_ensure_kind, COMMA},
 };
 
 use super::Visitor;
@@ -55,7 +55,7 @@ impl Visitor {
         let a_expr = self.visit_a_expr_or_b_expr(cursor, src)?;
 
         // expr_list に a_expr を追加
-        expr_list.add_expr(a_expr.to_aligned());
+        expr_list.add_expr(a_expr.to_aligned(), Some(COMMA.to_string()));
 
         cursor.goto_next_sibling();
         // cursor -> ')'

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/implicit_row.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/c_expr/implicit_row.rs
@@ -65,6 +65,6 @@ impl Visitor {
         // cursor -> implicit_row
         pg_ensure_kind!(cursor, SyntaxKind::implicit_row, src);
 
-        ColumnList::from_expr_list(&expr_list, loc, start_comments)
+        ColumnList::try_from_expr_list(&expr_list, loc, start_comments)
     }
 }

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/expr_list.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/expr_list.rs
@@ -2,129 +2,12 @@ use postgresql_cst_parser::syntax_kind::SyntaxKind;
 use postgresql_cst_parser::tree_sitter::TreeCursor;
 
 use crate::{
-    cst::{AlignedExpr, ColumnList, Comment, FunctionCallArgs, Location, SeparatedLines},
+    cst::{Comment, ExprList, Location, ParenthesizedExprList},
     error::UroboroSQLFmtError,
     new_visitor::{pg_ensure_kind, COMMA},
 };
 
 use super::{pg_error_annotation_from_cursor, Visitor};
-
-#[derive(Debug, Clone)]
-struct ExprListItem {
-    sep: Option<String>,
-    expr: AlignedExpr,
-    following_comments: Vec<Comment>,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct ExprList {
-    items: Vec<ExprListItem>,
-}
-
-impl ExprList {
-    fn new() -> Self {
-        Self { items: vec![] }
-    }
-
-    fn first_expr_mut(&mut self) -> Option<&mut AlignedExpr> {
-        self.items.first_mut().map(|item| &mut item.expr)
-    }
-
-    pub(crate) fn add_expr(&mut self, expr: AlignedExpr, sep: Option<String>) {
-        self.items.push(ExprListItem {
-            sep,
-            expr,
-            following_comments: vec![],
-        });
-    }
-
-    pub(crate) fn add_comment_to_last_item(
-        &mut self,
-        comment: Comment,
-    ) -> Result<(), UroboroSQLFmtError> {
-        if let Some(last) = self.items.last_mut() {
-            // 行末コメントならば最後の式に追加
-            if !comment.is_block_comment() && last.expr.loc().is_same_line(&comment.loc()) {
-                last.expr.set_trailing_comment(comment)?;
-            } else {
-                // 行末コメントでなければ式の下に追加する
-                last.following_comments.push(comment);
-            }
-
-            Ok(())
-        } else {
-            // 式がない場合はエラー
-            Err(UroboroSQLFmtError::IllegalOperation(
-                "ExprList::add_comment_to_last_item(): No expression to add comment to."
-                    .to_string(),
-            ))
-        }
-    }
-
-    pub(crate) fn to_separated_lines(&self) -> Result<SeparatedLines, UroboroSQLFmtError> {
-        let mut sep_lines = SeparatedLines::new();
-
-        for item in &self.items {
-            let ExprListItem {
-                sep,
-                expr,
-                following_comments,
-            } = item;
-
-            sep_lines.add_expr(expr.clone(), sep.clone(), vec![]);
-
-            for comment in following_comments {
-                sep_lines.add_comment_to_child(comment.clone())?;
-            }
-        }
-
-        Ok(sep_lines)
-    }
-
-    pub(crate) fn to_function_call_args(
-        &self,
-        location: Location,
-    ) -> Result<FunctionCallArgs, UroboroSQLFmtError> {
-        let mut exprs = Vec::new();
-        for item in &self.items {
-            if let Some(following_comment) = item.following_comments.first() {
-                return Err(UroboroSQLFmtError::Unimplemented(
-                    format!(
-                        "Comments following function arguments are not supported. Only trailing comments are supported.\ncomment: {}",
-                        following_comment.text()
-                    ),
-                ));
-            }
-
-            exprs.push(item.expr.clone());
-        }
-
-        Ok(FunctionCallArgs::new(exprs, location))
-    }
-
-    pub(crate) fn to_column_list(
-        &self,
-        location: Location,
-        start_comments: Vec<Comment>,
-    ) -> Result<ColumnList, UroboroSQLFmtError> {
-        // いずれかの ExprListItem に following_comments がある場合はエラーにする
-        let mut exprs = Vec::new();
-        for item in &self.items {
-            if let Some(following_comment) = item.following_comments.first() {
-                return Err(UroboroSQLFmtError::Unimplemented(
-                    format!(
-                        "Comments following columns are not supported. Only trailing comments are supported.\ncomment: {}",
-                        following_comment.text()
-                    ),
-                ));
-            }
-
-            exprs.push(item.expr.clone());
-        }
-
-        Ok(ColumnList::new(exprs, location, start_comments))
-    }
-}
 
 impl Visitor {
     /// 呼出し後、 cursor は expr_list を指している
@@ -199,77 +82,7 @@ impl Visitor {
 
         Ok(expr_list)
     }
-}
 
-/// 括弧で囲まれた式リストの共通表現
-#[derive(Debug, Clone)]
-pub struct ParenthesizedExprList {
-    pub expr_list: ExprList,
-    pub location: Location,
-    pub start_comments: Vec<Comment>,
-}
-
-impl ParenthesizedExprList {
-    pub fn new(expr_list: ExprList, location: Location, start_comments: Vec<Comment>) -> Self {
-        Self {
-            expr_list,
-            location,
-            start_comments,
-        }
-    }
-}
-
-impl TryFrom<ParenthesizedExprList> for ColumnList {
-    type Error = UroboroSQLFmtError;
-
-    fn try_from(paren_list: ParenthesizedExprList) -> Result<Self, Self::Error> {
-        // いずれかの ExprListItem に following_comments がある場合はエラーにする
-        let mut exprs = Vec::new();
-        for item in paren_list.expr_list.items {
-            if let Some(following_comment) = item.following_comments.first() {
-                return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "Comments following columns are not supported. Only trailing comments are supported.\ncomment: {}",
-                    following_comment.text()
-                )));
-            }
-            exprs.push(item.expr.clone());
-        }
-
-        Ok(ColumnList::new(
-            exprs,
-            paren_list.location,
-            paren_list.start_comments,
-        ))
-    }
-}
-
-impl TryFrom<ParenthesizedExprList> for FunctionCallArgs {
-    type Error = UroboroSQLFmtError;
-
-    fn try_from(paren_list: ParenthesizedExprList) -> Result<Self, Self::Error> {
-        if !paren_list.start_comments.is_empty() {
-            return Err(UroboroSQLFmtError::Unimplemented(
-                "Comments immediately after opening parenthesis in function arguments are not supported".to_string()
-            ));
-        }
-
-        // いずれかの ExprListItem に following_comments がある場合はエラーにする
-        let mut exprs = Vec::new();
-        for item in paren_list.expr_list.items {
-            if let Some(following_comment) = item.following_comments.first() {
-                return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "Comments following function arguments are not supported. Only trailing comments are supported.\ncomment: {}",
-                    following_comment.text()
-                )));
-            }
-            exprs.push(item.expr.clone());
-        }
-
-        Ok(FunctionCallArgs::new(exprs, paren_list.location))
-    }
-}
-
-impl Visitor {
     /// 括弧で囲まれた式リストを処理するメソッド
     /// 呼出し時、cursor は '(' を指している
     /// 呼出し後、cursor は ')' を指している

--- a/crates/uroborosql-fmt/src/new_visitor/pg_expr/expr_list.rs
+++ b/crates/uroborosql-fmt/src/new_visitor/pg_expr/expr_list.rs
@@ -87,11 +87,11 @@ impl ExprList {
     ) -> Result<FunctionCallArgs, UroboroSQLFmtError> {
         let mut exprs = Vec::new();
         for item in &self.items {
-            if !item.following_comments.is_empty() {
+            if let Some(following_comment) = item.following_comments.first() {
                 return Err(UroboroSQLFmtError::Unimplemented(
                     format!(
-                        "Comments following function argument are not supported. Only trailing comments are supported.\ncomment: {}",
-                        item.following_comments.first().unwrap().text()
+                        "Comments following function arguments are not supported. Only trailing comments are supported.\ncomment: {}",
+                        following_comment.text()
                     ),
                 ));
             }
@@ -110,11 +110,11 @@ impl ExprList {
         // いずれかの ExprListItem に following_comments がある場合はエラーにする
         let mut exprs = Vec::new();
         for item in &self.items {
-            if !item.following_comments.is_empty() {
+            if let Some(following_comment) = item.following_comments.first() {
                 return Err(UroboroSQLFmtError::Unimplemented(
                     format!(
-                        "Comments following column list are not supported. Only trailing comments are supported.\ncomment: {}",
-                        item.following_comments.first().unwrap().text()
+                        "Comments following columns are not supported. Only trailing comments are supported.\ncomment: {}",
+                        following_comment.text()
                     ),
                 ));
             }
@@ -226,10 +226,10 @@ impl TryFrom<ParenthesizedExprList> for ColumnList {
         // いずれかの ExprListItem に following_comments がある場合はエラーにする
         let mut exprs = Vec::new();
         for item in paren_list.expr_list.items {
-            if !item.following_comments.is_empty() {
+            if let Some(following_comment) = item.following_comments.first() {
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "Comments following function argument are not supported. Only trailing comments are supported.\ncomment: {}",
-                    item.following_comments.first().unwrap().text()
+                    "Comments following columns are not supported. Only trailing comments are supported.\ncomment: {}",
+                    following_comment.text()
                 )));
             }
             exprs.push(item.expr.clone());
@@ -256,10 +256,10 @@ impl TryFrom<ParenthesizedExprList> for FunctionCallArgs {
         // いずれかの ExprListItem に following_comments がある場合はエラーにする
         let mut exprs = Vec::new();
         for item in paren_list.expr_list.items {
-            if !item.following_comments.is_empty() {
+            if let Some(following_comment) = item.following_comments.first() {
                 return Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "Comments following function argument are not supported. Only trailing comments are supported.\ncomment: {}",
-                    item.following_comments.first().unwrap().text()
+                    "Comments following function arguments are not supported. Only trailing comments are supported.\ncomment: {}",
+                    following_comment.text()
                 )));
             }
             exprs.push(item.expr.clone());

--- a/crates/uroborosql-fmt/src/pg_validate.rs
+++ b/crates/uroborosql-fmt/src/pg_validate.rs
@@ -34,16 +34,16 @@ fn error_annotation(src_token: &Token, dst_token: Option<&Token>, _src: &str) ->
     // とりあえず Token の種類と値を表示する
 
     // src token
-    let src_token_str = format!("src_token: {:?}", src_token);
+    let src_token_str = format!("src_token: {src_token:?}");
 
     // dst token (if exists)
     let dst_token_str = if let Some(dst_token) = dst_token {
-        format!("dst_token: {:?}", dst_token)
+        format!("dst_token: {dst_token:?}")
     } else {
         "dst_token: None".to_string()
     };
 
-    format!("src_token: {}\ndst_token: {}", src_token_str, dst_token_str)
+    format!("src_token: {src_token_str}\ndst_token: {dst_token_str}")
 }
 
 fn compare_tokens(
@@ -78,7 +78,7 @@ fn compare_tokens(
                 // src.len() < dst.len() の場合
                 return Err(UroboroSQLFmtError::Validation {
                     format_result: format_result.to_owned(),
-                    error_msg: format!("different kind token: For some reason the number of tokens in the format result has increased\nformat_result: \n{}", format_result),
+                    error_msg: format!("different kind token: For some reason the number of tokens in the format result has increased\nformat_result: \n{format_result}"),
                 });
             }
         }

--- a/crates/uroborosql-fmt/src/util.rs
+++ b/crates/uroborosql-fmt/src/util.rs
@@ -96,8 +96,7 @@ fn byte_to_char_index(input: &str, target_byte_index: usize) -> Result<usize, Ur
         Ok(char_index)
     } else {
         Err(UroboroSQLFmtError::Runtime(format!(
-            "byte_to_char_index: byte_index({}) is out of range",
-            target_byte_index
+            "byte_to_char_index: byte_index({target_byte_index}) is out of range"
         )))
     }
 }

--- a/crates/uroborosql-fmt/src/validate.rs
+++ b/crates/uroborosql-fmt/src/validate.rs
@@ -169,7 +169,7 @@ fn compare_tokens(
                 // src.len() < dst.len() の場合
                 return Err(UroboroSQLFmtError::Validation {
                     format_result: format_result.to_owned(),
-                    error_msg: format!("different kind token: For some reason the number of tokens in the format result has increased\nformat_result: \n{}", format_result),
+                    error_msg: format!("different kind token: For some reason the number of tokens in the format result has increased\nformat_result: \n{format_result}"),
                 });
             }
         }

--- a/crates/uroborosql-fmt/test_normal_cases/dst/103_partition_by_comments.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/103_partition_by_comments.sql
@@ -1,0 +1,15 @@
+select
+	count(*) over(
+		partition by
+			a
+		,	b
+		/*IF 1 = 1*/
+		,	c
+		/*ELIF 1 = 2*/
+		,	d
+		,	e
+		/*END*/
+	)	as	a
+from
+	t
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/104_over_trailing_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/104_over_trailing_comment.sql
@@ -1,0 +1,11 @@
+select
+	coalesce(
+		min(a) over(
+			partition by
+				b
+		)	-- comment
+	,	f
+	)	as	a
+from
+	t
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/104_over_trailing_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/104_over_trailing_comment.sql
@@ -3,8 +3,19 @@ select
 		min(a) over(
 			partition by
 				b
-		)	-- comment
-	,	f
+		)	-- over comment
+	,	0
+	)	as	a
+from
+	t
+;
+select
+	coalesce(
+		count(*) filter(
+			where
+				a	=	1
+		)	-- filter comment
+	,	0
 	)	as	a
 from
 	t

--- a/crates/uroborosql-fmt/test_normal_cases/src/103_partition_by_comments.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/103_partition_by_comments.sql
@@ -1,0 +1,11 @@
+select
+count(*) over(partition by
+    a, b
+    /*IF 1 = 1*/
+    ,c
+    /*ELIF 1 = 2*/
+    ,d,e
+    /*END*/
+)   as a
+from t
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/104_over_trailing_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/104_over_trailing_comment.sql
@@ -2,8 +2,16 @@ select
 coalesce(
 min(a) over(
     partition by b
-) -- comment
-,   f
-)   as a
+) -- over comment
+,0) as a
+from t
+;
+select
+coalesce(
+count(*) filter (
+    where a = 1
+) -- filter comment
+,0
+) as a
 from t
 ;

--- a/crates/uroborosql-fmt/test_normal_cases/src/104_over_trailing_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/104_over_trailing_comment.sql
@@ -1,0 +1,9 @@
+select
+coalesce(
+min(a) over(
+    partition by b
+) -- comment
+,   f
+)   as a
+from t
+;

--- a/crates/uroborosql-fmt/tests/pgcst_coverage.rs
+++ b/crates/uroborosql-fmt/tests/pgcst_coverage.rs
@@ -86,9 +86,9 @@ fn try_format_with_new_parser(
     use uroborosql_fmt::error::UroboroSQLFmtError;
 
     let input =
-        fs::read_to_string(src_file_path).map_err(|e| format!("Failed to read file: {}", e))?;
+        fs::read_to_string(src_file_path).map_err(|e| format!("Failed to read file: {e}"))?;
     let expected =
-        fs::read_to_string(dst_file_path).map_err(|e| format!("Failed to read dst file: {}", e))?;
+        fs::read_to_string(dst_file_path).map_err(|e| format!("Failed to read dst file: {e}"))?;
 
     let setting = r#"
     {
@@ -114,19 +114,19 @@ fn try_format_with_new_parser(
         Err(e) => {
             // エラーの種類に応じてメッセージを詳細化
             let error_detail = match e {
-                UroboroSQLFmtError::ParseError(msg) => format!("Parse error: {}", msg),
-                UroboroSQLFmtError::IllegalOperation(msg) => format!("Illegal operation: {}", msg),
-                UroboroSQLFmtError::UnexpectedSyntax(msg) => format!("Syntax error: {}", msg),
-                UroboroSQLFmtError::Unimplemented(msg) => format!("Unimplemented: {}", msg),
-                UroboroSQLFmtError::FileNotFound(msg) => format!("File not found: {}", msg),
-                UroboroSQLFmtError::IllegalSettingFile(msg) => format!("Invalid config: {}", msg),
-                UroboroSQLFmtError::Rendering(msg) => format!("Rendering error: {}", msg),
-                UroboroSQLFmtError::Runtime(msg) => format!("Runtime error: {}", msg),
+                UroboroSQLFmtError::ParseError(msg) => format!("Parse error: {msg}"),
+                UroboroSQLFmtError::IllegalOperation(msg) => format!("Illegal operation: {msg}"),
+                UroboroSQLFmtError::UnexpectedSyntax(msg) => format!("Syntax error: {msg}"),
+                UroboroSQLFmtError::Unimplemented(msg) => format!("Unimplemented: {msg}"),
+                UroboroSQLFmtError::FileNotFound(msg) => format!("File not found: {msg}"),
+                UroboroSQLFmtError::IllegalSettingFile(msg) => format!("Invalid config: {msg}"),
+                UroboroSQLFmtError::Rendering(msg) => format!("Rendering error: {msg}"),
+                UroboroSQLFmtError::Runtime(msg) => format!("Runtime error: {msg}"),
                 UroboroSQLFmtError::Validation { error_msg, .. } => {
-                    format!("Validation error: {}", error_msg)
+                    format!("Validation error: {error_msg}")
                 }
             };
-            Err(format!("❌ {}", error_detail))
+            Err(format!("❌ {error_detail}"))
         }
     }
 }
@@ -147,7 +147,7 @@ fn print_coverage_report(results: &[TestResult], config: &TestReportConfig) {
         let unsupported = total - supported - skipped;
 
         println!("\nCoverage Report:");
-        println!("Total test cases: {:>4} cases", total);
+        println!("Total test cases: {total:>4} cases");
         println!(
             "{:<14} : {:>4} cases, {:>6.1}%",
             "✅ Supported",
@@ -301,12 +301,12 @@ fn print_error_group(
     show_annotations: bool,
 ) {
     if !errors.is_empty() {
-        println!("\n{}:", group_name);
+        println!("\n{group_name}:");
         for (file, message, annotation) in errors {
             println!("  {} - {}", file.display(), message);
             if show_annotations {
                 if let Some(ann) = annotation {
-                    println!("{}", ann);
+                    println!("{ann}");
                 }
             }
         }
@@ -364,9 +364,9 @@ fn run_config_test_suite() -> Vec<TestResult> {
             .to_str()
             .expect("Failed to convert config file stem to str.");
 
-        let dst_dir = PathBuf::from(format!("testfiles/config_test/dst_{}", config_name));
+        let dst_dir = PathBuf::from(format!("testfiles/config_test/dst_{config_name}"));
 
-        println!("config: {}", config_name);
+        println!("config: {config_name}");
 
         for src_file_path in src_files.iter().sorted() {
             let filename = src_file_path

--- a/crates/uroborosql-fmt/tests/pgcst_normal_cases.rs
+++ b/crates/uroborosql-fmt/tests/pgcst_normal_cases.rs
@@ -91,7 +91,7 @@ fn print_test_report(results: &[TestResult]) {
         .count();
 
     println!("\nTest Report:");
-    println!("Total test cases: {:>4} cases", total);
+    println!("Total test cases: {total:>4} cases");
     println!("{:<14} : {:>4} cases", "✅ Passed", passed);
     println!("{:<14} : {:>4} cases", "❌ Failed", failed);
     println!("{:<14} : {:>4} cases", "💥 Errors", errors);
@@ -142,15 +142,15 @@ fn collect_test_cases() -> Vec<TestCase> {
                     .and_then(|s| s.to_str())
                     .unwrap_or_default();
 
-                let dst_path = dst_dir.join(format!("{}.sql", file_stem));
+                let dst_path = dst_dir.join(format!("{file_stem}.sql"));
 
                 if dst_path.exists() {
                     match TestCase::from_files(file_stem, &src_path, &dst_path) {
                         Ok(test_case) => cases.push(test_case),
-                        Err(e) => eprintln!("Error loading test case {:?}: {}", src_path, e),
+                        Err(e) => eprintln!("Error loading test case {src_path:?}: {e}"),
                     }
                 } else {
-                    eprintln!("Missing dst file for test case: {:?}", src_path);
+                    eprintln!("Missing dst file for test case: {src_path:?}");
                 }
             }
         }


### PR DESCRIPTION
## Summary
`partition by` 句のカラム部分に行末コメントとバインド変数以外のコメントを書けるようにしました

```sql
select
	count(*) over(
		partition by
			a
		/*IF 1 = 1*/
		,	b
		/*END*/
	)	as	c
from
	t
;
```
## 実装について
これまで `visit_expr_list` の返り値は `Vec<AlignedExpr>` としており、`expr_list` で表される箇所では行末コメントとバインド変数以外のコメントは想定しない作りとなっていました。

しかし、新パーサで `expr_list` として扱われる箇所のうち、フォーマッタ内部で `SeparatedLines` として表現されている箇所については、式の次行以降にコメントを書けることが想定されています。

よって、`visit_expr_list` の返り値を、内部にコメントを保持する `ExprList` として表現するよう変更しました。利用側では visit_expr_list を呼び出した後に、必要な各構造体（`SeparatedLines`, `ColumnList`, `FunctionCallArgs`）へ変換します。 

よって、 `SeparatedLines` で表現されている `partition by` 句のカラムリスト部分に新しくコメントが書けるようになりました。

`ColumnList` や `FunctionCallArgs` については `SeparatedLines` のようなコメント（行末コメントやバインド変数以外のコメント）は想定されていないため、もしそれにあたるコメントがある場合は変換時にエラーとなるようにしています。

