### PR TITLE
Support order_by collate

### DIFF
--- a/crates/uroborosql-fmt/src/visitor/expr/a_expr.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/a_expr.rs
@@ -1,6 +1,7 @@
 mod all_some_any_subquery;
 mod arithmetic;
 mod between;
+mod collate_expr;
 mod comparison;
 mod in_expr;
 mod is_expr;
@@ -126,14 +127,16 @@ impl Visitor {
                 let expr = self.handle_typecast_nodes(cursor, src, lhs)?;
                 Ok(expr)
             }
-            // 属性関連
-            SyntaxKind::COLLATE | SyntaxKind::AT => {
-                Err(UroboroSQLFmtError::Unimplemented(format!(
-                    "handle_nodes_after_a_expr(): {} is not implemented.\n{}",
-                    cursor.node().kind(),
-                    error_annotation_from_cursor(cursor, src)
-                )))
+            // COLLATE
+            SyntaxKind::COLLATE => {
+                let aligned = self.handle_collate_expr_nodes(cursor, src, lhs)?;
+                Ok(Expr::Aligned(Box::new(aligned)))
             }
+            SyntaxKind::AT => Err(UroboroSQLFmtError::Unimplemented(format!(
+                "handle_nodes_after_a_expr(): {} is not implemented.\n{}",
+                cursor.node().kind(),
+                error_annotation_from_cursor(cursor, src)
+            ))),
             SyntaxKind::LIKE | SyntaxKind::ILIKE => {
                 // LIKE, ILIKE は同じ構造
                 let aligned = self.handle_like_expr_nodes(cursor, src, lhs, None)?;

--- a/crates/uroborosql-fmt/src/visitor/expr/a_expr/collate_expr.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/a_expr/collate_expr.rs
@@ -1,0 +1,65 @@
+use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::TreeCursor};
+
+use crate::{
+    cst::{AlignedExpr, Comment, Expr, PrimaryExpr, PrimaryExprKind},
+    error::UroboroSQLFmtError,
+    util::convert_keyword_case,
+    visitor::{ensure_kind, error_annotation_from_cursor},
+};
+
+use super::super::Visitor;
+
+impl Visitor {
+    /// 左辺の式を受け取り、COLLATE にあたるノード群を走査する
+    ///
+    /// 呼出時、 cursor は COLLATE を指している
+    /// 呼出後、 cursor は any_name を指している
+    ///
+    pub fn handle_collate_expr_nodes(
+        &mut self,
+        cursor: &mut TreeCursor,
+        src: &str,
+        lhs: Expr,
+    ) -> Result<AlignedExpr, UroboroSQLFmtError> {
+        // a_expr COLLATE any_name
+        // ^      ^       ^
+        // lhs    │       └ 呼出後
+        //        └ 呼出時
+
+        // cursor -> COLLATE
+        ensure_kind!(cursor, SyntaxKind::COLLATE, src);
+        let collate = convert_keyword_case(cursor.node().text());
+        cursor.goto_next_sibling();
+
+        // cursor -> comment?
+        // バインドパラメータを想定
+        let bind_param = if cursor.node().is_comment() {
+            let comment = Comment::new(cursor.node());
+            cursor.goto_next_sibling();
+
+            Some(comment)
+        } else {
+            None
+        };
+
+        // cursor -> any_name
+        ensure_kind!(cursor, SyntaxKind::any_name, src);
+        let mut any_name = PrimaryExpr::with_node(cursor.node(), PrimaryExprKind::Expr)?;
+
+        if let Some(comment) = bind_param {
+            if comment.is_block_comment() && comment.loc().is_next_to(&any_name.loc()) {
+                any_name.set_head_comment(comment);
+            } else {
+                return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
+                    "handle_collate_expr_nodes(): Unexpected comment\n{}",
+                    error_annotation_from_cursor(cursor, src)
+                )));
+            }
+        }
+
+        let mut aligned = AlignedExpr::new(lhs);
+        aligned.add_rhs(Some(collate), Expr::Primary(Box::new(any_name)));
+
+        Ok(aligned)
+    }
+}

--- a/crates/uroborosql-fmt/test_normal_cases/dst/105_order_by_collate.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/105_order_by_collate.sql
@@ -1,0 +1,8 @@
+select
+	*
+from
+	multilingual_test
+order by
+	japanese_text	collate	/*$LC_COLLATE*/"ja_JP.UTF-8"	desc
+,	german_text	collate	"de_DE.UTF-8"
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/105_order_by_collate.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/105_order_by_collate.sql
@@ -1,0 +1,8 @@
+SELECT
+    *
+FROM multilingual_test
+ORDER BY
+japanese_text
+     COLLATE 
+     /*$LC_COLLATE*/"ja_JP.UTF-8"        DESC,
+    german_text COLLATE          "de_DE.UTF-8";


### PR DESCRIPTION
Close #103

order by中のcollateに対応しました。


**format前**
```sql
SELECT
    *
FROM multilingual_test
ORDER BY
japanese_text
     COLLATE 
     /*$LC_COLLATE*/"ja_JP.UTF-8"        DESC,
    german_text COLLATE          "de_DE.UTF-8";
```

**format後**
```sql
select
	*
from
	multilingual_test
order by
	japanese_text	collate	/*$LC_COLLATE*/"ja_JP.UTF-8"	desc
,	german_text	collate	"de_DE.UTF-8"
;
```