### PR TITLE
Preserve case of comments in WHERE clauses

### DIFF
--- a/crates/uroborosql-fmt/src/visitor/expr/c_expr/columnref.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/c_expr/columnref.rs
@@ -25,7 +25,7 @@ impl Visitor {
         ensure_kind!(cursor, SyntaxKind::ColId, src);
 
         // ColId、indirectionで出現するノードを大文字小文字変換済みの文字列として順にpushしていく
-        // 途中で出現するバインドパラメータは大文字小文字変換を行わずそのまま文字列としてpushする
+        // 途中で出現する置換文字列は大文字小文字変換を行わずそのまま文字列としてpushする
         let mut columnref_text = convert_identifier_case(cursor.node().text());
 
         if cursor.goto_next_sibling() {
@@ -63,10 +63,10 @@ impl Visitor {
                                     .loc()
                                     .is_next_to(&Location::from(cursor.node().range()))
                             {
-                                // バインドパラメータの場合
+                                // 置換文字列の場合
                                 columnref_text.push_str(comment.text());
                             } else {
-                                // コメントがバインドパラメータではない場合はエラー
+                                // コメントが置換文字列ではない場合はエラー
                                 return Err(UroboroSQLFmtError::UnexpectedSyntax(format!(
                                     "visit_columnref(): unexpected comment node appeared.\n{}",
                                     error_annotation_from_cursor(cursor, src)
@@ -101,7 +101,7 @@ impl Visitor {
         }
 
         // アスタリスクが含まれる場合はAsteriskExprに変換する
-        // 単純に*が含まれるかどうかで判定すると、途中にバインドパラメータが含まれる場合もtrueとなるため、「*と完全一致」または「.*が含まれる」の場合にAsteriskExprに変換する
+        // 単純に*が含まれるかどうかで判定すると、途中に置換文字列が含まれる場合もtrueとなるため、「*と完全一致」または「.*が含まれる」の場合にAsteriskExprに変換する
         // また、columnref_textは既にcase変換済みなため、ここでは行わない
         let expr = if columnref_text == "*" || columnref_text.contains(".*") {
             AsteriskExpr::new(&columnref_text, cursor.node().range().into()).into()

--- a/crates/uroborosql-fmt/src/visitor/expr/c_expr/columnref.rs
+++ b/crates/uroborosql-fmt/src/visitor/expr/c_expr/columnref.rs
@@ -101,7 +101,8 @@ impl Visitor {
         }
 
         // アスタリスクが含まれる場合はAsteriskExprに変換する
-        // columnref_textは既にcase変換済みなため、ここでは行わない
+        // 単純に*が含まれるかどうかで判定すると、途中にバインドパラメータが含まれる場合もtrueとなるため、「*と完全一致」または「.*が含まれる」の場合にAsteriskExprに変換する
+        // また、columnref_textは既にcase変換済みなため、ここでは行わない
         let expr = if columnref_text == "*" || columnref_text.contains(".*") {
             AsteriskExpr::new(&columnref_text, cursor.node().range().into()).into()
         } else {

--- a/crates/uroborosql-fmt/test_normal_cases/dst/106_bind_param_columnref.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/106_bind_param_columnref.sql
@@ -1,0 +1,9 @@
+select /* _SQL_ID_ */
+	*
+from
+	tbl
+where
+	tbl./*$targetColumnName1*/col1											is	null
+and	schema1.tbl./*$targetColumnName2*/col2
+and	/*$targetColumnName1*/col1	+	tbl./*$targetColumnName2*/col2	=	10	is	not	null
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/106_bind_param_columnref.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/106_bind_param_columnref.sql
@@ -3,7 +3,7 @@ select /* _SQL_ID_ */
 from
 	tbl
 where
-	tbl./*$targetColumnName1*/col1											is	null
-and	schema1.tbl./*$targetColumnName2*/col2
-and	/*$targetColumnName1*/col1	+	tbl./*$targetColumnName2*/col2	=	10	is	not	null
+	tbl./*$targetColumnName1*/col1									is	null
+and	schema1.tbl./*$targetColumnName2*/col2							is	not	null
+and	/*$targetColumnName1*/col1	+	tbl./*$targetColumnName2*/col2	=	10
 ;

--- a/crates/uroborosql-fmt/test_normal_cases/src/106_bind_param_columnref.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/106_bind_param_columnref.sql
@@ -5,6 +5,6 @@ from
 where
 	tbl./*$targetColumnName1*/col1	
 	is	null
-and  		schema1. tbl./*$targetColumnName2*/col2
+and  		schema1. tbl./*$targetColumnName2*/col2 is not null
 and /*$targetColumnName1*/col1 + tbl.   /*$targetColumnName2*/col2 = 10
-is not null;
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/106_bind_param_columnref.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/106_bind_param_columnref.sql
@@ -1,0 +1,10 @@
+select /* _SQL_ID_ */
+	*
+from
+	tbl
+where
+	tbl./*$targetColumnName1*/col1	
+	is	null
+and  		schema1. tbl./*$targetColumnName2*/col2
+and /*$targetColumnName1*/col1 + tbl.   /*$targetColumnName2*/col2 = 10
+is not null;


### PR DESCRIPTION
Close #207

テーブル参照で置換文字列を使用するとコメントのcaseが変換されてしまうバグを修正しました。

原因は`visitor/expr/c_expr/columnref.rs`において、`indirection`をそのままテキストに変換して大文字小文字変換を行っていたため、以下のように`indirection`の子に`C_COMMENT`が含まれていた場合にコメントも同時に大文字小文字変換してしまっていたためでした。

```
indirection [(5, 4)-(5, 31)]
  indirection_el [(5, 4)-(5, 31)]
    Dot [(5, 4)-(5, 5)]
    C_COMMENT [(5, 5)-(5, 27)]
    attr_name [(5, 27)-(5, 31)]
      ColLabel [(5, 27)-(5, 31)]
        IDENT [(5, 27)-(5, 31)]
```


before:
```sql
select /* _SQL_ID_ */
	*
from
	tbl
where
	tbl./*$targetColumnName1*/col1	
	is	null
and  		schema1. tbl./*$targetColumnName2*/col2 is not null
and /*$targetColumnName1*/col1 + tbl.   /*$targetColumnName2*/col2 = 10
;
```

after:
```sql
select /* _SQL_ID_ */
	*
from
	tbl
where
	tbl./*$targetColumnName1*/col1									is	null
and	schema1.tbl./*$targetColumnName2*/col2							is	not	null
and	/*$targetColumnName1*/col1	+	tbl./*$targetColumnName2*/col2	=	10
;
```