### PR TITLE
feat(lint): add config store and CLI support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |-
+              # This image ships an older Cargo, so pin Rust 1.86.0 here for edition 2024 support.
+              rustup install 1.86.0 &&
+              rustup default 1.86.0 &&
               set -e &&
               yarn build --target x86_64-unknown-linux-gnu &&
               strip *.node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,6 +960,7 @@ name = "uroborosql-lint-cli"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "tempfile",
  "uroborosql-lint",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
@@ -364,9 +364,9 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "ignore"
@@ -623,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -784,9 +784,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -947,13 +947,19 @@ dependencies = [
 name = "uroborosql-lint"
 version = "0.1.0"
 dependencies = [
+ "globset",
  "postgresql-cst-parser",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]
 name = "uroborosql-lint-cli"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "uroborosql-lint",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ repository = "https://github.com/future-architect/uroborosql-fmt"
 # Internal crates
 uroborosql-fmt = { path = "./crates/uroborosql-fmt" }
 postgresql-cst-parser = { git = "https://github.com/future-architect/postgresql-cst-parser", branch = "feat/new-apis-for-linter" }
+clap = { version = "4", features = ["derive"] }
 
 [profile.release]
 lto = true

--- a/crates/uroborosql-fmt-cli/Cargo.toml
+++ b/crates/uroborosql-fmt-cli/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [dependencies]
 uroborosql-fmt = { workspace = true }
-clap = { version = "4", features = ["derive"] }
+clap = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/uroborosql-fmt/src/error.rs
+++ b/crates/uroborosql-fmt/src/error.rs
@@ -20,8 +20,7 @@ pub enum UroboroSQLFmtError {
     Runtime(String),
     #[error("Validation Error: {error_msg}\nformat_result: {format_result}")]
     Validation {
-        // テストでしか使用しておらず、clippy で警告が出るため _ を付与
-        _format_result: String,
+        format_result: String,
         error_msg: String,
     },
 }

--- a/crates/uroborosql-fmt/src/error.rs
+++ b/crates/uroborosql-fmt/src/error.rs
@@ -18,7 +18,7 @@ pub enum UroboroSQLFmtError {
     Rendering(String),
     #[error("Runtime Error: {0}")]
     Runtime(String),
-    #[error("Validation Error: {error_msg}")]
+    #[error("Validation Error: {error_msg}\nformat_result: {format_result}")]
     Validation {
         // テストでしか使用しておらず、clippy で警告が出るため _ を付与
         _format_result: String,

--- a/crates/uroborosql-fmt/src/validate.rs
+++ b/crates/uroborosql-fmt/src/validate.rs
@@ -61,7 +61,7 @@ fn compare_tokens(
                     compare_token_text(src_token, dst_token, format_result, src)?
                 } else {
                     return Err(UroboroSQLFmtError::Validation {
-                        _format_result: format_result.to_owned(),
+                        format_result: format_result.to_owned(),
                         error_msg: format!("different kind token: Errors have occurred near the following token\n{}", error_annotation(src_token, Some(dst_token), src)),
                     });
                 }
@@ -69,7 +69,7 @@ fn compare_tokens(
             itertools::EitherOrBoth::Left(src_token) => {
                 // src.len() > dst.len() の場合
                 return Err(UroboroSQLFmtError::Validation {
-                    _format_result: format_result.to_owned(),
+                    format_result: format_result.to_owned(),
                     error_msg: format!(
                         "different kind token: Errors have occurred near the following token\n{}",
                         error_annotation(src_token, None, src)
@@ -79,7 +79,7 @@ fn compare_tokens(
             itertools::EitherOrBoth::Right(_) => {
                 // src.len() < dst.len() の場合
                 return Err(UroboroSQLFmtError::Validation {
-                    _format_result: format_result.to_owned(),
+                    format_result: format_result.to_owned(),
                     error_msg: format!("different kind token: For some reason the number of tokens in the format result has increased\nformat_result: \n{format_result}"),
                 });
             }
@@ -109,7 +109,7 @@ fn compare_token_text(
                 Ok(())
             } else {
                 Err(UroboroSQLFmtError::Validation {
-                    _format_result: format_result.to_owned(),
+                    format_result: format_result.to_owned(),
                     error_msg: format!(
                         r#"hint must start with "/*+" or "--+".\n{}"#,
                         error_annotation(src_token, Some(dst_token), src)

--- a/crates/uroborosql-fmt/tests/test_all.rs
+++ b/crates/uroborosql-fmt/tests/test_all.rs
@@ -34,12 +34,12 @@ fn run_with_config(
     let result = match uroborosql_fmt::format_sql(&content, None, config_path) {
         Ok(format_result) => format_result,
         Err(UroboroSQLFmtError::Validation {
-            _format_result,
+            format_result,
             error_msg,
         }) => {
             // assertion errorが生じた際は、Ok((フォーマット結果, エラーメッセージ))が返される
             failure_results.insert(src.to_str().unwrap().to_string(), error_msg);
-            _format_result
+            format_result
         }
         Err(e) => {
             failure_results.insert(src.to_str().unwrap().to_string(), e.to_string());

--- a/crates/uroborosql-lint-cli/Cargo.toml
+++ b/crates/uroborosql-lint-cli/Cargo.toml
@@ -7,4 +7,5 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+clap = { version = "4.5", features = ["derive"] }
 uroborosql-lint = { path = "../uroborosql-lint" }

--- a/crates/uroborosql-lint-cli/Cargo.toml
+++ b/crates/uroborosql-lint-cli/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { workspace = true }
 uroborosql-lint = { path = "../uroborosql-lint" }
 
 [dev-dependencies]

--- a/crates/uroborosql-lint-cli/Cargo.toml
+++ b/crates/uroborosql-lint-cli/Cargo.toml
@@ -9,3 +9,6 @@ repository.workspace = true
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 uroborosql-lint = { path = "../uroborosql-lint" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/uroborosql-lint-cli/src/main.rs
+++ b/crates/uroborosql-lint-cli/src/main.rs
@@ -78,13 +78,10 @@ fn print_diagnostic(file: &str, diagnostic: &Diagnostic) {
     let column = diagnostic.span.start.column + 1;
 
     println!(
-        "{}:{}:{}: {}: {}: {}",
-        file,
-        line,
-        column,
-        severity_label(diagnostic.severity),
-        diagnostic.rule_id,
-        diagnostic.message
+        "{file}:{line}:{column}: {severity_label}: {rule_id}: {message}",
+        severity_label = severity_label(diagnostic.severity),
+        rule_id = diagnostic.rule_id,
+        message = diagnostic.message
     );
 }
 

--- a/crates/uroborosql-lint-cli/src/main.rs
+++ b/crates/uroborosql-lint-cli/src/main.rs
@@ -27,13 +27,13 @@ fn run() -> Result<(), String> {
     let linter = Linter::new();
     let mut exit_with_error = false;
 
-    let path = cli.input;
+    let cwd = env::current_dir().map_err(|err| format!("Failed to get cwd: {err}"))?;
+    let path = resolve_input_path(cli.input, &cwd)?;
     let display = path.display().to_string();
 
     let sql =
         fs::read_to_string(&path).map_err(|err| format!("Failed to read {}: {}", display, err))?;
 
-    let cwd = env::current_dir().map_err(|err| format!("Failed to get cwd: {err}"))?;
     let config_store =
         ConfigStore::new(cwd, cli.config).map_err(|err| format!("Failed to load config: {err}"))?;
 
@@ -62,6 +62,17 @@ fn run() -> Result<(), String> {
     }
 }
 
+fn resolve_input_path(path: PathBuf, cwd: &std::path::Path) -> Result<PathBuf, String> {
+    let path = if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    };
+
+    path.canonicalize()
+        .map_err(|err| format!("Failed to resolve input path {}: {}", path.display(), err))
+}
+
 fn print_diagnostic(file: &str, diagnostic: &Diagnostic) {
     let line = diagnostic.span.start.line + 1;
     let column = diagnostic.span.start.column + 1;
@@ -82,5 +93,43 @@ fn severity_label(severity: Severity) -> &'static str {
         Severity::Error => "error",
         Severity::Warning => "warning",
         Severity::Info => "info",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::resolve_input_path;
+
+    #[test]
+    fn resolves_relative_input_path_from_cwd() {
+        let temp = tempdir().expect("tempdir");
+        let cwd = temp.path().join("runner");
+        let project = temp.path().join("project");
+        let input = project.join("query.sql");
+
+        fs::create_dir_all(&cwd).expect("create cwd");
+        fs::create_dir_all(&project).expect("create project");
+        fs::write(&input, "select 1").expect("write input");
+
+        let resolved = resolve_input_path("../project/query.sql".into(), &cwd).expect("resolve");
+
+        assert_eq!(resolved, input.canonicalize().expect("canonicalize input"));
+    }
+
+    #[test]
+    fn keeps_absolute_input_path() {
+        let temp = tempdir().expect("tempdir");
+        let input = temp.path().join("query.sql");
+
+        fs::write(&input, "select 1").expect("write input");
+
+        let resolved =
+            resolve_input_path(input.clone(), temp.path()).expect("resolve absolute input");
+
+        assert_eq!(resolved, input.canonicalize().expect("canonicalize input"));
     }
 }

--- a/crates/uroborosql-lint/Cargo.toml
+++ b/crates/uroborosql-lint/Cargo.toml
@@ -8,3 +8,10 @@ repository.workspace = true
 
 [dependencies]
 postgresql-cst-parser = { workspace = true }
+globset = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -1,0 +1,98 @@
+# uroborosql-lint
+
+## Configuration
+
+The default config file name is `.uroborosqllintrc.json`.
+
+Example:
+
+```json
+{
+  "rules": {
+    "no-distinct": "error",
+    "no-wildcard-projection": "warn"
+  },
+  "ignore": ["dist/**"],
+  "overrides": [
+    {
+      "files": ["test/**/*.sql"],
+      "rules": {
+        "no-distinct": "off"
+      }
+    }
+  ],
+  "db": {
+    "schemaProvider": "file",
+    "path": "schema/schema.sql"
+  }
+}
+```
+
+### `rules`
+
+Configures the severity for each rule.
+
+Supported values:
+
+- `off`
+- `warn` / `warning`
+- `error`
+
+### `ignore`
+
+Configures file globs to ignore.
+
+### `overrides`
+
+Configures per-file rule settings.
+
+Each override must have:
+
+- `files`: glob patterns to match target files
+- `rules`: rule settings applied to matched files
+
+### `db`
+
+Configures how schema information should be loaded for rules that need database metadata.
+
+This setting is reserved for schema-aware rules.
+It is not used by the currently implemented rules yet.
+
+Supported values are:
+
+- `file`
+  - Loads schema information from a file
+  - `path` is required
+- `server`
+  - Loads schema information from a PostgreSQL server
+  - `host`, `user`, and `dbname` are required
+  - `port` and `password` are optional
+
+Examples:
+
+```json
+{
+  "db": {
+    "schemaProvider": "file",
+    "path": "schema/schema.sql"
+  }
+}
+```
+
+```json
+{
+  "db": {
+    "schemaProvider": "server",
+    "host": "localhost",
+    "port": 5432,
+    "user": "postgres",
+    "password": "secret",
+    "dbname": "app"
+  }
+}
+```
+
+## Path Resolution
+
+- `ignore` and `overrides.files` are resolved relative to the config file
+- `db.path` is resolved relative to the config file

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -36,12 +36,9 @@ Unknown rule names are reported as configuration errors.
 
 Supported values:
 
-- `off`
-- `warn` / `warning`
-- `error`
-- `"0"` / `0`
-- `"1"` / `1`
-- `"2"` / `2`
+- `off` / `"0"` / `0`
+- `warn` / `warning` / `"1"` / `1`
+- `error` / `"2"` / `2`
 
 ### `ignore`
 

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -32,6 +32,8 @@ Example:
 
 Configures the severity for each rule.
 
+Unknown rule names are reported as configuration errors.
+
 Supported values:
 
 - `off`
@@ -97,5 +99,4 @@ Examples:
 
 ## Path Resolution
 
-- `ignore` and `overrides.files` are resolved relative to the config file
-- `db.path` is resolved relative to the config file
+- `ignore`, `overrides.files`, and `db.path` are resolved relative to the current working directory

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -96,4 +96,5 @@ Examples:
 
 ## Path Resolution
 
-- `ignore`, `overrides.files`, and `db.path` are resolved relative to the current working directory
+- `ignore` and `overrides.files` are resolved relative to the current working directory
+- `db.path` is resolved relative to the directory containing the loaded config file

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -37,6 +37,9 @@ Supported values:
 - `off`
 - `warn` / `warning`
 - `error`
+- `"0"` / `0`
+- `"1"` / `1`
+- `"2"` / `2`
 
 ### `ignore`
 

--- a/crates/uroborosql-lint/src/config.rs
+++ b/crates/uroborosql-lint/src/config.rs
@@ -1,0 +1,9 @@
+mod config_store;
+mod lint_config;
+mod overrides;
+mod types;
+
+pub const DEFAULT_CONFIG_FILENAME: &str = ".uroborosqllintrc.json";
+
+pub use config_store::{ConfigError, ConfigStore, ResolvedLintConfig};
+pub use types::{RuleLevel, RuleSetting};

--- a/crates/uroborosql-lint/src/config/config_store.rs
+++ b/crates/uroborosql-lint/src/config/config_store.rs
@@ -1,0 +1,270 @@
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::{
+    diagnostic::Severity,
+    rules::{all_rules, default_rules, RuleEnum},
+};
+
+use super::{
+    lint_config::{DbConfig, LintConfigObject, LintOverride},
+    overrides::ResolvedOverride,
+    RuleLevel, RuleSetting, DEFAULT_CONFIG_FILENAME,
+};
+
+#[derive(Debug, Clone)]
+pub enum ResolvedDbConfig {
+    Server {
+        host: String,
+        port: Option<u16>,
+        user: String,
+        password: Option<String>,
+        dbname: String,
+    },
+    File {
+        path: PathBuf,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedLintConfig {
+    pub rules: Vec<(RuleEnum, Severity)>,
+    pub db: Option<ResolvedDbConfig>,
+}
+
+impl Default for ResolvedLintConfig {
+    fn default() -> Self {
+        Self {
+            rules: default_rules(),
+            db: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct LintConfig {
+    rules: HashMap<String, RuleSetting>,
+    overrides: Vec<ResolvedOverride>,
+    ignore: GlobSet,
+    db: Option<ResolvedDbConfig>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigStore {
+    root_dir: PathBuf,
+    unresolved_config: LintConfig,
+}
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("failed to read {0}: {1}")]
+    Io(PathBuf, #[source] std::io::Error),
+    #[error("failed to parse {0}: {1}")]
+    Json(PathBuf, #[source] serde_json::Error),
+    #[error("invalid glob pattern {0}: {1}")]
+    Glob(String, #[source] globset::Error),
+    #[error("invalid rule setting for {rule}: {value}")]
+    InvalidRuleSetting { rule: String, value: Value },
+}
+
+impl ConfigStore {
+    pub fn new(
+        root_dir: impl Into<PathBuf>,
+        config_path: Option<PathBuf>,
+    ) -> Result<Self, ConfigError> {
+        let root_dir = root_dir.into();
+        let (lint_config_object, origin) = load_config(&root_dir, config_path)?;
+        let unresolved_config =
+            LintConfig::from_lint_config_object(lint_config_object, &root_dir, origin.clone())?;
+        Ok(Self {
+            root_dir,
+            unresolved_config,
+        })
+    }
+
+    pub fn resolve(&self, file: &Path) -> ResolvedLintConfig {
+        let rel_path = file.strip_prefix(&self.root_dir).unwrap_or(file);
+        let mut rules = self.unresolved_config.rules.clone();
+
+        // override を順番に適用（後勝ち）
+        for override_config in &self.unresolved_config.overrides {
+            if override_config.files.is_match(rel_path) {
+                for (name, setting) in &override_config.rules {
+                    rules.insert(name.clone(), setting.clone());
+                }
+            }
+        }
+
+        // rule と severity のペアを作成
+        let mut resolved_rules = Vec::new();
+        for rule in all_rules() {
+            let name = rule.name();
+
+            let severity = if let Some(setting) = rules.get(name) {
+                match setting.level {
+                    RuleLevel::Off => continue,
+                    RuleLevel::Warn => Severity::Warning,
+                    RuleLevel::Error => Severity::Error,
+                }
+            } else {
+                rule.default_severity()
+            };
+
+            resolved_rules.push((rule, severity));
+        }
+
+        ResolvedLintConfig {
+            rules: resolved_rules,
+            db: self.unresolved_config.db.clone(),
+        }
+    }
+
+    pub fn is_ignored(&self, file: &Path) -> bool {
+        let rel_path = file.strip_prefix(&self.root_dir).unwrap_or(file);
+        self.unresolved_config.ignore.is_match(rel_path)
+    }
+
+    pub fn root_dir(&self) -> &Path {
+        &self.root_dir
+    }
+}
+
+impl LintConfig {
+    fn from_lint_config_object(
+        lint_config_object: LintConfigObject,
+        root_dir: &Path,
+        origin: Option<PathBuf>,
+    ) -> Result<Self, ConfigError> {
+        let rules = parse_rules_map(lint_config_object.rules)?;
+        let overrides = lint_config_object
+            .overrides
+            .into_iter()
+            .map(resolve_override)
+            .collect::<Result<Vec<_>, _>>()?;
+        let ignore = build_globset(&lint_config_object.ignore)?;
+        let db = resolve_db_config(lint_config_object.db, root_dir, origin.as_deref());
+
+        Ok(Self {
+            rules,
+            overrides,
+            ignore,
+            db,
+        })
+    }
+}
+
+fn load_config(
+    root_dir: &Path,
+    config_path: Option<PathBuf>,
+) -> Result<(LintConfigObject, Option<PathBuf>), ConfigError> {
+    if let Some(path) = config_path {
+        let config = read_config_file(&path)?;
+        return Ok((config, Some(path)));
+    }
+
+    let path = root_dir.join(DEFAULT_CONFIG_FILENAME);
+    if path.exists() {
+        let config = read_config_file(&path)?;
+        return Ok((config, Some(path)));
+    }
+
+    Ok((LintConfigObject::default(), None))
+}
+
+fn read_config_file(path: &Path) -> Result<LintConfigObject, ConfigError> {
+    let content =
+        fs::read_to_string(path).map_err(|err| ConfigError::Io(path.to_path_buf(), err))?;
+    let config =
+        serde_json::from_str(&content).map_err(|err| ConfigError::Json(path.to_path_buf(), err))?;
+    Ok(config)
+}
+
+fn resolve_override(ov: LintOverride) -> Result<ResolvedOverride, ConfigError> {
+    let files = build_globset(&ov.files)?;
+    let rules = parse_rules_map(ov.rules)?;
+    Ok(ResolvedOverride { files, rules })
+}
+
+fn resolve_db_config(
+    config: Option<DbConfig>,
+    root_dir: &Path,
+    origin: Option<&Path>,
+) -> Option<ResolvedDbConfig> {
+    let base_dir = origin.and_then(|path| path.parent()).unwrap_or(root_dir);
+    match config? {
+        DbConfig::Server {
+            host,
+            port,
+            user,
+            password,
+            dbname,
+        } => Some(ResolvedDbConfig::Server {
+            host,
+            port,
+            user,
+            password,
+            dbname,
+        }),
+        DbConfig::File { path } => Some(ResolvedDbConfig::File {
+            path: base_dir.join(path),
+        }),
+    }
+}
+
+fn build_globset(patterns: &[String]) -> Result<GlobSet, ConfigError> {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        let glob = Glob::new(pattern).map_err(|err| ConfigError::Glob(pattern.clone(), err))?;
+        builder.add(glob);
+    }
+    builder
+        .build()
+        .map_err(|err| ConfigError::Glob("failed to build globset".to_string(), err))
+}
+
+fn parse_rules_map(
+    rules: HashMap<String, Value>,
+) -> Result<HashMap<String, RuleSetting>, ConfigError> {
+    let mut parsed = HashMap::new();
+    for (name, value) in rules {
+        let setting = parse_rule_setting(&name, &value)?;
+        parsed.insert(name, setting);
+    }
+    Ok(parsed)
+}
+
+fn parse_rule_setting(name: &str, value: &Value) -> Result<RuleSetting, ConfigError> {
+    let level = parse_rule_level(value).ok_or_else(|| ConfigError::InvalidRuleSetting {
+        rule: name.to_string(),
+        value: value.clone(),
+    })?;
+    Ok(RuleSetting { level })
+}
+
+fn parse_rule_level(value: &Value) -> Option<RuleLevel> {
+    match value {
+        Value::String(text) => match text.as_str() {
+            "off" => Some(RuleLevel::Off),
+            "warn" | "warning" => Some(RuleLevel::Warn),
+            "error" => Some(RuleLevel::Error),
+            "0" => Some(RuleLevel::Off),
+            "1" => Some(RuleLevel::Warn),
+            "2" => Some(RuleLevel::Error),
+            _ => None,
+        },
+        Value::Number(num) => match num.as_i64()? {
+            0 => Some(RuleLevel::Off),
+            1 => Some(RuleLevel::Warn),
+            2 => Some(RuleLevel::Error),
+            _ => None,
+        },
+        _ => None,
+    }
+}

--- a/crates/uroborosql-lint/src/config/config_store.rs
+++ b/crates/uroborosql-lint/src/config/config_store.rs
@@ -80,6 +80,19 @@ impl ConfigStore {
         config_path: Option<PathBuf>,
     ) -> Result<Self, ConfigError> {
         let root_dir = root_dir.into();
+        let config_path = config_path
+            .map(|path| {
+                if path.is_absolute() {
+                    path
+                } else {
+                    root_dir.join(path)
+                }
+            })
+            .map(|path| {
+                path.canonicalize()
+                    .map_err(|err| ConfigError::Io(path, err))
+            })
+            .transpose()?;
         let (lint_config_object, origin) = load_config(&root_dir, config_path)?;
         let effective_root_dir = origin
             .as_deref()

--- a/crates/uroborosql-lint/src/config/config_store.rs
+++ b/crates/uroborosql-lint/src/config/config_store.rs
@@ -62,6 +62,11 @@ pub struct ConfigStore {
     unresolved_config: LintConfig,
 }
 
+struct LoadedConfig {
+    config: LintConfigObject,
+    origin: Option<PathBuf>,
+}
+
 #[derive(Debug, Error)]
 pub enum ConfigError {
     #[error("failed to read {0}: {1}")]
@@ -95,8 +100,14 @@ impl ConfigStore {
                     .map_err(|err| ConfigError::Io(path, err))
             })
             .transpose()?;
-        let lint_config_object = load_config(&root_dir, config_path)?;
-        let unresolved_config = LintConfig::from_lint_config_object(lint_config_object, &root_dir)?;
+        let loaded_config = load_config(&root_dir, config_path)?;
+        let config_base_dir = loaded_config
+            .origin
+            .as_deref()
+            .and_then(Path::parent)
+            .unwrap_or(&root_dir);
+        let unresolved_config =
+            LintConfig::from_lint_config_object(loaded_config.config, config_base_dir)?;
         Ok(Self {
             root_dir,
             unresolved_config,
@@ -153,7 +164,7 @@ impl ConfigStore {
 impl LintConfig {
     fn from_lint_config_object(
         lint_config_object: LintConfigObject,
-        root_dir: &Path,
+        config_base_dir: &Path,
     ) -> Result<Self, ConfigError> {
         validate_rule_names(&lint_config_object)?;
         let rules = parse_rules_map(lint_config_object.rules)?;
@@ -163,7 +174,7 @@ impl LintConfig {
             .map(resolve_override)
             .collect::<Result<Vec<_>, _>>()?;
         let ignore = build_globset(&lint_config_object.ignore)?;
-        let db = resolve_db_config(lint_config_object.db, root_dir);
+        let db = resolve_db_config(lint_config_object.db, config_base_dir);
 
         Ok(Self {
             rules,
@@ -174,20 +185,28 @@ impl LintConfig {
     }
 }
 
-fn load_config(
-    root_dir: &Path,
-    config_path: Option<PathBuf>,
-) -> Result<LintConfigObject, ConfigError> {
+fn load_config(root_dir: &Path, config_path: Option<PathBuf>) -> Result<LoadedConfig, ConfigError> {
     if let Some(path) = config_path {
-        return read_config_file(&path);
+        let config = read_config_file(&path)?;
+        return Ok(LoadedConfig {
+            config,
+            origin: Some(path),
+        });
     }
 
     let path = root_dir.join(DEFAULT_CONFIG_FILENAME);
     if path.exists() {
-        return read_config_file(&path);
+        let config = read_config_file(&path)?;
+        return Ok(LoadedConfig {
+            config,
+            origin: Some(path),
+        });
     }
 
-    Ok(LintConfigObject::default())
+    Ok(LoadedConfig {
+        config: LintConfigObject::default(),
+        origin: None,
+    })
 }
 
 fn read_config_file(path: &Path) -> Result<LintConfigObject, ConfigError> {
@@ -204,7 +223,7 @@ fn resolve_override(ov: LintOverride) -> Result<ResolvedOverride, ConfigError> {
     Ok(ResolvedOverride { files, rules })
 }
 
-fn resolve_db_config(config: Option<DbConfig>, root_dir: &Path) -> Option<ResolvedDbConfig> {
+fn resolve_db_config(config: Option<DbConfig>, config_base_dir: &Path) -> Option<ResolvedDbConfig> {
     match config? {
         DbConfig::Server {
             host,
@@ -220,7 +239,7 @@ fn resolve_db_config(config: Option<DbConfig>, root_dir: &Path) -> Option<Resolv
             dbname,
         }),
         DbConfig::File { path } => Some(ResolvedDbConfig::File {
-            path: root_dir.join(path),
+            path: config_base_dir.join(path),
         }),
     }
 }

--- a/crates/uroborosql-lint/src/config/config_store.rs
+++ b/crates/uroborosql-lint/src/config/config_store.rs
@@ -94,16 +94,13 @@ impl ConfigStore {
             })
             .transpose()?;
         let (lint_config_object, origin) = load_config(&root_dir, config_path)?;
+        let unresolved_config =
+            LintConfig::from_lint_config_object(lint_config_object, &root_dir, origin.as_deref())?;
         let effective_root_dir = origin
             .as_deref()
             .and_then(Path::parent)
             .unwrap_or(&root_dir)
             .to_path_buf();
-        let unresolved_config = LintConfig::from_lint_config_object(
-            lint_config_object,
-            &effective_root_dir,
-            origin.clone(),
-        )?;
         Ok(Self {
             root_dir: effective_root_dir,
             unresolved_config,
@@ -161,7 +158,7 @@ impl LintConfig {
     fn from_lint_config_object(
         lint_config_object: LintConfigObject,
         root_dir: &Path,
-        origin: Option<PathBuf>,
+        origin: Option<&Path>,
     ) -> Result<Self, ConfigError> {
         let rules = parse_rules_map(lint_config_object.rules)?;
         let overrides = lint_config_object
@@ -170,7 +167,7 @@ impl LintConfig {
             .map(resolve_override)
             .collect::<Result<Vec<_>, _>>()?;
         let ignore = build_globset(&lint_config_object.ignore)?;
-        let db = resolve_db_config(lint_config_object.db, root_dir, origin.as_deref());
+        let db = resolve_db_config(lint_config_object.db, root_dir, origin);
 
         Ok(Self {
             rules,
@@ -253,12 +250,13 @@ fn build_globset(patterns: &[String]) -> Result<GlobSet, ConfigError> {
 fn parse_rules_map(
     rules: HashMap<String, Value>,
 ) -> Result<HashMap<String, RuleSetting>, ConfigError> {
-    let mut parsed = HashMap::new();
-    for (name, value) in rules {
-        let setting = parse_rule_setting(&name, &value)?;
-        parsed.insert(name, setting);
-    }
-    Ok(parsed)
+    rules
+        .into_iter()
+        .map(|(name, value)| {
+            let setting = parse_rule_setting(&name, &value)?;
+            Ok((name, setting))
+        })
+        .collect()
 }
 
 fn parse_rule_setting(name: &str, value: &Value) -> Result<RuleSetting, ConfigError> {

--- a/crates/uroborosql-lint/src/config/config_store.rs
+++ b/crates/uroborosql-lint/src/config/config_store.rs
@@ -93,16 +93,10 @@ impl ConfigStore {
                     .map_err(|err| ConfigError::Io(path, err))
             })
             .transpose()?;
-        let (lint_config_object, origin) = load_config(&root_dir, config_path)?;
-        let unresolved_config =
-            LintConfig::from_lint_config_object(lint_config_object, &root_dir, origin.as_deref())?;
-        let effective_root_dir = origin
-            .as_deref()
-            .and_then(Path::parent)
-            .unwrap_or(&root_dir)
-            .to_path_buf();
+        let lint_config_object = load_config(&root_dir, config_path)?;
+        let unresolved_config = LintConfig::from_lint_config_object(lint_config_object, &root_dir)?;
         Ok(Self {
-            root_dir: effective_root_dir,
+            root_dir,
             unresolved_config,
         })
     }
@@ -158,7 +152,6 @@ impl LintConfig {
     fn from_lint_config_object(
         lint_config_object: LintConfigObject,
         root_dir: &Path,
-        origin: Option<&Path>,
     ) -> Result<Self, ConfigError> {
         let rules = parse_rules_map(lint_config_object.rules)?;
         let overrides = lint_config_object
@@ -167,7 +160,7 @@ impl LintConfig {
             .map(resolve_override)
             .collect::<Result<Vec<_>, _>>()?;
         let ignore = build_globset(&lint_config_object.ignore)?;
-        let db = resolve_db_config(lint_config_object.db, root_dir, origin);
+        let db = resolve_db_config(lint_config_object.db, root_dir);
 
         Ok(Self {
             rules,
@@ -181,19 +174,17 @@ impl LintConfig {
 fn load_config(
     root_dir: &Path,
     config_path: Option<PathBuf>,
-) -> Result<(LintConfigObject, Option<PathBuf>), ConfigError> {
+) -> Result<LintConfigObject, ConfigError> {
     if let Some(path) = config_path {
-        let config = read_config_file(&path)?;
-        return Ok((config, Some(path)));
+        return read_config_file(&path);
     }
 
     let path = root_dir.join(DEFAULT_CONFIG_FILENAME);
     if path.exists() {
-        let config = read_config_file(&path)?;
-        return Ok((config, Some(path)));
+        return read_config_file(&path);
     }
 
-    Ok((LintConfigObject::default(), None))
+    Ok(LintConfigObject::default())
 }
 
 fn read_config_file(path: &Path) -> Result<LintConfigObject, ConfigError> {
@@ -210,12 +201,7 @@ fn resolve_override(ov: LintOverride) -> Result<ResolvedOverride, ConfigError> {
     Ok(ResolvedOverride { files, rules })
 }
 
-fn resolve_db_config(
-    config: Option<DbConfig>,
-    root_dir: &Path,
-    origin: Option<&Path>,
-) -> Option<ResolvedDbConfig> {
-    let base_dir = origin.and_then(|path| path.parent()).unwrap_or(root_dir);
+fn resolve_db_config(config: Option<DbConfig>, root_dir: &Path) -> Option<ResolvedDbConfig> {
     match config? {
         DbConfig::Server {
             host,
@@ -231,7 +217,7 @@ fn resolve_db_config(
             dbname,
         }),
         DbConfig::File { path } => Some(ResolvedDbConfig::File {
-            path: base_dir.join(path),
+            path: root_dir.join(path),
         }),
     }
 }

--- a/crates/uroborosql-lint/src/config/config_store.rs
+++ b/crates/uroborosql-lint/src/config/config_store.rs
@@ -81,10 +81,18 @@ impl ConfigStore {
     ) -> Result<Self, ConfigError> {
         let root_dir = root_dir.into();
         let (lint_config_object, origin) = load_config(&root_dir, config_path)?;
-        let unresolved_config =
-            LintConfig::from_lint_config_object(lint_config_object, &root_dir, origin.clone())?;
+        let effective_root_dir = origin
+            .as_deref()
+            .and_then(Path::parent)
+            .unwrap_or(&root_dir)
+            .to_path_buf();
+        let unresolved_config = LintConfig::from_lint_config_object(
+            lint_config_object,
+            &effective_root_dir,
+            origin.clone(),
+        )?;
         Ok(Self {
-            root_dir,
+            root_dir: effective_root_dir,
             unresolved_config,
         })
     }

--- a/crates/uroborosql-lint/src/config/config_store.rs
+++ b/crates/uroborosql-lint/src/config/config_store.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     fs,
     path::{Path, PathBuf},
 };
@@ -70,6 +70,8 @@ pub enum ConfigError {
     Json(PathBuf, #[source] serde_json::Error),
     #[error("invalid glob pattern {0}: {1}")]
     Glob(String, #[source] globset::Error),
+    #[error("unknown rules: {rules:?}")]
+    UnknownRules { rules: Vec<String> },
     #[error("invalid rule setting for {rule}: {value}")]
     InvalidRuleSetting { rule: String, value: Value },
 }
@@ -153,6 +155,7 @@ impl LintConfig {
         lint_config_object: LintConfigObject,
         root_dir: &Path,
     ) -> Result<Self, ConfigError> {
+        validate_rule_names(&lint_config_object)?;
         let rules = parse_rules_map(lint_config_object.rules)?;
         let overrides = lint_config_object
             .overrides
@@ -243,6 +246,32 @@ fn parse_rules_map(
             Ok((name, setting))
         })
         .collect()
+}
+
+fn validate_rule_names(config: &LintConfigObject) -> Result<(), ConfigError> {
+    let mut unknown_rules = BTreeSet::new();
+
+    for name in config.rules.keys() {
+        if RuleEnum::from_name(name).is_none() {
+            unknown_rules.insert(name.clone());
+        }
+    }
+
+    for override_config in &config.overrides {
+        for name in override_config.rules.keys() {
+            if RuleEnum::from_name(name).is_none() {
+                unknown_rules.insert(name.clone());
+            }
+        }
+    }
+
+    if unknown_rules.is_empty() {
+        Ok(())
+    } else {
+        Err(ConfigError::UnknownRules {
+            rules: unknown_rules.into_iter().collect(),
+        })
+    }
 }
 
 fn parse_rule_setting(name: &str, value: &Value) -> Result<RuleSetting, ConfigError> {

--- a/crates/uroborosql-lint/src/config/lint_config.rs
+++ b/crates/uroborosql-lint/src/config/lint_config.rs
@@ -1,0 +1,41 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LintConfigObject {
+    #[serde(default)]
+    pub db: Option<DbConfig>,
+    #[serde(default)]
+    pub rules: HashMap<String, Value>,
+    #[serde(default)]
+    pub overrides: Vec<LintOverride>,
+    #[serde(default)]
+    pub ignore: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LintOverride {
+    pub files: Vec<String>,
+    #[serde(default)]
+    pub rules: HashMap<String, Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "schemaProvider", rename_all = "lowercase")]
+pub enum DbConfig {
+    Server {
+        host: String,
+        #[serde(default)]
+        port: Option<u16>,
+        user: String,
+        #[serde(default)]
+        password: Option<String>,
+        #[serde(rename = "dbname")]
+        dbname: String,
+    },
+    File {
+        path: String,
+    },
+}

--- a/crates/uroborosql-lint/src/config/overrides.rs
+++ b/crates/uroborosql-lint/src/config/overrides.rs
@@ -1,0 +1,11 @@
+use std::collections::HashMap;
+
+use globset::GlobSet;
+
+use crate::config::RuleSetting;
+
+#[derive(Debug, Clone)]
+pub struct ResolvedOverride {
+    pub files: GlobSet,
+    pub rules: HashMap<String, RuleSetting>,
+}

--- a/crates/uroborosql-lint/src/config/types.rs
+++ b/crates/uroborosql-lint/src/config/types.rs
@@ -1,0 +1,11 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleLevel {
+    Off,
+    Warn,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuleSetting {
+    pub level: RuleLevel,
+}

--- a/crates/uroborosql-lint/src/lib.rs
+++ b/crates/uroborosql-lint/src/lib.rs
@@ -1,3 +1,4 @@
+mod config;
 mod context;
 mod diagnostic;
 mod linter;
@@ -5,5 +6,9 @@ mod rule;
 mod rules;
 mod tree;
 
+pub use config::{
+    ConfigError, ConfigStore, ResolvedLintConfig, RuleLevel, RuleSetting, DEFAULT_CONFIG_FILENAME,
+};
 pub use diagnostic::{Diagnostic, Severity, SqlSpan};
-pub use linter::{LintError, LintOptions, Linter};
+pub use linter::{LintError, Linter};
+pub use rules::RuleEnum;

--- a/crates/uroborosql-lint/src/linter.rs
+++ b/crates/uroborosql-lint/src/linter.rs
@@ -1,101 +1,44 @@
 use crate::{
-    context::LintContext,
-    diagnostic::{Diagnostic, Severity},
-    rule::Rule,
-    rules::{
-        MissingTwoWaySample, NoDistinct, NoFunctionOnColumnInJoinOrWhere, NoNotIn, NoUnionDistinct,
-        NoWildcardProjection, TooLargeInList,
-    },
-    tree::collect_preorder,
+    context::LintContext, diagnostic::Diagnostic, tree::collect_preorder, ResolvedLintConfig,
 };
 use postgresql_cst_parser::tree_sitter;
-use std::collections::HashMap;
 
 #[derive(Debug)]
 pub enum LintError {
     ParseError(String),
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct LintOptions {
-    severity_overrides: HashMap<String, Severity>,
-}
-
-impl LintOptions {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn severity_for(&self, rule_id: &str) -> Option<Severity> {
-        self.severity_overrides.get(rule_id).copied()
-    }
-
-    pub fn set_severity_override(&mut self, rule_id: impl Into<String>, severity: Severity) {
-        self.severity_overrides.insert(rule_id.into(), severity);
-    }
-
-    pub fn with_severity_override(
-        mut self,
-        rule_id: impl Into<String>,
-        severity: Severity,
-    ) -> Self {
-        self.set_severity_override(rule_id, severity);
-        self
-    }
-}
-
-pub struct Linter {
-    rules: Vec<Box<dyn Rule>>,
-    options: LintOptions,
-}
-
-impl Default for Linter {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+#[derive(Debug, Default)]
+pub struct Linter;
 
 impl Linter {
     pub fn new() -> Self {
-        Self::with_options(LintOptions::default())
+        Self
     }
 
-    pub fn with_options(options: LintOptions) -> Self {
-        Self::with_rules_and_options(default_rules(), options)
-    }
-
-    pub fn with_rules(rules: Vec<Box<dyn Rule>>) -> Self {
-        Self::with_rules_and_options(rules, LintOptions::default())
-    }
-
-    pub fn with_rules_and_options(rules: Vec<Box<dyn Rule>>, options: LintOptions) -> Self {
-        Self { rules, options }
-    }
-
-    pub fn run(&self, sql: &str) -> Result<Vec<Diagnostic>, LintError> {
+    pub fn run(
+        &self,
+        sql: &str,
+        resolved_config: &ResolvedLintConfig,
+    ) -> Result<Vec<Diagnostic>, LintError> {
         let tree = tree_sitter::parse_2way(sql)
             .map_err(|err| LintError::ParseError(format!("{err:?}")))?;
         let root = tree.root_node();
         let nodes = collect_preorder(root.clone());
         let mut ctx = LintContext::new(sql);
 
-        for rule in &self.rules {
-            let severity = self
-                .options
-                .severity_for(rule.name())
-                .unwrap_or_else(|| rule.default_severity());
-
-            rule.run_once(&root, &mut ctx, severity);
+        for (rule, severity) in &resolved_config.rules {
+            rule.run_once(&root, &mut ctx, *severity);
 
             let targets = rule.target_kinds();
             if targets.is_empty() {
                 for node in &nodes {
-                    rule.run_on_node(node, &mut ctx, severity);
+                    rule.run_on_node(node, &mut ctx, *severity);
                 }
             } else {
                 for node in &nodes {
                     if targets.iter().any(|kind| node.kind() == *kind) {
-                        rule.run_on_node(node, &mut ctx, severity);
+                        rule.run_on_node(node, &mut ctx, *severity);
                     }
                 }
             }
@@ -105,33 +48,37 @@ impl Linter {
     }
 }
 
-fn default_rules() -> Vec<Box<dyn Rule>> {
-    vec![
-        Box::new(NoDistinct),
-        Box::new(NoNotIn),
-        Box::new(NoUnionDistinct),
-        Box::new(NoFunctionOnColumnInJoinOrWhere),
-        Box::new(NoWildcardProjection),
-        Box::new(MissingTwoWaySample),
-        Box::new(TooLargeInList),
-    ]
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::diagnostic::Severity;
+    use crate::{
+        diagnostic::Severity,
+        rules::{NoDistinct, RuleEnum},
+    };
 
-    pub fn run_with_rules(sql: &str, rules: Vec<Box<dyn Rule>>) -> Vec<Diagnostic> {
-        Linter::with_rules(rules).run(sql).expect("lint ok")
+    fn resolve_from_rules(rules: Vec<(RuleEnum, Severity)>) -> ResolvedLintConfig {
+        ResolvedLintConfig { rules, db: None }
+    }
+
+    pub fn run_with_rules(sql: &str, rules: Vec<RuleEnum>) -> Vec<Diagnostic> {
+        let resolved_rules = rules
+            .into_iter()
+            .map(|rule| {
+                let severity = rule.default_severity();
+                (rule, severity)
+            })
+            .collect();
+        let state = resolve_from_rules(resolved_rules);
+
+        Linter::new().run(sql, &state).expect("lint ok")
     }
 
     #[test]
     fn applies_severity_override() {
-        let options = LintOptions::default().with_severity_override("no-distinct", Severity::Error);
-        let linter = Linter::with_options(options);
+        let resolved_config =
+            resolve_from_rules(vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Error)]);
         let sql = "SELECT DISTINCT id FROM users;";
-        let diagnostics = linter.run(sql).expect("lint ok");
+        let diagnostics = Linter::new().run(sql, &resolved_config).expect("lint ok");
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].severity, Severity::Error);

--- a/crates/uroborosql-lint/src/rules.rs
+++ b/crates/uroborosql-lint/src/rules.rs
@@ -6,6 +6,10 @@ mod no_union_distinct;
 mod no_wildcard_projection;
 mod too_large_in_list;
 
+use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::Node};
+
+use crate::{context::LintContext, diagnostic::Severity, rule::Rule};
+
 pub use missing_two_way_sample::MissingTwoWaySample;
 pub use no_distinct::NoDistinct;
 pub use no_function_on_column_in_join_or_where::NoFunctionOnColumnInJoinOrWhere;
@@ -13,3 +17,79 @@ pub use no_not_in::NoNotIn;
 pub use no_union_distinct::NoUnionDistinct;
 pub use no_wildcard_projection::NoWildcardProjection;
 pub use too_large_in_list::TooLargeInList;
+
+pub fn all_rules() -> impl Iterator<Item = RuleEnum> {
+    [
+        RuleEnum::NoDistinct(NoDistinct),
+        RuleEnum::NoNotIn(NoNotIn),
+        RuleEnum::NoUnionDistinct(NoUnionDistinct),
+        RuleEnum::NoWildcardProjection(NoWildcardProjection),
+        RuleEnum::MissingTwoWaySample(MissingTwoWaySample),
+        RuleEnum::TooLargeInList(TooLargeInList),
+        RuleEnum::NoFunctionOnColumnInJoinOrWhere(NoFunctionOnColumnInJoinOrWhere),
+    ]
+    .into_iter()
+}
+
+pub fn default_rules() -> Vec<(RuleEnum, Severity)> {
+    all_rules()
+        .map(|rule| {
+            let severity = rule.default_severity();
+            (rule, severity)
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone)]
+pub enum RuleEnum {
+    NoDistinct(NoDistinct),
+    NoNotIn(NoNotIn),
+    NoUnionDistinct(NoUnionDistinct),
+    NoWildcardProjection(NoWildcardProjection),
+    MissingTwoWaySample(MissingTwoWaySample),
+    TooLargeInList(TooLargeInList),
+    NoFunctionOnColumnInJoinOrWhere(NoFunctionOnColumnInJoinOrWhere),
+}
+
+impl RuleEnum {
+    pub fn name(&self) -> &'static str {
+        self.as_rule().name()
+    }
+
+    pub fn default_severity(&self) -> Severity {
+        self.as_rule().default_severity()
+    }
+
+    pub fn target_kinds(&self) -> &'static [SyntaxKind] {
+        self.as_rule().target_kinds()
+    }
+
+    pub fn run_once<'tree>(&self, root: &Node<'tree>, ctx: &mut LintContext, severity: Severity) {
+        self.as_rule().run_once(root, ctx, severity);
+    }
+
+    pub fn run_on_node<'tree>(
+        &self,
+        node: &Node<'tree>,
+        ctx: &mut LintContext,
+        severity: Severity,
+    ) {
+        self.as_rule().run_on_node(node, ctx, severity);
+    }
+
+    pub fn from_name(name: &str) -> Option<Self> {
+        all_rules().find(|rule| rule.name() == name)
+    }
+
+    fn as_rule(&self) -> &dyn Rule {
+        match self {
+            Self::NoDistinct(rule) => rule,
+            Self::NoNotIn(rule) => rule,
+            Self::NoUnionDistinct(rule) => rule,
+            Self::NoWildcardProjection(rule) => rule,
+            Self::MissingTwoWaySample(rule) => rule,
+            Self::TooLargeInList(rule) => rule,
+            Self::NoFunctionOnColumnInJoinOrWhere(rule) => rule,
+        }
+    }
+}

--- a/crates/uroborosql-lint/src/rules/missing_two_way_sample.rs
+++ b/crates/uroborosql-lint/src/rules/missing_two_way_sample.rs
@@ -7,6 +7,7 @@ use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::Node};
 
 /// Detects 2WaySQL bind parameter without sample values (e.g. `/*param*/`).
 /// Rule source: https://future-architect.github.io/uroborosql-doc/background/#バインドパラメータ
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MissingTwoWaySample;
 
 impl Rule for MissingTwoWaySample {
@@ -56,10 +57,13 @@ impl Rule for MissingTwoWaySample {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{linter::tests::run_with_rules, SqlSpan};
+    use crate::{linter::tests::run_with_rules, rules::RuleEnum, SqlSpan};
 
     fn run(sql: &str) -> Vec<Diagnostic> {
-        run_with_rules(sql, vec![Box::new(MissingTwoWaySample)])
+        run_with_rules(
+            sql,
+            vec![RuleEnum::MissingTwoWaySample(MissingTwoWaySample)],
+        )
     }
 
     #[test]

--- a/crates/uroborosql-lint/src/rules/missing_two_way_sample.rs
+++ b/crates/uroborosql-lint/src/rules/missing_two_way_sample.rs
@@ -118,7 +118,7 @@ mod tests {
 
         assert!(diagnostics.iter().all(|diagnostic| {
             let SqlSpan { start, end } = diagnostic.span;
-            &sql[start.byte..end.byte] == ""
+            sql[start.byte..end.byte].is_empty()
         }));
     }
 
@@ -134,7 +134,7 @@ mod tests {
 
         assert!(diagnostics.iter().all(|diagnostic| {
             let SqlSpan { start, end } = diagnostic.span;
-            &sql[start.byte..end.byte] == ""
+            sql[start.byte..end.byte].is_empty()
         }));
     }
 

--- a/crates/uroborosql-lint/src/rules/no_distinct.rs
+++ b/crates/uroborosql-lint/src/rules/no_distinct.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 /// Rule source: https://future-architect.github.io/coding-standards/documents/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88PostgreSQL%EF%BC%89.html#distinct-%E5%8F%A5
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NoDistinct;
 
 impl Rule for NoDistinct {
@@ -36,12 +37,12 @@ impl Rule for NoDistinct {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{diagnostic::Severity, linter::tests::run_with_rules, rule::Rule};
+    use crate::{diagnostic::Severity, linter::tests::run_with_rules, rules::RuleEnum};
 
     #[test]
     fn detects_distinct_keyword() {
         let sql = "SELECT DISTINCT id FROM users;";
-        let diagnostics = run_with_rules(sql, vec![Box::new(NoDistinct) as Box<dyn Rule>]);
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
         assert_eq!(diagnostics.len(), 1);
         let diagnostic = &diagnostics[0];
         assert_eq!(diagnostic.rule_id, "no-distinct");
@@ -53,7 +54,7 @@ mod tests {
     #[test]
     fn ignores_select_without_distinct() {
         let sql = "SELECT id FROM users;";
-        let diagnostics = run_with_rules(sql, vec![Box::new(NoDistinct) as Box<dyn Rule>]);
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
         assert!(diagnostics.is_empty());
     }
 }

--- a/crates/uroborosql-lint/src/rules/no_function_on_column_in_join_or_where.rs
+++ b/crates/uroborosql-lint/src/rules/no_function_on_column_in_join_or_where.rs
@@ -10,6 +10,7 @@ use postgresql_cst_parser::{
 
 /// Detects function usage on columns in JOIN or WHERE conditions.
 /// source: https://future-architect.github.io/coding-standards/documents/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88PostgreSQL%EF%BC%89.html#:~:text=1-,%E3%82%A4%E3%83%B3%E3%83%87%E3%83%83%E3%82%AF%E3%82%B9%E3%82%AB%E3%83%A9%E3%83%A0%E3%81%AB%E9%96%A2%E6%95%B0,-%E3%82%92%E9%80%9A%E3%81%97%E3%81%9F
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NoFunctionOnColumnInJoinOrWhere;
 
 struct Report<'a> {
@@ -104,10 +105,15 @@ fn is_in_detection_range(func_expr: &Node) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{linter::tests::run_with_rules, Diagnostic, SqlSpan};
+    use crate::{linter::tests::run_with_rules, Diagnostic, RuleEnum, SqlSpan};
 
     fn run(sql: &str) -> Vec<Diagnostic> {
-        run_with_rules(sql, vec![Box::new(NoFunctionOnColumnInJoinOrWhere)])
+        run_with_rules(
+            sql,
+            vec![RuleEnum::NoFunctionOnColumnInJoinOrWhere(
+                NoFunctionOnColumnInJoinOrWhere,
+            )],
+        )
     }
 
     mod where_clause {

--- a/crates/uroborosql-lint/src/rules/no_not_in.rs
+++ b/crates/uroborosql-lint/src/rules/no_not_in.rs
@@ -11,6 +11,7 @@ use postgresql_cst_parser::{
 
 /// Detects NOT IN expressions.
 /// Rule source: https://future-architect.github.io/coding-standards/documents/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88PostgreSQL%EF%BC%89.html#not-in-%E5%8F%A5
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NoNotIn;
 
 impl Rule for NoNotIn {
@@ -68,12 +69,12 @@ fn detect_not_in(node: &Node<'_>) -> Option<Range> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{linter::tests::run_with_rules, SqlSpan};
+    use crate::{linter::tests::run_with_rules, rules::RuleEnum, SqlSpan};
 
     #[test]
     fn detects_simple_not_in() {
         let sql = "SELECT value FROM users WHERE id NOT IN (1, 2);";
-        let diagnostics = run_with_rules(sql, vec![Box::new(NoNotIn)]);
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoNotIn(NoNotIn)]);
 
         let diagnostic = diagnostics
             .iter()
@@ -87,7 +88,7 @@ mod tests {
     #[test]
     fn detects_not_in_with_comment() {
         let sql = "SELECT value FROM users WHERE id NOT /* comment */ IN (1);";
-        let diagnostics = run_with_rules(sql, vec![Box::new(NoNotIn)]);
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoNotIn(NoNotIn)]);
 
         let diagnostic = diagnostics
             .iter()
@@ -101,7 +102,7 @@ mod tests {
     #[test]
     fn detects_not_in_with_subquery() {
         let sql = "SELECT value FROM users WHERE id NOT IN (SELECT id FROM admins);";
-        let diagnostics = run_with_rules(sql, vec![Box::new(NoNotIn)]);
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoNotIn(NoNotIn)]);
 
         assert!(
             diagnostics.iter().any(|diag| diag.rule_id == "no-not-in"),
@@ -112,14 +113,14 @@ mod tests {
     #[test]
     fn allows_in_without_not() {
         let sql = "SELECT value FROM users WHERE id IN (1, 2);";
-        let diagnostics = run_with_rules(sql, vec![Box::new(NoNotIn)]);
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoNotIn(NoNotIn)]);
         assert!(diagnostics.is_empty());
     }
 
     #[test]
     fn allows_not_between() {
         let sql = "SELECT value FROM users WHERE id NOT BETWEEN 1 AND 5;";
-        let diagnostics = run_with_rules(sql, vec![Box::new(NoNotIn)]);
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoNotIn(NoNotIn)]);
         assert!(diagnostics.is_empty(), "NOT BETWEEN should be allowed");
     }
 }

--- a/crates/uroborosql-lint/src/rules/no_union_distinct.rs
+++ b/crates/uroborosql-lint/src/rules/no_union_distinct.rs
@@ -9,6 +9,7 @@ use postgresql_cst_parser::{
 };
 
 /// Rule source: https://future-architect.github.io/coding-standards/documents/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88PostgreSQL%EF%BC%89.html#union-%E5%8F%A5
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NoUnionDistinct;
 
 impl Rule for NoUnionDistinct {
@@ -91,12 +92,12 @@ fn extend_range(base: Range, extension: Range) -> Range {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{linter::tests::run_with_rules, SqlSpan};
+    use crate::{linter::tests::run_with_rules, rules::RuleEnum, SqlSpan};
 
     #[test]
     fn detects_union_without_all() {
         let sql = "SELECT 1 UNION SELECT 2;";
-        let diagnostics = run_with_rules(sql, vec![Box::new(NoUnionDistinct)]);
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoUnionDistinct(NoUnionDistinct)]);
         let diagnostic = diagnostics
             .iter()
             .find(|diag| diag.rule_id == "no-union-distinct")
@@ -109,7 +110,7 @@ mod tests {
     #[test]
     fn detects_union_distinct() {
         let sql = "SELECT 1 UNION DISTINCT SELECT 2;";
-        let diagnostics = run_with_rules(sql, vec![Box::new(NoUnionDistinct)]);
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoUnionDistinct(NoUnionDistinct)]);
         let diagnostic = diagnostics
             .iter()
             .find(|diag| diag.rule_id == "no-union-distinct")
@@ -122,7 +123,7 @@ mod tests {
     #[test]
     fn detects_union_distinct_with_comment() {
         let sql = "SELECT 1 UNION /* comment */ DISTINCT SELECT 2;";
-        let diagnostics = run_with_rules(sql, vec![Box::new(NoUnionDistinct)]);
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoUnionDistinct(NoUnionDistinct)]);
         let diagnostic = diagnostics
             .iter()
             .find(|diag| diag.rule_id == "no-union-distinct")
@@ -135,7 +136,7 @@ mod tests {
     #[test]
     fn allows_union_all() {
         let sql = "SELECT 1 UNION ALL SELECT 2;";
-        let diagnostics = run_with_rules(sql, vec![Box::new(NoUnionDistinct)]);
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoUnionDistinct(NoUnionDistinct)]);
         assert!(
             diagnostics
                 .iter()
@@ -147,7 +148,7 @@ mod tests {
     #[test]
     fn allows_union_all_with_comment() {
         let sql = "SELECT 1 UNION /* comment */ ALL SELECT 2;";
-        let diagnostics = run_with_rules(sql, vec![Box::new(NoUnionDistinct)]);
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoUnionDistinct(NoUnionDistinct)]);
 
         assert_eq!(diagnostics.len(), 0);
     }

--- a/crates/uroborosql-lint/src/rules/no_wildcard_projection.rs
+++ b/crates/uroborosql-lint/src/rules/no_wildcard_projection.rs
@@ -10,6 +10,7 @@ use postgresql_cst_parser::{
 
 /// Detects wildcard projections. (e.g. `SELECT *`, `SELECT u.*`, `RETURNING *`)
 /// Rule source: https://future-architect.github.io/coding-standards/documents/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88PostgreSQL%EF%BC%89.html#%E6%A4%9C%E7%B4%A2:~:text=%E3%82%92%E6%8C%87%E5%AE%9A%E3%81%99%E3%82%8B-,%E5%85%A8%E5%88%97%E3%83%AF%E3%82%A4%E3%83%AB%E3%83%89%E3%82%AB%E3%83%BC%E3%83%89%E3%80%8C*%E3%80%8D%E3%81%AE%E4%BD%BF%E7%94%A8%E3%81%AF%E3%81%9B%E3%81%9A%E3%80%81%E3%82%AB%E3%83%A9%E3%83%A0%E5%90%8D%E3%82%92%E6%98%8E%E8%A8%98%E3%81%99%E3%82%8B,-%E3%82%A4%E3%83%B3%E3%83%87%E3%83%83%E3%82%AF%E3%82%B9%E3%81%AB%E3%82%88%E3%82%8B%E6%A4%9C%E7%B4%A2
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NoWildcardProjection;
 
 impl Rule for NoWildcardProjection {
@@ -56,10 +57,13 @@ fn detect_wildcard(target_el_node: &Node<'_>) -> Option<Range> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{linter::tests::run_with_rules, SqlSpan};
+    use crate::{linter::tests::run_with_rules, rules::RuleEnum, SqlSpan};
 
     fn run(sql: &str) -> Vec<Diagnostic> {
-        run_with_rules(sql, vec![Box::new(NoWildcardProjection)])
+        run_with_rules(
+            sql,
+            vec![RuleEnum::NoWildcardProjection(NoWildcardProjection)],
+        )
     }
 
     #[test]

--- a/crates/uroborosql-lint/src/rules/too_large_in_list.rs
+++ b/crates/uroborosql-lint/src/rules/too_large_in_list.rs
@@ -8,6 +8,7 @@ use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::Node};
 const MAX_IN_ELEMENTS: usize = 100;
 
 /// Rule source: https://future-architect.github.io/coding-standards/documents/forSQL/SQL%E3%82%B3%E3%83%BC%E3%83%87%E3%82%A3%E3%83%B3%E3%82%B0%E8%A6%8F%E7%B4%84%EF%BC%88PostgreSQL%EF%BC%89.html#in-%E5%8F%A5-1
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TooLargeInList;
 
 impl Rule for TooLargeInList {
@@ -59,10 +60,10 @@ fn count_expr_list_elements(node: &Node<'_>) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::linter::tests::run_with_rules;
+    use crate::{linter::tests::run_with_rules, rules::RuleEnum};
 
     fn run(sql: &str) -> Vec<Diagnostic> {
-        run_with_rules(sql, vec![Box::new(TooLargeInList)])
+        run_with_rules(sql, vec![RuleEnum::TooLargeInList(TooLargeInList)])
     }
 
     fn repetitions(count: usize) -> String {

--- a/crates/uroborosql-lint/tests/config_store.rs
+++ b/crates/uroborosql-lint/tests/config_store.rs
@@ -1,0 +1,84 @@
+use std::fs;
+
+use tempfile::tempdir;
+use uroborosql_lint::{ConfigStore, ResolvedLintConfig, Severity, DEFAULT_CONFIG_FILENAME};
+
+fn write_config(root: &std::path::Path, contents: &str) {
+    let path = root.join(DEFAULT_CONFIG_FILENAME);
+    fs::write(path, contents).expect("write config");
+}
+
+fn severity_for_rule(state: &ResolvedLintConfig, name: &str) -> Option<Severity> {
+    state
+        .rules
+        .iter()
+        .find_map(|(rule, severity)| (rule.name() == name).then_some(*severity))
+}
+
+#[test]
+fn reads_config_from_root_file() {
+    let temp = tempdir().expect("tempdir");
+    write_config(
+        temp.path(),
+        r#"{
+  "rules": {
+    "no-distinct": "error"
+  }
+}"#,
+    );
+
+    let store = ConfigStore::new(temp.path().to_path_buf(), None).expect("config store");
+    let state = store.resolve(&temp.path().join("src/query.sql"));
+
+    assert_eq!(
+        severity_for_rule(&state, "no-distinct"),
+        Some(Severity::Error)
+    );
+}
+
+#[test]
+fn applies_overrides_by_path() {
+    let temp = tempdir().expect("tempdir");
+    write_config(
+        temp.path(),
+        r#"{
+  "rules": {
+    "no-distinct": "error"
+  },
+  "overrides": [
+    {
+      "files": ["test/**/*.sql"],
+      "rules": {
+        "no-distinct": "off"
+      }
+    }
+  ]
+}"#,
+    );
+
+    let store = ConfigStore::new(temp.path().to_path_buf(), None).expect("config store");
+    let state_src = store.resolve(&temp.path().join("src/main.sql"));
+    let state_test = store.resolve(&temp.path().join("test/case.sql"));
+
+    assert_eq!(
+        severity_for_rule(&state_src, "no-distinct"),
+        Some(Severity::Error)
+    );
+    assert_eq!(severity_for_rule(&state_test, "no-distinct"), None);
+}
+
+#[test]
+fn ignores_paths_matching_ignore_globs() {
+    let temp = tempdir().expect("tempdir");
+    write_config(
+        temp.path(),
+        r#"{
+  "ignore": ["dist/**"]
+}"#,
+    );
+
+    let store = ConfigStore::new(temp.path().to_path_buf(), None).expect("config store");
+
+    assert!(store.is_ignored(&temp.path().join("dist/app.sql")));
+    assert!(!store.is_ignored(&temp.path().join("src/app.sql")));
+}

--- a/crates/uroborosql-lint/tests/config_store.rs
+++ b/crates/uroborosql-lint/tests/config_store.rs
@@ -82,3 +82,39 @@ fn ignores_paths_matching_ignore_globs() {
     assert!(store.is_ignored(&temp.path().join("dist/app.sql")));
     assert!(!store.is_ignored(&temp.path().join("src/app.sql")));
 }
+
+#[test]
+fn uses_explicit_config_parent_as_root_dir() {
+    let temp = tempdir().expect("tempdir");
+    let config_root = temp.path().join("project");
+    let cwd = temp.path().join("cwd");
+
+    fs::create_dir_all(config_root.join("dist")).expect("create dist dir");
+    fs::create_dir_all(config_root.join("src")).expect("create src dir");
+    fs::create_dir_all(&cwd).expect("create cwd dir");
+
+    write_config(
+        &config_root,
+        r#"{
+  "ignore": ["dist/**"],
+  "overrides": [
+    {
+      "files": ["test/**/*.sql"],
+      "rules": {
+        "no-distinct": "off"
+      }
+    }
+  ]
+}"#,
+    );
+
+    let config_path = config_root.join(DEFAULT_CONFIG_FILENAME);
+    let store = ConfigStore::new(cwd, Some(config_path)).expect("config store");
+
+    assert_eq!(store.root_dir(), config_root.as_path());
+    assert!(store.is_ignored(&config_root.join("dist/app.sql")));
+    assert!(!store.is_ignored(&config_root.join("src/app.sql")));
+
+    let state_test = store.resolve(&config_root.join("test/case.sql"));
+    assert_eq!(severity_for_rule(&state_test, "no-distinct"), None);
+}

--- a/crates/uroborosql-lint/tests/config_store.rs
+++ b/crates/uroborosql-lint/tests/config_store.rs
@@ -1,7 +1,9 @@
 use std::fs;
 
 use tempfile::tempdir;
-use uroborosql_lint::{ConfigStore, ResolvedLintConfig, Severity, DEFAULT_CONFIG_FILENAME};
+use uroborosql_lint::{
+    ConfigError, ConfigStore, ResolvedLintConfig, Severity, DEFAULT_CONFIG_FILENAME,
+};
 
 fn write_config(root: &std::path::Path, contents: &str) {
     let path = root.join(DEFAULT_CONFIG_FILENAME);
@@ -126,4 +128,59 @@ fn keeps_cwd_as_root_dir_for_explicit_config() {
 
     let state_test = store.resolve(&test_file.canonicalize().expect("canonicalize test file"));
     assert_eq!(severity_for_rule(&state_test, "no-distinct"), None);
+}
+
+#[test]
+fn rejects_unknown_rule_in_root_rules() {
+    let temp = tempdir().expect("tempdir");
+    write_config(
+        temp.path(),
+        r#"{
+  "rules": {
+    "no-distnct": "error",
+    "no-dstinct": "warn"
+  }
+}"#,
+    );
+
+    let err = ConfigStore::new(temp.path().to_path_buf(), None).expect_err("unknown rule error");
+
+    assert!(matches!(
+        err,
+        ConfigError::UnknownRules { rules }
+            if rules == vec!["no-distnct".to_string(), "no-dstinct".to_string()]
+    ));
+}
+
+#[test]
+fn rejects_unknown_rule_in_override_rules() {
+    let temp = tempdir().expect("tempdir");
+    write_config(
+        temp.path(),
+        r#"{
+  "overrides": [
+    {
+      "files": ["test/**/*.sql"],
+      "rules": {
+        "no-distnct": "off"
+      }
+    },
+    {
+      "files": ["src/**/*.sql"],
+      "rules": {
+        "no-dstinct": "warn",
+        "no-distnct": "error"
+      }
+    }
+  ]
+}"#,
+    );
+
+    let err = ConfigStore::new(temp.path().to_path_buf(), None).expect_err("unknown rule error");
+
+    assert!(matches!(
+        err,
+        ConfigError::UnknownRules { rules }
+            if rules == vec!["no-distnct".to_string(), "no-dstinct".to_string()]
+    ));
 }

--- a/crates/uroborosql-lint/tests/config_store.rs
+++ b/crates/uroborosql-lint/tests/config_store.rs
@@ -84,18 +84,20 @@ fn ignores_paths_matching_ignore_globs() {
 }
 
 #[test]
-fn uses_explicit_config_parent_as_root_dir() {
+fn keeps_cwd_as_root_dir_for_explicit_config() {
     let temp = tempdir().expect("tempdir");
-    let config_root = temp.path().join("project");
-    let cwd = temp.path().join("cwd");
-    let dist_file = config_root.join("dist/app.sql");
-    let src_file = config_root.join("src/app.sql");
-    let test_file = config_root.join("test/case.sql");
+    let temp_root = temp.path().canonicalize().expect("canonicalize temp root");
+    let config_root = temp_root.join("project");
+    let cwd = temp_root.join("cwd");
+    let dist_file = cwd.join("dist/app.sql");
+    let src_file = cwd.join("src/app.sql");
+    let test_file = cwd.join("test/case.sql");
 
-    fs::create_dir_all(config_root.join("dist")).expect("create dist dir");
-    fs::create_dir_all(config_root.join("src")).expect("create src dir");
-    fs::create_dir_all(config_root.join("test")).expect("create test dir");
+    fs::create_dir_all(&config_root).expect("create config root");
     fs::create_dir_all(&cwd).expect("create cwd dir");
+    fs::create_dir_all(cwd.join("dist")).expect("create dist dir");
+    fs::create_dir_all(cwd.join("src")).expect("create src dir");
+    fs::create_dir_all(cwd.join("test")).expect("create test dir");
     fs::write(&dist_file, "select 1").expect("write dist file");
     fs::write(&src_file, "select 1").expect("write src file");
     fs::write(&test_file, "select distinct foo from bar").expect("write test file");
@@ -116,14 +118,9 @@ fn uses_explicit_config_parent_as_root_dir() {
     );
 
     let config_path = config_root.join(DEFAULT_CONFIG_FILENAME);
-    let store = ConfigStore::new(cwd, Some(config_path)).expect("config store");
+    let store = ConfigStore::new(cwd.clone(), Some(config_path)).expect("config store");
 
-    assert_eq!(
-        store.root_dir(),
-        config_root
-            .canonicalize()
-            .expect("canonicalize config root")
-    );
+    assert_eq!(store.root_dir(), cwd.as_path());
     assert!(store.is_ignored(&dist_file.canonicalize().expect("canonicalize dist file")));
     assert!(!store.is_ignored(&src_file.canonicalize().expect("canonicalize src file")));
 

--- a/crates/uroborosql-lint/tests/config_store.rs
+++ b/crates/uroborosql-lint/tests/config_store.rs
@@ -131,6 +131,39 @@ fn keeps_cwd_as_root_dir_for_explicit_config() {
 }
 
 #[test]
+fn resolves_db_file_path_relative_to_explicit_config() {
+    let temp = tempdir().expect("tempdir");
+    let temp_root = temp.path().canonicalize().expect("canonicalize temp root");
+    let config_root = temp_root.join("project/config");
+    let cwd = temp_root.join("cwd");
+    let schema_path = config_root.join("schema/schema.sql");
+
+    fs::create_dir_all(schema_path.parent().expect("schema parent")).expect("create schema dir");
+    fs::create_dir_all(&cwd).expect("create cwd dir");
+    fs::write(&schema_path, "create table users (id bigint);").expect("write schema file");
+
+    write_config(
+        &config_root,
+        r#"{
+  "db": {
+    "schemaProvider": "file",
+    "path": "schema/schema.sql"
+  }
+}"#,
+    );
+
+    let config_path = config_root.join(DEFAULT_CONFIG_FILENAME);
+    let store = ConfigStore::new(cwd, Some(config_path)).expect("config store");
+    let state = store.resolve(temp_root.join("anywhere/query.sql").as_path());
+
+    let db = state.db.expect("resolved db config");
+    assert_eq!(
+        format!("{db:?}"),
+        format!("File {{ path: {:?} }}", schema_path)
+    );
+}
+
+#[test]
 fn rejects_unknown_rule_in_root_rules() {
     let temp = tempdir().expect("tempdir");
     write_config(

--- a/crates/uroborosql-lint/tests/config_store.rs
+++ b/crates/uroborosql-lint/tests/config_store.rs
@@ -88,10 +88,17 @@ fn uses_explicit_config_parent_as_root_dir() {
     let temp = tempdir().expect("tempdir");
     let config_root = temp.path().join("project");
     let cwd = temp.path().join("cwd");
+    let dist_file = config_root.join("dist/app.sql");
+    let src_file = config_root.join("src/app.sql");
+    let test_file = config_root.join("test/case.sql");
 
     fs::create_dir_all(config_root.join("dist")).expect("create dist dir");
     fs::create_dir_all(config_root.join("src")).expect("create src dir");
+    fs::create_dir_all(config_root.join("test")).expect("create test dir");
     fs::create_dir_all(&cwd).expect("create cwd dir");
+    fs::write(&dist_file, "select 1").expect("write dist file");
+    fs::write(&src_file, "select 1").expect("write src file");
+    fs::write(&test_file, "select distinct foo from bar").expect("write test file");
 
     write_config(
         &config_root,
@@ -111,10 +118,15 @@ fn uses_explicit_config_parent_as_root_dir() {
     let config_path = config_root.join(DEFAULT_CONFIG_FILENAME);
     let store = ConfigStore::new(cwd, Some(config_path)).expect("config store");
 
-    assert_eq!(store.root_dir(), config_root.as_path());
-    assert!(store.is_ignored(&config_root.join("dist/app.sql")));
-    assert!(!store.is_ignored(&config_root.join("src/app.sql")));
+    assert_eq!(
+        store.root_dir(),
+        config_root
+            .canonicalize()
+            .expect("canonicalize config root")
+    );
+    assert!(store.is_ignored(&dist_file.canonicalize().expect("canonicalize dist file")));
+    assert!(!store.is_ignored(&src_file.canonicalize().expect("canonicalize src file")));
 
-    let state_test = store.resolve(&config_root.join("test/case.sql"));
+    let state_test = store.resolve(&test_file.canonicalize().expect("canonicalize test file"));
     assert_eq!(severity_for_rule(&state_test, "no-distinct"), None);
 }


### PR DESCRIPTION
## 概要

`uroborosql-lint` に config 解決処理を追加し、`uroborosql-lint-cli` から利用可能にしました。

## 変更

- `uroborosql-lint` に config 解決処理を追加
- `uroborosql-lint-cli` に `--config` オプションを追加

設定ファイルの項目については [crates/uroborosql-lint/README.md](https://github.com/future-architect/uroborosql-fmt/blob/feat/lint-config/crates/uroborosql-lint/README.md) に記載しています
