### PR TITLE
Support bind parameter immediately after JOIN keyword

### DIFF
--- a/crates/uroborosql-fmt/src/visitor/clause/from/table_ref/joined_table.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/from/table_ref/joined_table.rs
@@ -138,7 +138,16 @@ impl Visitor {
                 }
 
                 // cursor -> table_ref
-                let right = self.visit_table_ref(cursor, src)?;
+                let mut right = self.visit_table_ref(cursor, src)?;
+
+                // comments_after_join_keywordの最後の要素がバインドパラメータかどうか調べ、
+                // バインドパラメータであればrightにセットする
+                if let Some(comment) = comments_after_join_keyword.last() {
+                    if comment.is_block_comment() && comment.loc().is_next_to(&right.loc()) {
+                        // last()がSome()であるため、pop().unwrap()は必ず成功する
+                        right.set_head_comment(comments_after_join_keyword.pop().unwrap());
+                    }
+                }
 
                 cursor.goto_next_sibling();
 

--- a/crates/uroborosql-fmt/test_normal_cases/dst/107_bind_param_after_join.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/107_bind_param_after_join.sql
@@ -1,0 +1,8 @@
+select
+	*
+from
+	tbl1
+join
+	/*$tableName*/tbl2
+on
+	tbl1.id	=	tbl2.id

--- a/crates/uroborosql-fmt/test_normal_cases/src/107_bind_param_after_join.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/107_bind_param_after_join.sql
@@ -1,0 +1,1 @@
+select * from tbl1 join /*$tableName*/tbl2 on tbl1.id = tbl2.id


### PR DESCRIPTION
Close #209 

JOINキーワード直後にバインドパラメータが出現した場合、バインドパラメータの直後に改行が含まれてしまうバグを修正しました。

**before**
```sql
select * from tbl1 join /*$tableName*/tbl2 on tbl1.id = tbl2.id
```

**after**
```sql
select
	*
from
	tbl1
join
	/*$tableName*/tbl2
on
	tbl1.id	=	tbl2.id
```