### PR TITLE
#115 fix: support CRLF line endings

### DIFF
--- a/crates/uroborosql-fmt/src/lib.rs
+++ b/crates/uroborosql-fmt/src/lib.rs
@@ -38,7 +38,8 @@ pub(crate) fn format_sql_with_config(
     config: Config,
 ) -> Result<String, UroboroSQLFmtError> {
     // CRLF を LF に正規化して、改行コードによる挙動の差異を防ぐ
-    let src = &src.replace("\r\n", "\n");
+    let src_owned = src.replace("\r\n", "\n");
+    let src = src_owned.as_str();
 
     load_settings(config.clone());
 

--- a/crates/uroborosql-fmt/src/lib.rs
+++ b/crates/uroborosql-fmt/src/lib.rs
@@ -37,6 +37,9 @@ pub(crate) fn format_sql_with_config(
     src: &str,
     config: Config,
 ) -> Result<String, UroboroSQLFmtError> {
+    // CRLF を LF に正規化して、改行コードによる挙動の差異を防ぐ
+    let src = &src.replace("\r\n", "\n");
+
     load_settings(config.clone());
 
     // パーサの2way-sql用エラー回復機能を使うかどうか

--- a/crates/uroborosql-fmt/test_normal_cases/dst/110_crlf_hint_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/110_crlf_hint_comment.sql
@@ -1,0 +1,5 @@
+/*+
+	comment
+*/
+select
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/111_crlf_block_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/111_crlf_block_comment.sql
@@ -1,0 +1,6 @@
+/*
+ * comment
+ */
+select
+	1
+;

--- a/crates/uroborosql-fmt/test_normal_cases/dst/112_crlf_line_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/dst/112_crlf_line_comment.sql
@@ -1,0 +1,4 @@
+-- line comment
+select
+	1
+;

--- a/crates/uroborosql-fmt/test_normal_cases/src/110_crlf_hint_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/110_crlf_hint_comment.sql
@@ -1,0 +1,4 @@
+/*+
+	comment
+*/
+SELECT;

--- a/crates/uroborosql-fmt/test_normal_cases/src/111_crlf_block_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/111_crlf_block_comment.sql
@@ -1,0 +1,4 @@
+/*
+ * comment
+ */
+SELECT 1;

--- a/crates/uroborosql-fmt/test_normal_cases/src/112_crlf_line_comment.sql
+++ b/crates/uroborosql-fmt/test_normal_cases/src/112_crlf_line_comment.sql
@@ -1,0 +1,4 @@
+-- line comment
+SELECT
+	1
+;

--- a/crates/uroborosql-fmt/tests/normal_cases.rs
+++ b/crates/uroborosql-fmt/tests/normal_cases.rs
@@ -176,42 +176,7 @@ fn test_normal_cases() {
     for case in cases {
         println!("\nTesting: {}", case.name);
 
-        let result = match uroborosql_fmt::format_sql(&case.sql, None, None) {
-            Ok(formatted) => {
-                if formatted == case.expected {
-                    println!("✅ Test passed");
-                    TestResult {
-                        name: case.name,
-                        status: TestStatus::Pass,
-                        input: case.sql,
-                        expected: case.expected,
-                        got: Some(formatted),
-                        error: None,
-                    }
-                } else {
-                    println!("❌ Test failed");
-                    TestResult {
-                        name: case.name,
-                        status: TestStatus::Fail,
-                        input: case.sql,
-                        expected: case.expected,
-                        got: Some(formatted),
-                        error: None,
-                    }
-                }
-            }
-            Err(e) => {
-                println!("💥 Test error");
-                TestResult {
-                    name: case.name,
-                    status: TestStatus::Error,
-                    input: case.sql,
-                    expected: case.expected,
-                    got: None,
-                    error: Some(e.to_string()),
-                }
-            }
-        };
+        let result = run_format_test(&case.name, case.sql, case.expected);
 
         // エラー時にテストを中止するモードの場合
         if options.fail_fast {
@@ -228,6 +193,107 @@ fn test_normal_cases() {
         } else {
             results.push(result);
         }
+    }
+
+    print_test_report(&results);
+}
+
+fn run_format_test(name: &str, sql: String, expected: String) -> TestResult {
+    match uroborosql_fmt::format_sql(&sql, None, None) {
+        Ok(formatted) => {
+            if formatted == expected {
+                println!("✅ Test passed");
+                TestResult {
+                    name: name.to_string(),
+                    status: TestStatus::Pass,
+                    input: sql,
+                    expected,
+                    got: Some(formatted),
+                    error: None,
+                }
+            } else {
+                println!("❌ Test failed");
+                TestResult {
+                    name: name.to_string(),
+                    status: TestStatus::Fail,
+                    input: sql,
+                    expected,
+                    got: Some(formatted),
+                    error: None,
+                }
+            }
+        }
+        Err(e) => {
+            println!("💥 Test error");
+            TestResult {
+                name: name.to_string(),
+                status: TestStatus::Error,
+                input: sql,
+                expected,
+                got: None,
+                error: Some(e.to_string()),
+            }
+        }
+    }
+}
+
+/// CRLF改行コードを含むSQLが正しくフォーマットされることを確認する。
+///
+/// テストファイルは test_normal_cases にも配置されており、
+/// test_normal_cases() では LF 版、本テストでは CRLF 版として両方検証される。
+///
+/// issue: https://github.com/future-architect/uroborosql-fmt/issues/115
+#[test]
+fn test_crlf_cases() {
+    let src_dir = Path::new("test_normal_cases/src");
+    let dst_dir = Path::new("test_normal_cases/dst");
+
+    let crlf_cases = vec![
+        "110_crlf_hint_comment",
+        "111_crlf_block_comment",
+        "112_crlf_line_comment",
+    ];
+
+    let mut results = Vec::new();
+
+    for name in &crlf_cases {
+        println!("\nTesting (CRLF): {name}");
+
+        let src_path = src_dir.join(format!("{name}.sql"));
+        let dst_path = dst_dir.join(format!("{name}.sql"));
+
+        let sql_lf = match fs::read_to_string(&src_path) {
+            Ok(s) => s.replace("\r\n", "\n"),
+            Err(e) => {
+                results.push(TestResult {
+                    name: name.to_string(),
+                    status: TestStatus::Error,
+                    input: String::new(),
+                    expected: String::new(),
+                    got: None,
+                    error: Some(format!("Failed to read src: {e}")),
+                });
+                continue;
+            }
+        };
+        let expected = match fs::read_to_string(&dst_path) {
+            Ok(s) => s,
+            Err(e) => {
+                results.push(TestResult {
+                    name: name.to_string(),
+                    status: TestStatus::Error,
+                    input: sql_lf,
+                    expected: String::new(),
+                    got: None,
+                    error: Some(format!("Failed to read dst: {e}")),
+                });
+                continue;
+            }
+        };
+
+        let sql_crlf = sql_lf.replace('\n', "\r\n");
+
+        results.push(run_format_test(name, sql_crlf, expected));
     }
 
     print_test_report(&results);


### PR DESCRIPTION
## Summary

- CRLF 改行コードを含む SQL ファイルが正しくフォーマットされるよう対応
- `format_sql_with_config()` の先頭で CRLF を LF に正規化
- Windows の `core.autocrlf=true` 環境での動作を保証
- テストコード のリファクタリング（`run_format_test` 関数を抽出）

## Changes

- **lib.rs**: CRLF → LF の正規化処理を追加
- **normal_cases.rs**: 
  - `run_format_test()` ヘルパー関数を抽出（重複コードの削減）
  - `test_crlf_cases()` テスト関数を追加（新 CRLF テストケースの検証）
- **test_normal_cases/**: CRLF テストケースを 3 個追加
  - `110_crlf_hint_comment.sql`
  - `111_crlf_block_comment.sql`
  - `112_crlf_line_comment.sql`

## Test plan

- [x] `cargo test --workspace` — 全テスト通過
- [x] `git diff --exit-code` — テスト実行時のファイル変更なし
- [x] 新 `test_crlf_cases()` が CRLF インプットで動作確認
- [x] 既存の `test_normal_cases()` で LF インプットの互換性確認