### PR TITLE
feat: automate version management with release-plz

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ permissions:
 "on":
   push:
     branches: [main]
+    tags: ["v*"]
     paths-ignore:
       - "**/*.md"
       - LICENSE
@@ -179,15 +180,16 @@ jobs:
         with:
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  deploy-to-gh-pages:
+  # NAPI バイナリを npm pack して GitHub Release のアセットにアップロード
+  upload-napi-to-release:
     if: github.repository == 'future-architect/uroborosql-fmt' &&
-      contains('refs/heads/main', github.ref) && github.event_name == 'push'
-    needs: [build-wasm, build-napi]
+      startsWith(github.ref, 'refs/tags/v')
+    needs: build-napi
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           check-latest: true
@@ -197,8 +199,16 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }}
         run: yarn install
 
+      # タグからバージョンを取得し、NAPI の package.json を同期する
+      # npm pack がタグと一致するファイル名（例: uroborosql-fmt-napi-1.0.2.tgz）を生成するために必要
+      - name: Sync NAPI package.json version from tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "Syncing NAPI package.json version to ${VERSION}"
+          jq --arg v "$VERSION" '.version = $v' ${{ env.WORKING_DIR }}/package.json > tmp.json
+          mv tmp.json ${{ env.WORKING_DIR }}/package.json
+
       # *.node のダウンロード
-      # TODO: まとめてダウンロードできないか？
       - name: Download .node file for aarch64-apple-darwin
         uses: actions/download-artifact@v4
         with:
@@ -235,10 +245,28 @@ jobs:
           mv *.node repo
           cd repo
           npm pack
