### PR TITLE
CLI版の改善・機能追加

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+[env]
+# For now, do not run tests in parallel because tests involving configuration may conflict
+RUST_TEST_THREADS = "1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "assert_fs"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +143,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.33",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "console"
 version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,7 +198,7 @@ dependencies = [
  "libc",
  "once_cell",
  "unicode-width 0.2.0",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -130,6 +257,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,12 +287,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -167,6 +361,29 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -189,6 +406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,10 +427,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
-name = "libc"
-version = "0.2.148"
+name = "lazy_static"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"
@@ -218,6 +447,12 @@ dependencies = [
  "cfg-if",
  "winapi",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
@@ -299,10 +534,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "parking_lot"
@@ -333,6 +589,36 @@ version = "0.2.0"
 source = "git+https://github.com/future-architect/postgresql-cst-parser#449673d07f016f97a0769461cfc340c94e66f955"
 dependencies = [
  "cstree",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -392,6 +678,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +701,15 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -475,6 +783,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +809,24 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tempfile"
+version = "3.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "text-size"
@@ -520,6 +852,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.33",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -576,6 +917,10 @@ dependencies = [
 name = "uroborosql-fmt-cli"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
+ "assert_fs",
+ "clap",
+ "predicates",
  "uroborosql-fmt",
 ]
 
@@ -596,6 +941,31 @@ dependencies = [
  "console_error_panic_hook",
  "uroborosql-fmt",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -673,10 +1043,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Please install [Rust](https://www.rust-lang.org/tools/install) before installing
 cargo install --git https://github.com/future-architect/uroborosql-fmt
 ```
 
+### CLI Documentation
+
+For detailed CLI usage, options, and examples, see the [CLI documentation](crates/uroborosql-fmt-cli/README.md).
+
 ## Usage
 
 ### Command line output

--- a/crates/uroborosql-fmt-cli/Cargo.toml
+++ b/crates/uroborosql-fmt-cli/Cargo.toml
@@ -11,3 +11,9 @@ repository.workspace = true
 
 [dependencies]
 uroborosql-fmt = { workspace = true }
+clap = { version = "4", features = ["derive"] }
+
+[dev-dependencies]
+assert_cmd = "2"
+assert_fs = "1"
+predicates = "3"

--- a/crates/uroborosql-fmt-cli/README.md
+++ b/crates/uroborosql-fmt-cli/README.md
@@ -1,0 +1,56 @@
+# uroborosql-fmt-cli
+
+## Install
+
+```bash
+cargo install --git https://github.com/future-architect/uroborosql-fmt
+```
+
+## Usage
+
+```bash
+uroborosql-fmt-cli -- [OPTIONS] [INPUT]
+```
+
+### Arguments
+
+* `INPUT` — Path to the SQL file to format.
+  * If omitted, reads from STDIN.
+
+### Options
+
+| Option                    | Description                                                                                              |
+|---------------------------|----------------------------------------------------------------------------------------------------------|
+| `-w`, `--write`           | Overwrite the `INPUT` file with the formatted result. Cannot be used with `--check`.                     |
+| `-c`, `--check`           | Exit with code 2 if formatting changes are detected. Cannot be used with `--write`.                     |
+| `--config <FILE>`         | Specify the configuration file path. Defaults to `.uroborosqlfmtrc.json` in the current directory.      |
+| `-h`, `--help`            | Print help information.                                                                                  |
+| `-V`, `--version`         | Print version information.                                                                               |
+
+### Exit Codes
+
+| Code | Name          | Description                                                                                       |
+|------|---------------|---------------------------------------------------------------------------------------------------|
+| 0    | `Ok`          | Successful completion                                                                             |
+| 1    | `ParseError`  | SQL parsing failed                                                                                |
+| 2    | `OtherError`  | Other errors (config file, I/O, formatting differences detected, option conflicts, etc.)          |
+
+## Examples
+
+```bash
+# Format a file and output to stdout
+uroborosql-fmt-cli query.sql
+
+# Read from STDIN and format
+cat query.sql | uroborosql-fmt-cli
+uroborosql-fmt-cli < query.sql
+
+# Check formatting differences only
+uroborosql-fmt-cli --check query.sql
+
+# Format and overwrite the file
+uroborosql-fmt-cli --write query.sql
+
+# Format with a specific configuration file
+uroborosql-fmt-cli --config mycfg.json query.sql
+```

--- a/crates/uroborosql-fmt-cli/src/cli.rs
+++ b/crates/uroborosql-fmt-cli/src/cli.rs
@@ -1,0 +1,132 @@
+use std::fs;
+use std::io::{self, IsTerminal, Read, Write};
+use std::path::PathBuf;
+
+use clap::Parser;
+
+use uroborosql_fmt::error::UroboroSQLFmtError;
+use uroborosql_fmt::format_sql;
+
+/// Default configuration file name searched in current directory.
+pub const DEFAULT_CONFIG_PATH: &str = ".uroborosqlfmtrc.json";
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Cli {
+    /// Input file. If omitted, read from STDIN.
+    pub input: Option<PathBuf>,
+
+    /// Overwrite the input file with the formatted result.
+    #[arg(long, short = 'w', conflicts_with = "check")]
+    pub write: bool,
+
+    /// Check formatting; exit code 2 if the input is not properly formatted.
+    #[arg(long, short = 'c', conflicts_with = "write")]
+    pub check: bool,
+
+    #[arg(long, value_name = "FILE", default_value = DEFAULT_CONFIG_PATH, help = "Path to configuration file.")]
+    pub config: PathBuf,
+}
+
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ExitCode {
+    Ok = 0,
+    ParseError = 1,
+    OtherError = 2,
+}
+
+/// Run CLI processing and return `Ok(())` or an `ExitCode` on error.
+pub fn run(cli: Cli) -> Result<(), ExitCode> {
+    // 1) Read source SQL
+    let (src, input_path) = match cli.input {
+        Some(ref path) => {
+            let content = fs::read_to_string(path).map_err(|_| ExitCode::OtherError)?;
+            (content, Some(path.clone()))
+        }
+        // ファイルパスが指定されていない場合は標準入力から読み込む
+        None => {
+            if io::stdin().is_terminal() {
+                eprintln!("error: Please provide an INPUT file or pipe SQL to STDIN.");
+                return Err(ExitCode::OtherError);
+            }
+            let mut buf = String::new();
+            io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|_| ExitCode::OtherError)?;
+            (buf, None)
+        }
+    };
+
+    // 2) Resolve config path
+    let config_path: Option<&str> = if cli.config.exists() {
+        cli.config.to_str()
+    } else {
+        None
+    };
+
+    // 3) Format SQL
+    let formatted = format_sql(&src, None, config_path).map_err(|e| match e {
+        UroboroSQLFmtError::ParseError(_) => ExitCode::ParseError,
+        _ => ExitCode::OtherError,
+    })?;
+
+    // 4) Option handling
+    //
+    // write モード:
+    // - 与えられたパスのファイルをフォーマット結果で上書きする
+    // - パスが指定されていなければエラー
+    //
+    // check モード:
+    // - フォーマット結果とソースが異なる場合はエラー
+    // - フォーマット結果とソースが同じ場合は成功
+    //
+    // モード指定なしの場合:
+    // - フォーマット結果を標準出力に出力する
+
+    if cli.write {
+        let Some(path) = input_path else {
+            eprintln!(
+                "error: --write requires an input file path. Piping from STDIN is not supported."
+            );
+            return Err(ExitCode::OtherError);
+        };
+
+        if formatted != src {
+            fs::write(&path, formatted).map_err(|_| ExitCode::OtherError)?;
+            eprintln!("formattting done: {}", path.display());
+        } else {
+            eprintln!("no changes: {}", path.display());
+        }
+        return Ok(());
+    }
+
+    if cli.check {
+        if formatted != src {
+            match input_path {
+                Some(ref path) => {
+                    eprintln!("{}", path.display());
+                    eprintln!(
+                        "Code style issues found in the file. Run uroborosql-fmt-cli with --write to fix."
+                    );
+                }
+                None => {
+                    eprintln!("Code style issues found in STDIN.");
+                }
+            }
+            return Err(ExitCode::OtherError);
+        }
+
+        println!("The input uses uroboroSQL-fmt code style.");
+        return Ok(());
+    }
+
+    // 5) Output to STDOUT
+    let mut stdout = io::stdout();
+    stdout
+        .write_all(formatted.as_bytes())
+        .and_then(|_| stdout.flush())
+        .map_err(|_| ExitCode::OtherError)?;
+
+    Ok(())
+}

--- a/crates/uroborosql-fmt-cli/src/main.rs
+++ b/crates/uroborosql-fmt-cli/src/main.rs
@@ -1,39 +1,14 @@
-use std::fs::read_to_string;
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
+use clap::Parser;
+use std::process::exit;
 
-use uroborosql_fmt::format_sql;
+mod cli;
+
+use cli::{run, Cli, ExitCode};
 
 fn main() {
-    let msg = "arguments error";
-    let input_file = std::env::args().nth(1).expect(msg);
-
-    let output_file = std::env::args().nth(2);
-
-    let src = read_to_string(input_file).unwrap();
-
-    let config_path = match Path::is_file(Path::new("./.uroborosqlfmtrc.json")) {
-        true => Some("./.uroborosqlfmtrc.json"),
-        false => {
-            eprintln!("hint: Create the file '.uroborosqlfmtrc.json' if you want to customize the configuration");
-            None
-        }
-    };
-
-    let result = match format_sql(src.as_ref(), None, config_path) {
-        Ok(res) => res,
-        Err(e) => {
-            eprintln!("{e}");
-            src
-        }
-    };
-
-    match output_file {
-        Some(path) => {
-            let mut file = File::create(path).unwrap();
-            file.write_all(result.as_bytes()).unwrap();
-        }
-        None => println!("{result}"),
+    let cli = Cli::parse();
+    match run(cli) {
+        Ok(()) => exit(ExitCode::Ok as i32),
+        Err(code) => exit(code as i32),
     }
 }

--- a/crates/uroborosql-fmt-cli/tests/cli.rs
+++ b/crates/uroborosql-fmt-cli/tests/cli.rs
@@ -1,0 +1,101 @@
+use assert_cmd::Command;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+use std::fs;
+
+/// Returns a pair (raw_sql, formatted_sql)
+fn sample_sql() -> (&'static str, String) {
+    let raw = "select 1;";
+    let formatted = uroborosql_fmt::format_sql(raw, None, None).unwrap();
+    (raw, formatted)
+}
+
+#[test]
+/// 標準入力からSQLを読み込んでフォーマットする
+fn format_from_stdin() {
+    let (raw, formatted) = sample_sql();
+    let mut cmd = Command::cargo_bin("uroborosql-fmt-cli").unwrap();
+    cmd.write_stdin(raw)
+        .assert()
+        .success()
+        .stdout(predicate::eq(formatted.clone()));
+}
+
+#[test]
+/// check モードと write モードは排他である
+fn check_and_write_mode_conflict() {
+    let mut cmd = Command::cargo_bin("uroborosql-fmt-cli").unwrap();
+    cmd.arg("--check").arg("--write").assert().failure();
+}
+
+#[cfg(test)]
+mod check_mode {
+    use super::*;
+
+    #[test]
+    /// ファイルの内容がフォーマット結果と同じ場合は成功する
+    fn check_mode_detects_no_difference() {
+        let (_raw, formatted) = sample_sql();
+        let file = assert_fs::NamedTempFile::new("ok.sql").unwrap();
+        file.write_str(&formatted).unwrap();
+
+        // uroborosql-fmt-cli --check ok.sql
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .arg("--check")
+            .arg(file.path())
+            .assert()
+            .success();
+    }
+
+    #[test]
+    /// ファイルの内容がフォーマット結果と異なる場合はエラーになる
+    fn check_mode_detects_difference() {
+        let (raw, _formatted) = sample_sql();
+        let file = assert_fs::NamedTempFile::new("ng.sql").unwrap();
+        file.write_str(raw).unwrap();
+
+        // uroborosql-fmt-cli --check ng.sql
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .arg("--check")
+            .arg(file.path())
+            .assert()
+            .failure();
+    }
+}
+
+#[cfg(test)]
+mod write_mode {
+    use super::*;
+
+    #[test]
+    /// ファイルの内容をフォーマット結果で上書きする
+    fn write_mode_overwrites_file() {
+        let (raw, formatted) = sample_sql();
+        let file = assert_fs::NamedTempFile::new("rewrite.sql").unwrap();
+        file.write_str(raw).unwrap();
+
+        // uroborosql-fmt-cli -w rewrite.sql
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .arg("--write")
+            .arg(file.path())
+            .assert()
+            .success();
+
+        let content = fs::read_to_string(file.path()).unwrap();
+        assert_eq!(content, formatted);
+    }
+
+    #[test]
+    /// write モードでパスが指定されていなければ失敗する
+    fn write_mode_fails_without_path() {
+        // uroborosql-fmt-cli -w
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .arg("--write")
+            .assert()
+            .failure();
+    }
+}

--- a/crates/uroborosql-fmt-cli/tests/cli_ext.rs
+++ b/crates/uroborosql-fmt-cli/tests/cli_ext.rs
@@ -1,0 +1,216 @@
+use assert_cmd::Command;
+use assert_fs::{prelude::*, NamedTempFile, TempDir};
+use predicates::ord::eq;
+use std::fs;
+
+use uroborosql_fmt::format_sql;
+const DEFAULT_CONFIG_PATH: &str = ".uroborosqlfmtrc.json";
+
+#[test]
+/// モード指定なしの場合、標準出力にフォーマット結果が出力される
+fn file_to_stdout() {
+    let raw = "select 1;";
+    let formatted = format_sql(raw, None, None).unwrap();
+
+    let file = assert_fs::NamedTempFile::new("input.sql").unwrap();
+    file.write_str(raw).unwrap();
+
+    // uroborosql-fmt-cli input.sql
+    Command::cargo_bin("uroborosql-fmt-cli")
+        .unwrap()
+        .arg(file.path())
+        .assert()
+        .success()
+        .stdout(eq(formatted));
+}
+
+#[cfg(test)]
+mod config {
+    use super::*;
+
+    #[test]
+    /// 設定ファイルを指定してフォーマットする
+    fn custom_config_option() {
+        let raw = "select col1 from tbl;";
+        let config_json = r#"{ "complement_alias": false }"#;
+        let expected = format_sql(raw, Some(config_json), None).unwrap();
+
+        // input file: input.sql
+        let input_file = NamedTempFile::new("input.sql").unwrap();
+        input_file.write_str(raw).unwrap();
+
+        // config file: mycfg.json
+        let config_file = NamedTempFile::new("mycfg.json").unwrap();
+        config_file.write_str(config_json).unwrap();
+
+        // uroborosql-fmt-cli --config mycfg.json input.sql
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .arg("--config")
+            .arg(config_file.path())
+            .arg(input_file.path())
+            .assert()
+            .success()
+            .stdout(eq(expected));
+    }
+
+    #[test]
+    // デフォルトパスの設定ファイルが検出されフォーマットに使用される
+    fn default_config_file_detected() {
+        let raw = "select col1 from tbl;";
+        let config_json = r#"{ "complement_alias": false }"#;
+        let formatted_result_with_default_config =
+            format_sql(raw, Some(config_json), None).unwrap();
+
+        // place default config file
+        let dir = TempDir::new().unwrap();
+        let default_config_file = dir.child(DEFAULT_CONFIG_PATH);
+        default_config_file.write_str(config_json).unwrap();
+
+        let input_file = dir.child("q.sql");
+        input_file.write_str(raw).unwrap();
+
+        // uroborosql-fmt-cli q.sql
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .current_dir(&dir)
+            .arg(input_file.path())
+            .assert()
+            .success()
+            .stdout(eq(formatted_result_with_default_config));
+    }
+
+    #[test]
+    // 明示的に設定ファイルを指定するとデフォルト設定のパスよりも優先される
+    fn config_option_overrides_default() {
+        let raw = "select col1 from tbl;";
+        let default_config_json = r#"{ "complement_alias": false }"#;
+        let explicit_config_json = r#"{ "complement_alias": true }"#;
+        let formatted_result_with_explicit_config =
+            format_sql(raw, Some(explicit_config_json), None).unwrap();
+
+        let dir = TempDir::new().unwrap();
+        // default config file
+        let default_config_file = dir.child(DEFAULT_CONFIG_PATH);
+        default_config_file.write_str(default_config_json).unwrap();
+
+        // explicit config file
+        let explicit_config_file = dir.child("exp.json");
+        explicit_config_file
+            .write_str(explicit_config_json)
+            .unwrap();
+
+        let input_file = dir.child("q.sql");
+        input_file.write_str(raw).unwrap();
+
+        // uroborosql-fmt-cli --config exp.json q.sql
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .current_dir(&dir)
+            .arg("--config")
+            .arg(explicit_config_file.path())
+            .arg(input_file.path())
+            .assert()
+            .success()
+            .stdout(eq(formatted_result_with_explicit_config));
+    }
+}
+
+#[cfg(test)]
+mod exit_code {
+    use super::*;
+
+    #[test]
+    // パースエラーの場合、終了コード 1 (ParseError) を返す
+    fn parse_error_exit_code() {
+        let invalid_sql = "SELECT FROM";
+
+        // uroborosql-fmt-cli < echo "SELECT FROM"
+        // error code 1
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .write_stdin(invalid_sql)
+            .assert()
+            .code(1);
+    }
+
+    #[test]
+    /// 不正な設定ファイルの場合、終了コード 2 (OtherError) を返す
+    fn invalid_config_exit_other_error() {
+        let invalid_json = "{ invalid json }";
+
+        let config_file = NamedTempFile::new("bad.json").unwrap();
+        config_file.write_str(invalid_json).unwrap();
+        let input_file = NamedTempFile::new("input.sql").unwrap();
+        input_file.write_str("select 1;").unwrap();
+
+        // uroborosql-fmt-cli --config bad.json input.sql
+        // error code 2
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .arg("--config")
+            .arg(config_file.path())
+            .arg(input_file.path())
+            .assert()
+            .code(2);
+    }
+
+    #[test]
+    /// 入力なしの場合、終了コード 2 (OtherError) を返す
+    fn no_input_exit_other_error() {
+        // uroborosql-fmt-cli
+        // error code 2
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .assert()
+            .code(2);
+    }
+
+    #[test]
+    /// 存在しないファイルの場合、終了コード 2 (OtherError) を返す
+    fn nonexistent_file_exit_other_error() {
+        // uroborosql-fmt-cli no_such_file.sql
+        // error code 2
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .arg("no_such_file.sql")
+            .assert()
+            .code(2);
+    }
+
+    #[test]
+    /// 読み取り専用ファイルに書き込みを試みると終了コード 2 (OtherError) を返す
+    fn write_readonly_file_exit_other_error() {
+        let raw = "select 1;";
+
+        let file = NamedTempFile::new("ro.sql").unwrap();
+        file.write_str(raw).unwrap();
+
+        let mut perm = fs::metadata(file.path()).unwrap().permissions();
+        perm.set_readonly(true);
+        fs::set_permissions(file.path(), perm).unwrap();
+
+        // uroborosql-fmt-cli -w ro.sql
+        // error code 2
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .arg("-w")
+            .arg(file.path())
+            .assert()
+            .code(2);
+    }
+
+    #[test]
+    /// -w と --check が競合する場合、終了コード 2 (OtherError) を返す
+    fn write_and_check_conflict() {
+        // uroborosql-fmt-cli -w --check
+        // error code 2
+        Command::cargo_bin("uroborosql-fmt-cli")
+            .unwrap()
+            .arg("-w")
+            .arg("--check")
+            .assert()
+            .failure() // clap returns non-zero; exact code 2
+            .code(2);
+    }
+}


### PR DESCRIPTION
## Summary 
CLI 版に機能を追加しました。

主な変更点は以下です。
- 標準入出力対応
- 終了コード出し分け
- config file のパス指定

具体的な仕様は [CLI版の README](https://github.com/future-architect/uroborosql-fmt/blob/feat/cli-improvement/crates/uroborosql-fmt-cli/README.md) に記載しました。