-          cd ..
-          cd ..
-          cd ..
-          mv ${{ env.WORKING_DIR }}/repo/*.tgz ./wasm
+
+      - name: Upload .tgz to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${GITHUB_REF_NAME}" ${{ env.WORKING_DIR }}/repo/*.tgz --clobber
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: ./.github/actions/slack-failure-notify
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: failure
+
+  # WASM デモページを GitHub Pages にデプロイ
+  deploy-wasm-to-gh-pages:
+    if: github.repository == 'future-architect/uroborosql-fmt' &&
+      startsWith(github.ref, 'refs/tags/v')
+    needs: build-wasm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Download wasm
         uses: actions/download-artifact@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,9 +71,9 @@ jobs:
       run:
         working-directory: ./crates/uroborosql-fmt-napi
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}
         with:
           node-version: 18
@@ -87,7 +87,7 @@ jobs:
           toolchain: stable
           targets: ${{ matrix.settings.target }}
       - name: Cache cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry/index/
@@ -111,7 +111,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Setup node x86
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         if: matrix.settings.target == 'i686-pc-windows-msvc'
         with:
           node-version: 18
@@ -150,7 +150,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup cargo
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -27,6 +27,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run release-plz
-        uses: release-plz/action@v0.5
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # デフォルトの GITHUB_TOKEN で作成したタグは他のワークフローをトリガーしないため、
-          # PAT (Personal Access Token) を使用する。
-          # PAT がまだ設定されていない場合は GITHUB_TOKEN にフォールバック。
-          token: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+          # RELEASE_PLZ_TOKEN (PAT) が必須。
+          # デフォルトの GITHUB_TOKEN で作成したタグは他のワークフロー (on: push: tags) を
+          # トリガーしないため、PAT を使用する必要がある。
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -29,5 +29,4 @@ jobs:
       - name: Run release-plz
         uses: release-plz/action@v0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,33 @@
+name: Release-plz
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-plz:
+    runs-on: ubuntu-latest
+    # fork からの実行を防止
+    if: github.repository == 'future-architect/uroborosql-fmt'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # デフォルトの GITHUB_TOKEN で作成したタグは他のワークフローをトリガーしないため、
+          # PAT (Personal Access Token) を使用する。
+          # PAT がまだ設定されていない場合は GITHUB_TOKEN にフォールバック。
+          token: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Send Notification to Slack
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   test-and-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup cargo
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
+version = "1.0.1"
 authors = ["Future Corporation"]
 edition = "2021"
 license = "BUSL-1.1"

--- a/crates/uroborosql-fmt-cli/Cargo.toml
+++ b/crates/uroborosql-fmt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uroborosql-fmt-cli"
-version = "1.0.1"
+version.workspace = true
 description = "Crate to run uroborosql-fmt on the CLI"
 authors.workspace = true
 edition.workspace = true

--- a/crates/uroborosql-fmt-napi/Cargo.toml
+++ b/crates/uroborosql-fmt-napi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "uroborosql-fmt-napi"
-version = "1.0.1"
+version.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/uroborosql-fmt-wasm/Cargo.toml
+++ b/crates/uroborosql-fmt-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uroborosql-fmt-wasm"
-version = "1.0.1"
+version.workspace = true
 description = "Crate to build uroborosql-fmt wasm"
 authors.workspace = true
 edition.workspace = true

--- a/crates/uroborosql-fmt/Cargo.toml
+++ b/crates/uroborosql-fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uroborosql-fmt"
-version = "1.0.1"
+version.workspace = true
 description = "The core of uroborosql-fmt"
 authors.workspace = true
 edition.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,8 @@
 [workspace]
 # crates.io には公開しない（GitHub Releases + GitHub Pages でのみ配布）
-publish = false
+# git_only を有効にすると、レジストリではなく Git タグから最新バージョンを判定し、
+# publish も自動的に無効になる
+git_only = true
 # semver 互換性チェックは不要（crates.io 非公開のため）
 semver_check = false
 # デフォルトではタグ・リリース・CHANGELOG を無効にし、コアパッケージのみで有効化

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,19 @@
+[workspace]
+# crates.io には公開しない（GitHub Releases + GitHub Pages でのみ配布）
+publish = false
+# semver 互換性チェックは不要（crates.io 非公開のため）
+semver_check = false
+# デフォルトではタグ・リリース・CHANGELOG を無効にし、コアパッケージのみで有効化
+git_tag_enable = false
+git_release_enable = false
+changelog_update = false
+
+# コアパッケージのみがタグ・GitHub Release・CHANGELOG を管理する
+# （全クレートのバージョンは workspace 継承で同期される）
+[[package]]
+name = "uroborosql-fmt"
+git_tag_enable = true
+git_tag_name = "v{{ version }}"
+git_release_enable = true
+changelog_update = true
+changelog_path = "CHANGELOG.md"


### PR DESCRIPTION
## 概要

バージョン管理を手動（[#214](https://github.com/future-architect/uroborosql-fmt/pull/214) のような bump up PR）から [release-plz](https://release-plz.dev/) による自動化に移行する。

## 背景

- バージョン番号を各 Cargo.toml / package.json に手動で書き換えていた
- CHANGELOG がない
- Git タグがない
- main への push ごとに GitHub Pages へデプロイされ、リリースの概念が曖昧だった

## 変更内容

### 1. Cargo.toml: workspace version の一元化

全クレートのバージョンを `[workspace.package]` で一元管理するように変更。

```toml
# ルート Cargo.toml
[workspace.package]
version = "1.0.1"

# 各クレートの Cargo.toml
version.workspace = true
```

### 2. release-plz の導入

- `release-plz.toml`: crates.io 非公開、コアクレートのみがタグ/Release/CHANGELOG を管理
- `.github/workflows/release-plz.yml`: main push → Release PR 自動作成 → マージ後タグ自動作成

### 3. NAPI .tgz の配布先を GitHub Pages から GitHub Releases に移行

これまで NAPI バイナリ (.tgz) は GitHub Pages にデプロイしていたが、`force_orphan: true` により新バージョンのデプロイで旧バージョンが消えてしまう問題があった。GitHub Releases のアセットに変更することで、**バージョンごとに .tgz が保持される**ようになる。

| | Before | After |
|---|---|---|
| NAPI .tgz | GitHub Pages (`force_orphan` で上書き) | **GitHub Releases のアセット** |
| WASM (デモ用) | GitHub Pages | GitHub Pages (変更なし) |
| ダウンロード URL | `https://future-architect.github.io/uroborosql-fmt/uroborosql-fmt-napi-X.Y.Z.tgz` | `https://github.com/future-architect/uroborosql-fmt/releases/download/vX.Y.Z/uroborosql-fmt-napi-X.Y.Z.tgz` |

> vscode-uroborosql-fmt 側のダウンロード URL も合わせて変更が必要（別 PR で対応）。

### 4. CI.yml: デプロイフローの改善

- **トリガー**: `tags: ["v*"]` を追加し、タグ push 時のみデプロイ
- **ジョブ分離**: 旧 `deploy-to-gh-pages` を2ジョブに分離
  - `upload-napi-to-release`: NAPI .tgz を GitHub Release にアップロード（`gh release upload`）
  - `deploy-wasm-to-gh-pages`: WASM のみ GitHub Pages にデプロイ（デモページ用）
- **バージョン同期**: デプロイ時にタグからバージョンを取得し、NAPI の package.json を自動同期

### 5. ドキュメント

- `docs/release-plz-migration.md`: 設計の経緯・フロー・手動作業まとめ

## リリースフロー: Before / After

### Before（手動）

```
1. 開発者がコードを変更して main にマージ
2. main push で自動的に NAPI + WASM がビルド・デプロイ（GitHub Pages）
   → リリースの区切りが曖昧（main push = デプロイ）
3. リリースしたいとき、手動で全 Cargo.toml / package.json のバージョンを書き換え
4. bump up PR を作成してマージ（#214）
   → CHANGELOG なし、Git タグなし、GitHub Release なし
```

### After（release-plz で自動化）

```
1. 開発者が Conventional Commits (feat: / fix: 等) でコミットし main にマージ
2. release-plz が自動で Release PR を作成
   → Cargo.toml のバージョン更新 + CHANGELOG.md 生成
3. Release PR をレビュー & マージ
4. release-plz が Git タグ (v1.0.2) + GitHub Release を自動作成
5. CI がタグトリガーで起動
   → NAPI ビルド → .tgz を GitHub Release にアップロード
   → WASM ビルド → GitHub Pages にデプロイ（デモ用）
```

### 比較

| | Before | After |
|---|---|---|
| バージョン更新 | 手動で全ファイル書き換え | release-plz が自動更新 |
| CHANGELOG | なし | 自動生成 |
| Git タグ | なし | 自動作成 (v1.0.2) |
| GitHub Release | なし | 自動作成 |
| デプロイ契機 | main push（毎回） | タグ push（リリース時のみ） |
| NAPI 配布先 | GitHub Pages（上書き） | GitHub Releases（バージョンごとに保持） |

## マージ前の TODO

- [x] **PAT の作成と登録** — Classic PAT を `repo` スコープで作成し、リポジトリの Secrets に `RELEASE_PLZ_TOKEN` として登録する。デフォルトの `GITHUB_TOKEN` で作成したタグは他のワークフローをトリガーしないため必須。Fine-grained PAT はリポジトリ単位で権限を絞れるが、組織に所属していないと Resource owner に組織を指定できないため Classic PAT を使用する。
- [ ] **Conventional Commits の運用開始**（推奨） — `feat:` → minor, `fix:` → patch, `feat!:` → major。従来のコミットも patch として扱われるため段階的に移行可能。

## 検討事項

- **CLI バイナリも GitHub Release に含めるか** — 現時点では NAPI .tgz のみ。需要が出たら追加する。
- **PAT の代わりに GitHub App を使うか** — PAT は個人アカウントに紐づくため、作成者が退職するとトークンが無効化されるリスクがある。GitHub App は組織に紐づくため長期運用に適しているが、組織の Owner 権限がないと作成できない（現時点では権限なし）。また、vscode-uroborosql-fmt でも既に `VSCE_PAT`（個人 PAT）を使用して VS Code Marketplace への公開を行っており、PAT 運用の前例がある。後から GitHub App に切り替え可能なので、一旦 PAT で運用を開始する。
- **Conventional Commits を PR タイトルで強制するか** — 今回は保留。段階的に運用を定着させてから検討する。

## マージ後の TODO

- [ ] **初回タグの作成** — この PR のマージコミットに `v1.0.1` タグを打つ。release-plz は最後のタグ以降のコミットから CHANGELOG を生成するため、タグを打つことで以降の純粋な機能変更だけが CHANGELOG に載るようになる。
  ```bash
  git tag v1.0.1 main
  git push origin v1.0.1
  ```
- [ ] vscode-uroborosql-fmt 側の対応 PR をマージする — https://github.com/future-architect/vscode-uroborosql-fmt/pull/103

## 変更ファイル

| ファイル | 操作 |
|---|---|
| `Cargo.toml` | 修正: `version = "1.0.1"` を `[workspace.package]` に追加 |
| `crates/*/Cargo.toml` (4ファイル) | 修正: `version.workspace = true` に変更 |
| `.github/workflows/CI.yml` | 修正: タグトリガー追加、デプロイを2ジョブに分離 |
| `release-plz.toml` | **新規**: release-plz 設定 |
| `.github/workflows/release-plz.yml` | **新規**: release-plz ワークフロー |
| `docs/release-plz-migration.md` | **新規**: 設計ドキュメント |
