### PR TITLE
feat(lint): support directive comments

### DIFF
--- a/crates/uroborosql-language-server/src/lint.rs
+++ b/crates/uroborosql-language-server/src/lint.rs
@@ -96,7 +96,7 @@ fn to_lsp_diagnostic(diag: SqlDiagnostic, rope: Option<&ropey::Rope>) -> Diagnos
     Diagnostic {
         range,
         severity,
-        code: Some(NumberOrString::String(diag.rule_id.to_string())),
+        code: Some(NumberOrString::String(diag.code.to_string())),
         source: Some("uroborosql-lint".into()),
         message: diag.message,
         ..Diagnostic::default()

--- a/crates/uroborosql-language-server/tests/diagnostics.rs
+++ b/crates/uroborosql-language-server/tests/diagnostics.rs
@@ -97,7 +97,7 @@ async fn diagnostics_include_invalid_directive_warning() {
     server
         .send_request(build_did_open(
             &uri,
-            "-- uroborosql-lint-disable no-dstinct\nSELECT DISTINCT id FROM users;",
+            "-- uroborosql-lint-disable definitely-not-a-rule\nSELECT DISTINCT id FROM users;",
             1,
         ))
         .await;

--- a/crates/uroborosql-language-server/tests/diagnostics.rs
+++ b/crates/uroborosql-language-server/tests/diagnostics.rs
@@ -86,3 +86,37 @@ async fn did_change_watched_files_relints_open_documents() {
     let diag_notification = server.receive_notification().await;
     assert_eq!(diag_notification.method(), PublishDiagnostics::METHOD);
 }
+
+#[tokio::test]
+async fn diagnostics_include_invalid_directive_warning() {
+    let mut server = new_test_server();
+    let uri = Uri::from_str("file:///directive.sql").unwrap();
+
+    initialize_server(&mut server).await;
+
+    server
+        .send_request(build_did_open(
+            &uri,
+            "-- uroborosql-lint-disable no-dstinct\nSELECT DISTINCT id FROM users;",
+            1,
+        ))
+        .await;
+    let diag_notification = server.receive_notification().await;
+    assert_eq!(diag_notification.method(), PublishDiagnostics::METHOD);
+
+    let diagnostics = diag_notification.params().unwrap()["diagnostics"]
+        .as_array()
+        .unwrap()
+        .clone();
+    assert_eq!(diagnostics.len(), 2);
+    assert_eq!(
+        diagnostics[0]["code"].as_str(),
+        Some("invalid-lint-directive")
+    );
+    assert_eq!(diagnostics[0]["range"]["start"]["line"].as_u64(), Some(0));
+    assert_eq!(
+        diagnostics[0]["range"]["start"]["character"].as_u64(),
+        Some(27)
+    );
+    assert_eq!(diagnostics[1]["code"].as_str(), Some("no-distinct"));
+}

--- a/crates/uroborosql-lint-cli/src/main.rs
+++ b/crates/uroborosql-lint-cli/src/main.rs
@@ -78,9 +78,9 @@ fn print_diagnostic(file: &str, diagnostic: &Diagnostic) {
     let column = diagnostic.span.start.column + 1;
 
     println!(
-        "{file}:{line}:{column}: {severity_label}: {rule_id}: {message}",
+        "{file}:{line}:{column}: {severity_label}: {code}: {message}",
         severity_label = severity_label(diagnostic.severity),
-        rule_id = diagnostic.rule_id,
+        code = diagnostic.code,
         message = diagnostic.message
     );
 }

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -33,8 +33,8 @@ Behavior:
 - `disable` suppresses rules for the whole file, but only when it appears in the file head comment section
 - The file head comment section is the leading sequence of blank lines and line comments
 - A block comment ends that file head section, so any later `disable` directive is ignored
-- Unknown rule names in directives produce an `invalid-lint-directive` warning on the comment
-- Missing rule names, trailing commas, and other invalid directive syntax also produce an `invalid-lint-directive` warning
+- Unknown rule names in directives produce an `invalid-lint-directive` warning on the comment, while known rules in the same directive still apply
+- Missing rule names, empty comma-separated elements, and trailing commas also produce an `invalid-lint-directive` warning
 
 Example:
 

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -4,6 +4,37 @@
 
 The default config file name is `.uroborosqllintrc.json`.
 
+## Directive Comments
+
+Line comment directives can suppress specific lint rules directly in SQL.
+
+Supported directives:
+
+- `-- uroborosql-lint-disable <rules>`
+- `-- uroborosql-lint-disable-next-line <rules>`
+
+Rules must be comma-separated canonical rule names such as `no-distinct` or `no-wildcard-projection`.
+
+Example:
+
+```sql
+-- uroborosql-lint-disable no-distinct
+SELECT DISTINCT id FROM users;
+```
+
+```sql
+-- uroborosql-lint-disable-next-line no-distinct, no-wildcard-projection
+SELECT DISTINCT * FROM users;
+```
+
+Behavior:
+
+- `disable-next-line` suppresses diagnostics whose start position is on the next physical line only
+- `disable` suppresses rules for the whole file, but only when it appears in the file head comment section
+- The file head comment section is the leading sequence of blank lines and line comments
+- A block comment ends that file head section, so any later `disable` directive is ignored
+- Invalid directives are ignored silently in the current implementation
+
 Example:
 
 ```json

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -34,7 +34,7 @@ Behavior:
 - The file head comment section is the leading sequence of blank lines and line comments
 - A block comment ends that file head section, so any later `disable` directive is ignored
 - Unknown rule names in directives produce an `invalid-lint-directive` warning on the comment
-- Other invalid directives are ignored silently in the current implementation
+- Missing rule names, trailing commas, and other invalid directive syntax also produce an `invalid-lint-directive` warning
 
 Example:
 

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -33,7 +33,8 @@ Behavior:
 - `disable` suppresses rules for the whole file, but only when it appears in the file head comment section
 - The file head comment section is the leading sequence of blank lines and line comments
 - A block comment ends that file head section, so any later `disable` directive is ignored
-- Invalid directives are ignored silently in the current implementation
+- Unknown rule names in directives produce an `invalid-lint-directive` warning on the comment
+- Other invalid directives are ignored silently in the current implementation
 
 Example:
 

--- a/crates/uroborosql-lint/src/diagnostic.rs
+++ b/crates/uroborosql-lint/src/diagnostic.rs
@@ -37,9 +37,9 @@ impl SqlSpan {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Diagnostic {
-    pub rule_id: &'static str,
+    pub code: &'static str,
     pub message: String,
     pub severity: Severity,
     pub span: SqlSpan,
@@ -47,13 +47,13 @@ pub struct Diagnostic {
 
 impl Diagnostic {
     pub fn new(
-        rule_id: &'static str,
+        code: &'static str,
         severity: Severity,
         message: impl Into<String>,
         range: &Range,
     ) -> Self {
         Self {
-            rule_id,
+            code,
             severity,
             message: message.into(),
             span: SqlSpan::from_range(range),

--- a/crates/uroborosql-lint/src/directive.rs
+++ b/crates/uroborosql-lint/src/directive.rs
@@ -301,12 +301,6 @@ fn apply_directives(diagnostics: Vec<Diagnostic>, directives: &[LintDirective]) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        diagnostic::Severity,
-        linter::tests::run_with_rules,
-        rules::{NoDistinct, NoWildcardProjection, RuleEnum},
-        Linter, ResolvedLintConfig,
-    };
     use postgresql_cst_parser::tree_sitter;
 
     fn parse(sql: &str) -> postgresql_cst_parser::tree_sitter::Tree {
@@ -390,100 +384,6 @@ mod tests {
     }
 
     #[test]
-    fn disable_next_line_suppresses_only_the_next_physical_line() {
-        let sql = r#"-- uroborosql-lint-disable-next-line no-distinct
-SELECT DISTINCT id FROM users;
-SELECT DISTINCT name FROM users;"#;
-
-        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
-
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-    }
-
-    #[test]
-    fn disable_next_line_does_not_skip_blank_lines() {
-        let sql = r#"-- uroborosql-lint-disable-next-line no-distinct
-
-SELECT DISTINCT id FROM users;"#;
-
-        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
-
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.start.line, 2);
-    }
-
-    #[test]
-    fn file_head_disable_suppresses_requested_rule_only() {
-        let sql = r#"-- uroborosql-lint-disable no-distinct
-SELECT DISTINCT * FROM users;"#;
-
-        let diagnostics = run_with_rules(
-            sql,
-            vec![
-                RuleEnum::NoDistinct(NoDistinct),
-                RuleEnum::NoWildcardProjection(NoWildcardProjection),
-            ],
-        );
-
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].code, "no-wildcard-projection");
-    }
-
-    #[test]
-    fn file_head_disable_remains_effective_after_block_comment() {
-        let sql = r#"-- uroborosql-lint-disable no-distinct
-/* comment */
-SELECT DISTINCT id FROM users;"#;
-
-        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
-
-        assert!(diagnostics.is_empty());
-    }
-
-    #[test]
-    fn disable_after_block_comment_is_ignored() {
-        let sql = r#"/* comment */
--- uroborosql-lint-disable no-distinct
-SELECT DISTINCT id FROM users;"#;
-
-        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
-
-        assert_eq!(diagnostics.len(), 1);
-    }
-
-    #[test]
-    fn file_head_disable_and_next_line_directives_compose() {
-        let sql = r#"-- uroborosql-lint-disable no-distinct
--- uroborosql-lint-disable-next-line no-wildcard-projection
-SELECT DISTINCT * FROM users;"#;
-
-        let diagnostics = run_with_rules(
-            sql,
-            vec![
-                RuleEnum::NoDistinct(NoDistinct),
-                RuleEnum::NoWildcardProjection(NoWildcardProjection),
-            ],
-        );
-
-        assert!(diagnostics.is_empty());
-    }
-
-    #[test]
-    fn linter_run_returns_suppressed_diagnostics() {
-        let sql = r#"-- uroborosql-lint-disable no-distinct
-SELECT DISTINCT id FROM users;"#;
-        let resolved_config = ResolvedLintConfig {
-            rules: vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)],
-            db: None,
-        };
-
-        let diagnostics = Linter::new().run(sql, &resolved_config).expect("lint ok");
-
-        assert!(diagnostics.is_empty());
-    }
-
-    #[test]
     fn extracts_only_head_disable_directives() {
         let sql = r#"-- uroborosql-lint-disable no-distinct
 SELECT 1;
@@ -501,48 +401,5 @@ SELECT 1;
                 rules: vec!["no-distinct".to_string()],
             }]
         );
-    }
-
-    #[test]
-    fn unknown_rule_in_directive_produces_warning_on_rule_name() {
-        let sql = r#"-- uroborosql-lint-disable no-dstinct
-SELECT DISTINCT id FROM users;"#;
-        let resolved_config = ResolvedLintConfig {
-            rules: vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)],
-            db: None,
-        };
-
-        let diagnostics = Linter::new().run(sql, &resolved_config).expect("lint ok");
-
-        assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].code, INVALID_LINT_DIRECTIVE_CODE);
-        assert_eq!(
-            diagnostics[0].message,
-            "unknown lint directive rule `no-dstinct`"
-        );
-        assert_eq!(diagnostics[0].span.start.line, 0);
-        assert_eq!(diagnostics[0].span.start.column, 27);
-        assert_eq!(diagnostics[0].span.end.column, 37);
-        assert_eq!(diagnostics[1].code, "no-distinct");
-    }
-
-    #[test]
-    fn invalid_directive_syntax_produces_warning() {
-        let sql = r#"-- uroborosql-lint-disable no-distinct because reason
-SELECT DISTINCT id FROM users;"#;
-        let resolved_config = ResolvedLintConfig {
-            rules: vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)],
-            db: None,
-        };
-
-        let diagnostics = Linter::new().run(sql, &resolved_config).expect("lint ok");
-
-        assert_eq!(diagnostics.len(), 2);
-        assert_eq!(diagnostics[0].code, INVALID_LINT_DIRECTIVE_CODE);
-        assert_eq!(
-            diagnostics[0].message,
-            "invalid lint directive syntax: expected comma-separated rule names"
-        );
-        assert_eq!(diagnostics[1].code, "no-distinct");
     }
 }

--- a/crates/uroborosql-lint/src/directive.rs
+++ b/crates/uroborosql-lint/src/directive.rs
@@ -364,17 +364,11 @@ mod tests {
     fn rejects_invalid_directive_inputs() {
         assert!(matches!(
             parse_comment_directive("-- uroborosql-lint-disable"),
-            ParsedDirective::Invalid(Diagnostic {
-                message,
-                ..
-            }) if message == "invalid lint directive syntax: expected one or more comma-separated rule names"
+            ParsedDirective::Invalid(_)
         ));
         assert!(matches!(
             parse_comment_directive("-- uroborosql-lint-disable no-distinct,"),
-            ParsedDirective::Invalid(Diagnostic {
-                message,
-                ..
-            }) if message == "invalid lint directive syntax: trailing comma is not allowed"
+            ParsedDirective::Invalid(_)
         ));
         assert!(matches!(
             parse_comment_directive("-- uroborosql-lint-disable unknown-rule"),
@@ -382,10 +376,7 @@ mod tests {
         ));
         assert!(matches!(
             parse_comment_directive("-- uroborosql-lint-disable no-distinct because reason"),
-            ParsedDirective::Invalid(Diagnostic {
-                message,
-                ..
-            }) if message == "invalid lint directive syntax: expected comma-separated rule names"
+            ParsedDirective::Invalid(_)
         ));
     }
 

--- a/crates/uroborosql-lint/src/directive.rs
+++ b/crates/uroborosql-lint/src/directive.rs
@@ -48,7 +48,11 @@ fn extract_directives<'tree>(root: &Node<'tree>) -> (Vec<LintDirective>, Vec<Dia
         match parse_directive(&comment) {
             ParsedDirective::NotDirective => {}
             ParsedDirective::Invalid(diagnostic) => diagnostics.push(diagnostic),
-            ParsedDirective::Valid(directive) => {
+            ParsedDirective::Valid {
+                directive,
+                diagnostics: mut directive_diagnostics,
+            } => {
+                diagnostics.append(&mut directive_diagnostics);
                 if directive.kind == LintDirectiveKind::Disable
                     && comment.range().start_byte >= file_head_comment_end_byte
                 {
@@ -83,7 +87,10 @@ fn file_head_comment_end_byte<'tree>(root: &Node<'tree>) -> usize {
 enum ParsedDirective {
     NotDirective,
     Invalid(Diagnostic),
-    Valid(LintDirective),
+    Valid {
+        directive: LintDirective,
+        diagnostics: Vec<Diagnostic>,
+    },
 }
 
 fn parse_directive<'tree>(comment: &Node<'tree>) -> ParsedDirective {
@@ -99,82 +106,72 @@ fn parse_directive<'tree>(comment: &Node<'tree>) -> ParsedDirective {
     let body_offset = comment_text.len() - body.len();
 
     if let Some(rest) = body.strip_prefix(DISABLE_NEXT_LINE) {
-        return parse_rules(comment, rest, body_offset + DISABLE_NEXT_LINE.len()).map_or(
-            ParsedDirective::NotDirective,
-            |parsed| match parsed {
-                ParsedRules::Valid(rules) => ParsedDirective::Valid(LintDirective {
+        return match parse_rules(comment, rest, body_offset + DISABLE_NEXT_LINE.len()) {
+            ParsedRules::Valid { rules, diagnostics } => ParsedDirective::Valid {
+                directive: LintDirective {
                     kind: LintDirectiveKind::DisableNextLine,
                     line,
                     rules,
-                }),
-                ParsedRules::Invalid(diagnostic) => ParsedDirective::Invalid(diagnostic),
-                ParsedRules::Ignore => ParsedDirective::NotDirective,
+                },
+                diagnostics,
             },
-        );
+            ParsedRules::Invalid(diagnostic) => ParsedDirective::Invalid(diagnostic),
+            ParsedRules::NotDirective => ParsedDirective::NotDirective,
+        };
     }
 
     if let Some(rest) = body.strip_prefix(DISABLE) {
-        return parse_rules(comment, rest, body_offset + DISABLE.len()).map_or(
-            ParsedDirective::NotDirective,
-            |parsed| match parsed {
-                ParsedRules::Valid(rules) => ParsedDirective::Valid(LintDirective {
+        return match parse_rules(comment, rest, body_offset + DISABLE.len()) {
+            ParsedRules::Valid { rules, diagnostics } => ParsedDirective::Valid {
+                directive: LintDirective {
                     kind: LintDirectiveKind::Disable,
                     line,
                     rules,
-                }),
-                ParsedRules::Invalid(diagnostic) => ParsedDirective::Invalid(diagnostic),
-                ParsedRules::Ignore => ParsedDirective::NotDirective,
+                },
+                diagnostics,
             },
-        );
+            ParsedRules::Invalid(diagnostic) => ParsedDirective::Invalid(diagnostic),
+            ParsedRules::NotDirective => ParsedDirective::NotDirective,
+        };
     }
 
     ParsedDirective::NotDirective
 }
 
 enum ParsedRules {
-    Valid(Vec<String>),
+    Valid {
+        rules: Vec<String>,
+        diagnostics: Vec<Diagnostic>,
+    },
     Invalid(Diagnostic),
-    Ignore,
+    NotDirective,
 }
 
-fn parse_rules<'tree>(
-    comment: &Node<'tree>,
-    rest: &str,
-    directive_offset: usize,
-) -> Option<ParsedRules> {
-    if rest.is_empty() {
-        return Some(ParsedRules::Invalid(invalid_syntax_diagnostic(
+fn parse_rules<'tree>(comment: &Node<'tree>, rest: &str, directive_offset: usize) -> ParsedRules {
+    if rest.trim().is_empty() {
+        return ParsedRules::Invalid(invalid_syntax_diagnostic(
             comment,
             "invalid lint directive syntax: expected one or more comma-separated rule names",
             0,
             comment.text().len(),
-        )));
+        ));
     }
 
     if !rest.starts_with(char::is_whitespace) {
-        return Some(ParsedRules::Ignore);
+        return ParsedRules::NotDirective;
     }
 
-    let mut seen = HashSet::new();
-    let mut rules = Vec::new();
     // Keep spans in original comment coordinates for directive diagnostics.
     let rules_offset = directive_offset + (rest.len() - rest.trim_start().len());
     let rest = rest.trim();
-
-    if rest.is_empty() {
-        return Some(ParsedRules::Invalid(invalid_syntax_diagnostic(
-            comment,
-            "invalid lint directive syntax: expected one or more comma-separated rule names",
-            rules_offset,
-            comment.text().len(),
-        )));
-    }
+    let mut seen = HashSet::new();
+    let mut rules = Vec::new();
+    let mut diagnostics = Vec::new();
 
     let mut offset = 0;
     for raw_name in rest.split(',') {
+        let name = raw_name.trim();
         let trimmed_start = raw_name.len() - raw_name.trim_start().len();
-        let trimmed_end = raw_name.trim_end().len();
-        let name = raw_name[trimmed_start..trimmed_end].trim();
 
         if name.is_empty() {
             let start = rules_offset + offset + trimmed_start;
@@ -188,31 +185,20 @@ fn parse_rules<'tree>(
             } else {
                 "invalid lint directive syntax: expected comma-separated rule names"
             };
-            return Some(ParsedRules::Invalid(invalid_syntax_diagnostic(
+            return ParsedRules::Invalid(invalid_syntax_diagnostic(
                 comment,
                 message,
                 start.saturating_sub(1),
                 end,
-            )));
-        }
-
-        if name.contains(char::is_whitespace) {
-            let start = rules_offset + offset + trimmed_start;
-            let end = start + name.len();
-            return Some(ParsedRules::Invalid(invalid_syntax_diagnostic(
-                comment,
-                "invalid lint directive syntax: expected comma-separated rule names",
-                start,
-                end,
-            )));
+            ));
         }
 
         if RuleEnum::from_name(name).is_none() {
             let start = rules_offset + offset + trimmed_start;
             let end = start + name.len();
-            return Some(ParsedRules::Invalid(unknown_rule_diagnostic(
-                comment, name, start, end,
-            )));
+            diagnostics.push(unknown_rule_diagnostic(comment, name, start, end));
+            offset += raw_name.len() + 1;
+            continue;
         }
 
         if seen.insert(name) {
@@ -222,7 +208,7 @@ fn parse_rules<'tree>(
         offset += raw_name.len() + 1;
     }
 
-    Some(ParsedRules::Valid(rules))
+    ParsedRules::Valid { rules, diagnostics }
 }
 
 fn unknown_rule_diagnostic<'tree>(
@@ -325,39 +311,48 @@ mod tests {
 
     #[test]
     fn parses_directive_with_optional_space_after_prefix() {
-        assert_eq!(
+        assert!(matches!(
             parse_comment_directive("-- uroborosql-lint-disable no-distinct"),
-            ParsedDirective::Valid(LintDirective {
-                kind: LintDirectiveKind::Disable,
-                line: 0,
-                rules: vec!["no-distinct".to_string()],
-            })
-        );
-        assert_eq!(
+            ParsedDirective::Valid {
+                directive: LintDirective {
+                    kind: LintDirectiveKind::Disable,
+                    line: 0,
+                    rules,
+                },
+                diagnostics,
+            } if rules == vec!["no-distinct".to_string()] && diagnostics.is_empty()
+        ));
+        assert!(matches!(
             parse_comment_directive("--uroborosql-lint-disable-next-line no-distinct"),
-            ParsedDirective::Valid(LintDirective {
-                kind: LintDirectiveKind::DisableNextLine,
-                line: 0,
-                rules: vec!["no-distinct".to_string()],
-            })
-        );
+            ParsedDirective::Valid {
+                directive: LintDirective {
+                    kind: LintDirectiveKind::DisableNextLine,
+                    line: 0,
+                    rules,
+                },
+                diagnostics,
+            } if rules == vec!["no-distinct".to_string()] && diagnostics.is_empty()
+        ));
     }
 
     #[test]
     fn parses_multiple_rules_and_deduplicates_them() {
-        assert_eq!(
+        assert!(matches!(
             parse_comment_directive(
                 "-- uroborosql-lint-disable no-distinct, no-wildcard-projection, no-distinct"
             ),
-            ParsedDirective::Valid(LintDirective {
-                kind: LintDirectiveKind::Disable,
-                line: 0,
-                rules: vec![
-                    "no-distinct".to_string(),
-                    "no-wildcard-projection".to_string(),
-                ],
-            })
-        );
+            ParsedDirective::Valid {
+                directive: LintDirective {
+                    kind: LintDirectiveKind::Disable,
+                    line: 0,
+                    rules,
+                },
+                diagnostics,
+            } if rules == vec![
+                "no-distinct".to_string(),
+                "no-wildcard-projection".to_string(),
+            ] && diagnostics.is_empty()
+        ));
     }
 
     #[test]
@@ -371,12 +366,26 @@ mod tests {
             ParsedDirective::Invalid(_)
         ));
         assert!(matches!(
-            parse_comment_directive("-- uroborosql-lint-disable unknown-rule"),
+            parse_comment_directive("-- uroborosql-lint-disable  , , "),
             ParsedDirective::Invalid(_)
         ));
+    }
+
+    #[test]
+    fn keeps_known_rules_when_unknown_rules_are_mixed_in() {
         assert!(matches!(
-            parse_comment_directive("-- uroborosql-lint-disable no-distinct because reason"),
-            ParsedDirective::Invalid(_)
+            parse_comment_directive("-- uroborosql-lint-disable no-distinct, clearly-not-a-rule"),
+            ParsedDirective::Valid {
+                directive: LintDirective {
+                    kind: LintDirectiveKind::Disable,
+                    line: 0,
+                    rules,
+                },
+                diagnostics,
+            } if rules == vec!["no-distinct".to_string()]
+                && diagnostics.len() == 1
+                && diagnostics[0].code == INVALID_LINT_DIRECTIVE_CODE
+                && diagnostics[0].message == "unknown lint directive rule `clearly-not-a-rule`"
         ));
     }
 

--- a/crates/uroborosql-lint/src/directive.rs
+++ b/crates/uroborosql-lint/src/directive.rs
@@ -211,7 +211,9 @@ mod tests {
 
     #[test]
     fn disable_next_line_suppresses_only_the_next_physical_line() {
-        let sql = "-- uroborosql-lint-disable-next-line no-distinct\nSELECT DISTINCT id FROM users;\nSELECT DISTINCT name FROM users;";
+        let sql = r#"-- uroborosql-lint-disable-next-line no-distinct
+SELECT DISTINCT id FROM users;
+SELECT DISTINCT name FROM users;"#;
 
         let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
 
@@ -221,8 +223,9 @@ mod tests {
 
     #[test]
     fn disable_next_line_does_not_skip_blank_lines() {
-        let sql =
-            "-- uroborosql-lint-disable-next-line no-distinct\n\nSELECT DISTINCT id FROM users;";
+        let sql = r#"-- uroborosql-lint-disable-next-line no-distinct
+
+SELECT DISTINCT id FROM users;"#;
 
         let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
 
@@ -232,7 +235,8 @@ mod tests {
 
     #[test]
     fn file_head_disable_suppresses_requested_rule_only() {
-        let sql = "-- uroborosql-lint-disable no-distinct\nSELECT DISTINCT * FROM users;";
+        let sql = r#"-- uroborosql-lint-disable no-distinct
+SELECT DISTINCT * FROM users;"#;
 
         let diagnostics = run_with_rules(
             sql,
@@ -248,8 +252,9 @@ mod tests {
 
     #[test]
     fn file_head_disable_remains_effective_after_block_comment() {
-        let sql =
-            "-- uroborosql-lint-disable no-distinct\n/* comment */\nSELECT DISTINCT id FROM users;";
+        let sql = r#"-- uroborosql-lint-disable no-distinct
+/* comment */
+SELECT DISTINCT id FROM users;"#;
 
         let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
 
@@ -258,8 +263,9 @@ mod tests {
 
     #[test]
     fn disable_after_block_comment_is_ignored() {
-        let sql =
-            "/* comment */\n-- uroborosql-lint-disable no-distinct\nSELECT DISTINCT id FROM users;";
+        let sql = r#"/* comment */
+-- uroborosql-lint-disable no-distinct
+SELECT DISTINCT id FROM users;"#;
 
         let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
 
@@ -268,7 +274,9 @@ mod tests {
 
     #[test]
     fn file_head_disable_and_next_line_directives_compose() {
-        let sql = "-- uroborosql-lint-disable no-distinct\n-- uroborosql-lint-disable-next-line no-wildcard-projection\nSELECT DISTINCT * FROM users;";
+        let sql = r#"-- uroborosql-lint-disable no-distinct
+-- uroborosql-lint-disable-next-line no-wildcard-projection
+SELECT DISTINCT * FROM users;"#;
 
         let diagnostics = run_with_rules(
             sql,
@@ -283,7 +291,8 @@ mod tests {
 
     #[test]
     fn linter_run_returns_suppressed_diagnostics() {
-        let sql = "-- uroborosql-lint-disable no-distinct\nSELECT DISTINCT id FROM users;";
+        let sql = r#"-- uroborosql-lint-disable no-distinct
+SELECT DISTINCT id FROM users;"#;
         let resolved_config = ResolvedLintConfig {
             rules: vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)],
             db: None,
@@ -296,7 +305,9 @@ mod tests {
 
     #[test]
     fn extracts_only_head_disable_directives() {
-        let sql = "-- uroborosql-lint-disable no-distinct\nSELECT 1;\n-- uroborosql-lint-disable no-wildcard-projection";
+        let sql = r#"-- uroborosql-lint-disable no-distinct
+SELECT 1;
+-- uroborosql-lint-disable no-wildcard-projection"#;
         let tree = parse(sql);
 
         let directives = extract_directives(&tree.root_node());

--- a/crates/uroborosql-lint/src/directive.rs
+++ b/crates/uroborosql-lint/src/directive.rs
@@ -1,0 +1,313 @@
+use std::collections::{HashMap, HashSet};
+
+use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::Node};
+
+use crate::{diagnostic::Diagnostic, rules::RuleEnum};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LintDirectiveKind {
+    Disable,
+    DisableNextLine,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LintDirective {
+    kind: LintDirectiveKind,
+    line: usize,
+    rules: Vec<String>,
+}
+
+pub fn suppress_diagnostics<'tree>(
+    root: &Node<'tree>,
+    diagnostics: Vec<Diagnostic>,
+) -> Vec<Diagnostic> {
+    let directives = extract_directives(root);
+    apply_directives(diagnostics, &directives)
+}
+
+fn extract_directives<'tree>(root: &Node<'tree>) -> Vec<LintDirective> {
+    let file_head_end_byte = file_head_end_byte(root);
+
+    root.descendants()
+        .filter(|node| node.child_count() == 0 && node.kind() == SyntaxKind::SQL_COMMENT)
+        .filter_map(|comment| {
+            let directive = parse_directive(comment.text(), comment.range().start_position.row)?;
+
+            if directive.kind == LintDirectiveKind::Disable
+                && comment.range().start_byte >= file_head_end_byte
+            {
+                return None;
+            }
+
+            Some(directive)
+        })
+        .collect()
+}
+
+fn file_head_end_byte<'tree>(root: &Node<'tree>) -> usize {
+    root.descendants()
+        .filter(|node| node.child_count() == 0)
+        .find_map(|node| match node.kind() {
+            SyntaxKind::SQL_COMMENT => None,
+            SyntaxKind::C_COMMENT => Some(node.range().start_byte),
+            _ => Some(node.range().start_byte),
+        })
+        .unwrap_or(usize::MAX)
+}
+
+fn parse_directive(comment_text: &str, line: usize) -> Option<LintDirective> {
+    const DISABLE_NEXT_LINE: &str = "uroborosql-lint-disable-next-line";
+    const DISABLE: &str = "uroborosql-lint-disable";
+
+    let body = comment_text.strip_prefix("--")?;
+    let body = body.trim_start_matches([' ', '\t']);
+
+    if let Some(rest) = body.strip_prefix(DISABLE_NEXT_LINE) {
+        return parse_rules(rest).map(|rules| LintDirective {
+            kind: LintDirectiveKind::DisableNextLine,
+            line,
+            rules,
+        });
+    }
+
+    if let Some(rest) = body.strip_prefix(DISABLE) {
+        return parse_rules(rest).map(|rules| LintDirective {
+            kind: LintDirectiveKind::Disable,
+            line,
+            rules,
+        });
+    }
+
+    None
+}
+
+fn parse_rules(rest: &str) -> Option<Vec<String>> {
+    if !rest.starts_with(char::is_whitespace) {
+        return None;
+    }
+
+    let mut seen = HashSet::new();
+    let mut rules = Vec::new();
+    let rest = rest.trim();
+
+    if rest.is_empty() {
+        return None;
+    }
+
+    for name in rest.split(',').map(str::trim) {
+        if name.is_empty() || RuleEnum::from_name(name).is_none() {
+            return None;
+        }
+
+        if seen.insert(name) {
+            rules.push(name.to_string());
+        }
+    }
+
+    Some(rules)
+}
+
+fn apply_directives(diagnostics: Vec<Diagnostic>, directives: &[LintDirective]) -> Vec<Diagnostic> {
+    let mut file_disabled_rules = HashSet::new();
+    let mut next_line_disabled_rules: HashMap<usize, HashSet<String>> = HashMap::new();
+
+    for directive in directives {
+        match directive.kind {
+            LintDirectiveKind::Disable => {
+                file_disabled_rules.extend(directive.rules.iter().cloned());
+            }
+            LintDirectiveKind::DisableNextLine => {
+                next_line_disabled_rules
+                    .entry(directive.line + 1)
+                    .or_default()
+                    .extend(directive.rules.iter().cloned());
+            }
+        }
+    }
+
+    diagnostics
+        .into_iter()
+        .filter(|diagnostic| {
+            !file_disabled_rules.contains(diagnostic.rule_id)
+                && !next_line_disabled_rules
+                    .get(&diagnostic.span.start.line)
+                    .is_some_and(|rules| rules.contains(diagnostic.rule_id))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        diagnostic::Severity,
+        linter::tests::run_with_rules,
+        rules::{NoDistinct, NoWildcardProjection, RuleEnum},
+        Linter, ResolvedLintConfig,
+    };
+    use postgresql_cst_parser::tree_sitter;
+
+    fn parse(sql: &str) -> postgresql_cst_parser::tree_sitter::Tree {
+        tree_sitter::parse_2way(sql).expect("parse ok")
+    }
+
+    fn parse_comment_directive(comment: &str) -> Option<LintDirective> {
+        parse_directive(comment, 3)
+    }
+
+    #[test]
+    fn parses_directive_with_optional_space_after_prefix() {
+        assert_eq!(
+            parse_comment_directive("-- uroborosql-lint-disable no-distinct"),
+            Some(LintDirective {
+                kind: LintDirectiveKind::Disable,
+                line: 3,
+                rules: vec!["no-distinct".to_string()],
+            })
+        );
+        assert_eq!(
+            parse_comment_directive("--uroborosql-lint-disable-next-line no-distinct"),
+            Some(LintDirective {
+                kind: LintDirectiveKind::DisableNextLine,
+                line: 3,
+                rules: vec!["no-distinct".to_string()],
+            })
+        );
+    }
+
+    #[test]
+    fn parses_multiple_rules_and_deduplicates_them() {
+        assert_eq!(
+            parse_comment_directive(
+                "-- uroborosql-lint-disable no-distinct, no-wildcard-projection, no-distinct"
+            ),
+            Some(LintDirective {
+                kind: LintDirectiveKind::Disable,
+                line: 3,
+                rules: vec![
+                    "no-distinct".to_string(),
+                    "no-wildcard-projection".to_string(),
+                ],
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_directive_inputs() {
+        assert_eq!(parse_comment_directive("-- uroborosql-lint-disable"), None);
+        assert_eq!(
+            parse_comment_directive("-- uroborosql-lint-disable no-distinct,"),
+            None
+        );
+        assert_eq!(
+            parse_comment_directive("-- uroborosql-lint-disable unknown-rule"),
+            None
+        );
+        assert_eq!(
+            parse_comment_directive("-- uroborosql-lint-disable no-distinct because reason"),
+            None
+        );
+    }
+
+    #[test]
+    fn disable_next_line_suppresses_only_the_next_physical_line() {
+        let sql = "-- uroborosql-lint-disable-next-line no-distinct\nSELECT DISTINCT id FROM users;\nSELECT DISTINCT name FROM users;";
+
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn disable_next_line_does_not_skip_blank_lines() {
+        let sql =
+            "-- uroborosql-lint-disable-next-line no-distinct\n\nSELECT DISTINCT id FROM users;";
+
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn file_head_disable_suppresses_requested_rule_only() {
+        let sql = "-- uroborosql-lint-disable no-distinct\nSELECT DISTINCT * FROM users;";
+
+        let diagnostics = run_with_rules(
+            sql,
+            vec![
+                RuleEnum::NoDistinct(NoDistinct),
+                RuleEnum::NoWildcardProjection(NoWildcardProjection),
+            ],
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule_id, "no-wildcard-projection");
+    }
+
+    #[test]
+    fn file_head_disable_remains_effective_after_block_comment() {
+        let sql =
+            "-- uroborosql-lint-disable no-distinct\n/* comment */\nSELECT DISTINCT id FROM users;";
+
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn disable_after_block_comment_is_ignored() {
+        let sql =
+            "/* comment */\n-- uroborosql-lint-disable no-distinct\nSELECT DISTINCT id FROM users;";
+
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn file_head_disable_and_next_line_directives_compose() {
+        let sql = "-- uroborosql-lint-disable no-distinct\n-- uroborosql-lint-disable-next-line no-wildcard-projection\nSELECT DISTINCT * FROM users;";
+
+        let diagnostics = run_with_rules(
+            sql,
+            vec![
+                RuleEnum::NoDistinct(NoDistinct),
+                RuleEnum::NoWildcardProjection(NoWildcardProjection),
+            ],
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn linter_run_returns_suppressed_diagnostics() {
+        let sql = "-- uroborosql-lint-disable no-distinct\nSELECT DISTINCT id FROM users;";
+        let resolved_config = ResolvedLintConfig {
+            rules: vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)],
+            db: None,
+        };
+
+        let diagnostics = Linter::new().run(sql, &resolved_config).expect("lint ok");
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn extracts_only_head_disable_directives() {
+        let sql = "-- uroborosql-lint-disable no-distinct\nSELECT 1;\n-- uroborosql-lint-disable no-wildcard-projection";
+        let tree = parse(sql);
+
+        let directives = extract_directives(&tree.root_node());
+
+        assert_eq!(
+            directives,
+            vec![LintDirective {
+                kind: LintDirectiveKind::Disable,
+                line: 0,
+                rules: vec!["no-distinct".to_string()],
+            }]
+        );
+    }
+}

--- a/crates/uroborosql-lint/src/directive.rs
+++ b/crates/uroborosql-lint/src/directive.rs
@@ -1,8 +1,16 @@
 use std::collections::{HashMap, HashSet};
 
-use postgresql_cst_parser::{syntax_kind::SyntaxKind, tree_sitter::Node};
+use postgresql_cst_parser::{
+    syntax_kind::SyntaxKind,
+    tree_sitter::{Node, Point, Range},
+};
 
-use crate::{diagnostic::Diagnostic, rules::RuleEnum};
+use crate::{
+    diagnostic::{Diagnostic, Severity},
+    rules::RuleEnum,
+};
+
+const INVALID_LINT_DIRECTIVE_CODE: &str = "invalid-lint-directive";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LintDirectiveKind {
@@ -21,27 +29,38 @@ pub fn suppress_diagnostics<'tree>(
     root: &Node<'tree>,
     diagnostics: Vec<Diagnostic>,
 ) -> Vec<Diagnostic> {
-    let directives = extract_directives(root);
-    apply_directives(diagnostics, &directives)
+    let (directives, mut directive_diagnostics) = extract_directives(root);
+    let mut diagnostics = apply_directives(diagnostics, &directives);
+    diagnostics.append(&mut directive_diagnostics);
+    diagnostics.sort_by_key(|diag| (diag.span.start.byte, diag.span.end.byte, diag.code));
+    diagnostics
 }
 
-fn extract_directives<'tree>(root: &Node<'tree>) -> Vec<LintDirective> {
+fn extract_directives<'tree>(root: &Node<'tree>) -> (Vec<LintDirective>, Vec<Diagnostic>) {
     let file_head_end_byte = file_head_end_byte(root);
+    let mut directives = Vec::new();
+    let mut diagnostics = Vec::new();
 
-    root.descendants()
+    for comment in root
+        .descendants()
         .filter(|node| node.child_count() == 0 && node.kind() == SyntaxKind::SQL_COMMENT)
-        .filter_map(|comment| {
-            let directive = parse_directive(comment.text(), comment.range().start_position.row)?;
+    {
+        match parse_directive(&comment) {
+            ParsedDirective::NotDirective => {}
+            ParsedDirective::Invalid(diagnostic) => diagnostics.push(diagnostic),
+            ParsedDirective::Valid(directive) => {
+                if directive.kind == LintDirectiveKind::Disable
+                    && comment.range().start_byte >= file_head_end_byte
+                {
+                    continue;
+                }
 
-            if directive.kind == LintDirectiveKind::Disable
-                && comment.range().start_byte >= file_head_end_byte
-            {
-                return None;
+                directives.push(directive);
             }
+        }
+    }
 
-            Some(directive)
-        })
-        .collect()
+    (directives, diagnostics)
 }
 
 fn file_head_end_byte<'tree>(root: &Node<'tree>) -> usize {
@@ -55,56 +74,147 @@ fn file_head_end_byte<'tree>(root: &Node<'tree>) -> usize {
         .unwrap_or(usize::MAX)
 }
 
-fn parse_directive(comment_text: &str, line: usize) -> Option<LintDirective> {
+#[derive(Debug, PartialEq)]
+enum ParsedDirective {
+    NotDirective,
+    Invalid(Diagnostic),
+    Valid(LintDirective),
+}
+
+fn parse_directive<'tree>(comment: &Node<'tree>) -> ParsedDirective {
     const DISABLE_NEXT_LINE: &str = "uroborosql-lint-disable-next-line";
     const DISABLE: &str = "uroborosql-lint-disable";
 
-    let body = comment_text.strip_prefix("--")?;
+    let comment_text = comment.text();
+    let line = comment.range().start_position.row;
+    let Some(body) = comment_text.strip_prefix("--") else {
+        return ParsedDirective::NotDirective;
+    };
     let body = body.trim_start_matches([' ', '\t']);
+    let body_offset = comment_text.len() - body.len();
 
     if let Some(rest) = body.strip_prefix(DISABLE_NEXT_LINE) {
-        return parse_rules(rest).map(|rules| LintDirective {
-            kind: LintDirectiveKind::DisableNextLine,
-            line,
-            rules,
-        });
+        return parse_rules(comment, rest, body_offset + DISABLE_NEXT_LINE.len()).map_or(
+            ParsedDirective::NotDirective,
+            |parsed| match parsed {
+                ParsedRules::Valid(rules) => ParsedDirective::Valid(LintDirective {
+                    kind: LintDirectiveKind::DisableNextLine,
+                    line,
+                    rules,
+                }),
+                ParsedRules::Invalid(diagnostic) => ParsedDirective::Invalid(diagnostic),
+                ParsedRules::Ignore => ParsedDirective::NotDirective,
+            },
+        );
     }
 
     if let Some(rest) = body.strip_prefix(DISABLE) {
-        return parse_rules(rest).map(|rules| LintDirective {
-            kind: LintDirectiveKind::Disable,
-            line,
-            rules,
-        });
+        return parse_rules(comment, rest, body_offset + DISABLE.len()).map_or(
+            ParsedDirective::NotDirective,
+            |parsed| match parsed {
+                ParsedRules::Valid(rules) => ParsedDirective::Valid(LintDirective {
+                    kind: LintDirectiveKind::Disable,
+                    line,
+                    rules,
+                }),
+                ParsedRules::Invalid(diagnostic) => ParsedDirective::Invalid(diagnostic),
+                ParsedRules::Ignore => ParsedDirective::NotDirective,
+            },
+        );
     }
 
-    None
+    ParsedDirective::NotDirective
 }
 
-fn parse_rules(rest: &str) -> Option<Vec<String>> {
+enum ParsedRules {
+    Valid(Vec<String>),
+    Invalid(Diagnostic),
+    Ignore,
+}
+
+fn parse_rules<'tree>(
+    comment: &Node<'tree>,
+    rest: &str,
+    directive_offset: usize,
+) -> Option<ParsedRules> {
     if !rest.starts_with(char::is_whitespace) {
-        return None;
+        return Some(ParsedRules::Ignore);
     }
 
     let mut seen = HashSet::new();
     let mut rules = Vec::new();
+    let rules_offset = directive_offset + (rest.len() - rest.trim_start().len());
     let rest = rest.trim();
 
     if rest.is_empty() {
-        return None;
+        return Some(ParsedRules::Ignore);
     }
 
-    for name in rest.split(',').map(str::trim) {
-        if name.is_empty() || RuleEnum::from_name(name).is_none() {
-            return None;
+    let mut offset = 0;
+    for raw_name in rest.split(',') {
+        let trimmed_start = raw_name.len() - raw_name.trim_start().len();
+        let trimmed_end = raw_name.trim_end().len();
+        let name = raw_name[trimmed_start..trimmed_end].trim();
+
+        if name.is_empty() {
+            return Some(ParsedRules::Ignore);
+        }
+
+        if name.contains(char::is_whitespace) {
+            return Some(ParsedRules::Ignore);
+        }
+
+        if RuleEnum::from_name(name).is_none() {
+            let start = rules_offset + offset + trimmed_start;
+            let end = start + name.len();
+            return Some(ParsedRules::Invalid(unknown_rule_diagnostic(
+                comment, name, start, end,
+            )));
         }
 
         if seen.insert(name) {
             rules.push(name.to_string());
         }
+
+        offset += raw_name.len() + 1;
     }
 
-    Some(rules)
+    Some(ParsedRules::Valid(rules))
+}
+
+fn unknown_rule_diagnostic<'tree>(
+    comment: &Node<'tree>,
+    unknown_rule: &str,
+    start_offset: usize,
+    end_offset: usize,
+) -> Diagnostic {
+    let range = subrange_in_comment(comment, start_offset, end_offset);
+    Diagnostic::new(
+        INVALID_LINT_DIRECTIVE_CODE,
+        Severity::Warning,
+        format!("unknown lint directive rule `{unknown_rule}`"),
+        &range,
+    )
+}
+
+fn subrange_in_comment<'tree>(
+    comment: &Node<'tree>,
+    start_offset: usize,
+    end_offset: usize,
+) -> Range {
+    let full_range = comment.range();
+    Range {
+        start_byte: full_range.start_byte + start_offset,
+        end_byte: full_range.start_byte + end_offset,
+        start_position: Point {
+            row: full_range.start_position.row,
+            column: full_range.start_position.column + start_offset,
+        },
+        end_position: Point {
+            row: full_range.start_position.row,
+            column: full_range.start_position.column + end_offset,
+        },
+    }
 }
 
 fn apply_directives(diagnostics: Vec<Diagnostic>, directives: &[LintDirective]) -> Vec<Diagnostic> {
@@ -128,10 +238,10 @@ fn apply_directives(diagnostics: Vec<Diagnostic>, directives: &[LintDirective]) 
     diagnostics
         .into_iter()
         .filter(|diagnostic| {
-            !file_disabled_rules.contains(diagnostic.rule_id)
+            !file_disabled_rules.contains(diagnostic.code)
                 && !next_line_disabled_rules
                     .get(&diagnostic.span.start.line)
-                    .is_some_and(|rules| rules.contains(diagnostic.rule_id))
+                    .is_some_and(|rules| rules.contains(diagnostic.code))
         })
         .collect()
 }
@@ -151,25 +261,31 @@ mod tests {
         tree_sitter::parse_2way(sql).expect("parse ok")
     }
 
-    fn parse_comment_directive(comment: &str) -> Option<LintDirective> {
-        parse_directive(comment, 3)
+    fn parse_comment_directive(comment: &str) -> ParsedDirective {
+        let tree = parse(comment);
+        let comment_node = tree
+            .root_node()
+            .descendants()
+            .find(|node| node.kind() == SyntaxKind::SQL_COMMENT)
+            .expect("sql comment");
+        parse_directive(&comment_node)
     }
 
     #[test]
     fn parses_directive_with_optional_space_after_prefix() {
         assert_eq!(
             parse_comment_directive("-- uroborosql-lint-disable no-distinct"),
-            Some(LintDirective {
+            ParsedDirective::Valid(LintDirective {
                 kind: LintDirectiveKind::Disable,
-                line: 3,
+                line: 0,
                 rules: vec!["no-distinct".to_string()],
             })
         );
         assert_eq!(
             parse_comment_directive("--uroborosql-lint-disable-next-line no-distinct"),
-            Some(LintDirective {
+            ParsedDirective::Valid(LintDirective {
                 kind: LintDirectiveKind::DisableNextLine,
-                line: 3,
+                line: 0,
                 rules: vec!["no-distinct".to_string()],
             })
         );
@@ -181,9 +297,9 @@ mod tests {
             parse_comment_directive(
                 "-- uroborosql-lint-disable no-distinct, no-wildcard-projection, no-distinct"
             ),
-            Some(LintDirective {
+            ParsedDirective::Valid(LintDirective {
                 kind: LintDirectiveKind::Disable,
-                line: 3,
+                line: 0,
                 rules: vec![
                     "no-distinct".to_string(),
                     "no-wildcard-projection".to_string(),
@@ -194,18 +310,21 @@ mod tests {
 
     #[test]
     fn rejects_invalid_directive_inputs() {
-        assert_eq!(parse_comment_directive("-- uroborosql-lint-disable"), None);
+        assert!(matches!(
+            parse_comment_directive("-- uroborosql-lint-disable"),
+            ParsedDirective::NotDirective
+        ));
         assert_eq!(
             parse_comment_directive("-- uroborosql-lint-disable no-distinct,"),
-            None
+            ParsedDirective::NotDirective
         );
-        assert_eq!(
+        assert!(matches!(
             parse_comment_directive("-- uroborosql-lint-disable unknown-rule"),
-            None
-        );
+            ParsedDirective::Invalid(_)
+        ));
         assert_eq!(
             parse_comment_directive("-- uroborosql-lint-disable no-distinct because reason"),
-            None
+            ParsedDirective::NotDirective
         );
     }
 
@@ -247,7 +366,7 @@ SELECT DISTINCT * FROM users;"#;
         );
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].rule_id, "no-wildcard-projection");
+        assert_eq!(diagnostics[0].code, "no-wildcard-projection");
     }
 
     #[test]
@@ -310,8 +429,9 @@ SELECT 1;
 -- uroborosql-lint-disable no-wildcard-projection"#;
         let tree = parse(sql);
 
-        let directives = extract_directives(&tree.root_node());
+        let (directives, diagnostics) = extract_directives(&tree.root_node());
 
+        assert!(diagnostics.is_empty());
         assert_eq!(
             directives,
             vec![LintDirective {
@@ -320,5 +440,28 @@ SELECT 1;
                 rules: vec!["no-distinct".to_string()],
             }]
         );
+    }
+
+    #[test]
+    fn unknown_rule_in_directive_produces_warning_on_rule_name() {
+        let sql = r#"-- uroborosql-lint-disable no-dstinct
+SELECT DISTINCT id FROM users;"#;
+        let resolved_config = ResolvedLintConfig {
+            rules: vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)],
+            db: None,
+        };
+
+        let diagnostics = Linter::new().run(sql, &resolved_config).expect("lint ok");
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].code, INVALID_LINT_DIRECTIVE_CODE);
+        assert_eq!(
+            diagnostics[0].message,
+            "unknown lint directive rule `no-dstinct`"
+        );
+        assert_eq!(diagnostics[0].span.start.line, 0);
+        assert_eq!(diagnostics[0].span.start.column, 27);
+        assert_eq!(diagnostics[0].span.end.column, 37);
+        assert_eq!(diagnostics[1].code, "no-distinct");
     }
 }

--- a/crates/uroborosql-lint/src/directive.rs
+++ b/crates/uroborosql-lint/src/directive.rs
@@ -37,7 +37,7 @@ pub fn suppress_diagnostics<'tree>(
 }
 
 fn extract_directives<'tree>(root: &Node<'tree>) -> (Vec<LintDirective>, Vec<Diagnostic>) {
-    let file_head_end_byte = file_head_end_byte(root);
+    let file_head_comment_end_byte = file_head_comment_end_byte(root);
     let mut directives = Vec::new();
     let mut diagnostics = Vec::new();
 
@@ -50,7 +50,7 @@ fn extract_directives<'tree>(root: &Node<'tree>) -> (Vec<LintDirective>, Vec<Dia
             ParsedDirective::Invalid(diagnostic) => diagnostics.push(diagnostic),
             ParsedDirective::Valid(directive) => {
                 if directive.kind == LintDirectiveKind::Disable
-                    && comment.range().start_byte >= file_head_end_byte
+                    && comment.range().start_byte >= file_head_comment_end_byte
                 {
                     continue;
                 }
@@ -63,7 +63,12 @@ fn extract_directives<'tree>(root: &Node<'tree>) -> (Vec<LintDirective>, Vec<Dia
     (directives, diagnostics)
 }
 
-fn file_head_end_byte<'tree>(root: &Node<'tree>) -> usize {
+/// Returns the byte offset where the leading line-comment section ends.
+///
+/// File-head `disable` directives are valid only inside the initial run of
+/// blank lines and SQL line comments. The first block comment or non-comment
+/// token ends that section.
+fn file_head_comment_end_byte<'tree>(root: &Node<'tree>) -> usize {
     root.descendants()
         .filter(|node| node.child_count() == 0)
         .find_map(|node| match node.kind() {
@@ -152,6 +157,7 @@ fn parse_rules<'tree>(
 
     let mut seen = HashSet::new();
     let mut rules = Vec::new();
+    // Keep spans in original comment coordinates for directive diagnostics.
     let rules_offset = directive_offset + (rest.len() - rest.trim_start().len());
     let rest = rest.trim();
 

--- a/crates/uroborosql-lint/src/directive.rs
+++ b/crates/uroborosql-lint/src/directive.rs
@@ -43,7 +43,7 @@ fn extract_directives<'tree>(root: &Node<'tree>) -> (Vec<LintDirective>, Vec<Dia
 
     for comment in root
         .descendants()
-        .filter(|node| node.child_count() == 0 && node.kind() == SyntaxKind::SQL_COMMENT)
+        .filter(|node| node.kind() == SyntaxKind::SQL_COMMENT)
     {
         match parse_directive(&comment) {
             ParsedDirective::NotDirective => {}
@@ -66,8 +66,8 @@ fn extract_directives<'tree>(root: &Node<'tree>) -> (Vec<LintDirective>, Vec<Dia
 /// Returns the byte offset where the leading line-comment section ends.
 ///
 /// File-head `disable` directives are valid only inside the initial run of
-/// blank lines and SQL line comments. The first block comment or non-comment
-/// token ends that section.
+/// blank lines and SQL line comments. The first block comment or other token
+/// ends that section.
 fn file_head_comment_end_byte<'tree>(root: &Node<'tree>) -> usize {
     root.descendants()
         .filter(|node| node.child_count() == 0)

--- a/crates/uroborosql-lint/src/directive.rs
+++ b/crates/uroborosql-lint/src/directive.rs
@@ -137,6 +137,15 @@ fn parse_rules<'tree>(
     rest: &str,
     directive_offset: usize,
 ) -> Option<ParsedRules> {
+    if rest.is_empty() {
+        return Some(ParsedRules::Invalid(invalid_syntax_diagnostic(
+            comment,
+            "invalid lint directive syntax: expected one or more comma-separated rule names",
+            0,
+            comment.text().len(),
+        )));
+    }
+
     if !rest.starts_with(char::is_whitespace) {
         return Some(ParsedRules::Ignore);
     }
@@ -147,7 +156,12 @@ fn parse_rules<'tree>(
     let rest = rest.trim();
 
     if rest.is_empty() {
-        return Some(ParsedRules::Ignore);
+        return Some(ParsedRules::Invalid(invalid_syntax_diagnostic(
+            comment,
+            "invalid lint directive syntax: expected one or more comma-separated rule names",
+            rules_offset,
+            comment.text().len(),
+        )));
     }
 
     let mut offset = 0;
@@ -157,11 +171,34 @@ fn parse_rules<'tree>(
         let name = raw_name[trimmed_start..trimmed_end].trim();
 
         if name.is_empty() {
-            return Some(ParsedRules::Ignore);
+            let start = rules_offset + offset + trimmed_start;
+            let end = if offset + raw_name.len() == rest.len() {
+                start.saturating_sub(1)
+            } else {
+                start + raw_name.len()
+            };
+            let message = if offset + raw_name.len() == rest.len() {
+                "invalid lint directive syntax: trailing comma is not allowed"
+            } else {
+                "invalid lint directive syntax: expected comma-separated rule names"
+            };
+            return Some(ParsedRules::Invalid(invalid_syntax_diagnostic(
+                comment,
+                message,
+                start.saturating_sub(1),
+                end,
+            )));
         }
 
         if name.contains(char::is_whitespace) {
-            return Some(ParsedRules::Ignore);
+            let start = rules_offset + offset + trimmed_start;
+            let end = start + name.len();
+            return Some(ParsedRules::Invalid(invalid_syntax_diagnostic(
+                comment,
+                "invalid lint directive syntax: expected comma-separated rule names",
+                start,
+                end,
+            )));
         }
 
         if RuleEnum::from_name(name).is_none() {
@@ -193,6 +230,21 @@ fn unknown_rule_diagnostic<'tree>(
         INVALID_LINT_DIRECTIVE_CODE,
         Severity::Warning,
         format!("unknown lint directive rule `{unknown_rule}`"),
+        &range,
+    )
+}
+
+fn invalid_syntax_diagnostic<'tree>(
+    comment: &Node<'tree>,
+    message: impl Into<String>,
+    start_offset: usize,
+    end_offset: usize,
+) -> Diagnostic {
+    let range = subrange_in_comment(comment, start_offset, end_offset.max(start_offset + 1));
+    Diagnostic::new(
+        INVALID_LINT_DIRECTIVE_CODE,
+        Severity::Warning,
+        message,
         &range,
     )
 }
@@ -312,20 +364,29 @@ mod tests {
     fn rejects_invalid_directive_inputs() {
         assert!(matches!(
             parse_comment_directive("-- uroborosql-lint-disable"),
-            ParsedDirective::NotDirective
+            ParsedDirective::Invalid(Diagnostic {
+                message,
+                ..
+            }) if message == "invalid lint directive syntax: expected one or more comma-separated rule names"
         ));
-        assert_eq!(
+        assert!(matches!(
             parse_comment_directive("-- uroborosql-lint-disable no-distinct,"),
-            ParsedDirective::NotDirective
-        );
+            ParsedDirective::Invalid(Diagnostic {
+                message,
+                ..
+            }) if message == "invalid lint directive syntax: trailing comma is not allowed"
+        ));
         assert!(matches!(
             parse_comment_directive("-- uroborosql-lint-disable unknown-rule"),
             ParsedDirective::Invalid(_)
         ));
-        assert_eq!(
+        assert!(matches!(
             parse_comment_directive("-- uroborosql-lint-disable no-distinct because reason"),
-            ParsedDirective::NotDirective
-        );
+            ParsedDirective::Invalid(Diagnostic {
+                message,
+                ..
+            }) if message == "invalid lint directive syntax: expected comma-separated rule names"
+        ));
     }
 
     #[test]
@@ -462,6 +523,26 @@ SELECT DISTINCT id FROM users;"#;
         assert_eq!(diagnostics[0].span.start.line, 0);
         assert_eq!(diagnostics[0].span.start.column, 27);
         assert_eq!(diagnostics[0].span.end.column, 37);
+        assert_eq!(diagnostics[1].code, "no-distinct");
+    }
+
+    #[test]
+    fn invalid_directive_syntax_produces_warning() {
+        let sql = r#"-- uroborosql-lint-disable no-distinct because reason
+SELECT DISTINCT id FROM users;"#;
+        let resolved_config = ResolvedLintConfig {
+            rules: vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)],
+            db: None,
+        };
+
+        let diagnostics = Linter::new().run(sql, &resolved_config).expect("lint ok");
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].code, INVALID_LINT_DIRECTIVE_CODE);
+        assert_eq!(
+            diagnostics[0].message,
+            "invalid lint directive syntax: expected comma-separated rule names"
+        );
         assert_eq!(diagnostics[1].code, "no-distinct");
     }
 }

--- a/crates/uroborosql-lint/src/lib.rs
+++ b/crates/uroborosql-lint/src/lib.rs
@@ -1,6 +1,7 @@
 mod config;
 mod context;
 mod diagnostic;
+mod directive;
 mod linter;
 mod rule;
 mod rules;

--- a/crates/uroborosql-lint/src/linter.rs
+++ b/crates/uroborosql-lint/src/linter.rs
@@ -54,7 +54,7 @@ pub mod tests {
     use super::*;
     use crate::{
         diagnostic::Severity,
-        rules::{NoDistinct, RuleEnum},
+        rules::{NoDistinct, NoWildcardProjection, RuleEnum},
     };
 
     fn resolve_from_rules(rules: Vec<(RuleEnum, Severity)>) -> ResolvedLintConfig {
@@ -83,5 +83,136 @@ pub mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].severity, Severity::Error);
+    }
+
+    #[test]
+    fn disable_next_line_suppresses_only_the_next_physical_line() {
+        let sql = r#"-- uroborosql-lint-disable-next-line no-distinct
+SELECT DISTINCT id FROM users;
+SELECT DISTINCT name FROM users;"#;
+
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn disable_next_line_does_not_skip_blank_lines() {
+        let sql = r#"-- uroborosql-lint-disable-next-line no-distinct
+
+SELECT DISTINCT id FROM users;"#;
+
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn file_head_disable_suppresses_requested_rule_only() {
+        let sql = r#"-- uroborosql-lint-disable no-distinct
+SELECT DISTINCT * FROM users;"#;
+
+        let diagnostics = run_with_rules(
+            sql,
+            vec![
+                RuleEnum::NoDistinct(NoDistinct),
+                RuleEnum::NoWildcardProjection(NoWildcardProjection),
+            ],
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "no-wildcard-projection");
+    }
+
+    #[test]
+    fn file_head_disable_remains_effective_after_block_comment() {
+        let sql = r#"-- uroborosql-lint-disable no-distinct
+/* comment */
+SELECT DISTINCT id FROM users;"#;
+
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn disable_after_block_comment_is_ignored() {
+        let sql = r#"/* comment */
+-- uroborosql-lint-disable no-distinct
+SELECT DISTINCT id FROM users;"#;
+
+        let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
+
+        assert_eq!(diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn file_head_disable_and_next_line_directives_compose() {
+        let sql = r#"-- uroborosql-lint-disable no-distinct
+-- uroborosql-lint-disable-next-line no-wildcard-projection
+SELECT DISTINCT * FROM users;"#;
+
+        let diagnostics = run_with_rules(
+            sql,
+            vec![
+                RuleEnum::NoDistinct(NoDistinct),
+                RuleEnum::NoWildcardProjection(NoWildcardProjection),
+            ],
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn linter_run_returns_suppressed_diagnostics() {
+        let resolved_config =
+            resolve_from_rules(vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)]);
+        let sql = r#"-- uroborosql-lint-disable no-distinct
+SELECT DISTINCT id FROM users;"#;
+
+        let diagnostics = Linter::new().run(sql, &resolved_config).expect("lint ok");
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn unknown_rule_in_directive_produces_warning_on_rule_name() {
+        let resolved_config =
+            resolve_from_rules(vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)]);
+        let sql = r#"-- uroborosql-lint-disable no-dstinct
+SELECT DISTINCT id FROM users;"#;
+
+        let diagnostics = Linter::new().run(sql, &resolved_config).expect("lint ok");
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].code, "invalid-lint-directive");
+        assert_eq!(
+            diagnostics[0].message,
+            "unknown lint directive rule `no-dstinct`"
+        );
+        assert_eq!(diagnostics[0].span.start.line, 0);
+        assert_eq!(diagnostics[0].span.start.column, 27);
+        assert_eq!(diagnostics[0].span.end.column, 37);
+        assert_eq!(diagnostics[1].code, "no-distinct");
+    }
+
+    #[test]
+    fn invalid_directive_syntax_produces_warning() {
+        let resolved_config =
+            resolve_from_rules(vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)]);
+        let sql = r#"-- uroborosql-lint-disable no-distinct because reason
+SELECT DISTINCT id FROM users;"#;
+
+        let diagnostics = Linter::new().run(sql, &resolved_config).expect("lint ok");
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].code, "invalid-lint-directive");
+        assert_eq!(
+            diagnostics[0].message,
+            "invalid lint directive syntax: expected comma-separated rule names"
+        );
+        assert_eq!(diagnostics[1].code, "no-distinct");
     }
 }

--- a/crates/uroborosql-lint/src/linter.rs
+++ b/crates/uroborosql-lint/src/linter.rs
@@ -181,7 +181,7 @@ SELECT DISTINCT id FROM users;"#;
     fn unknown_rule_in_directive_produces_warning_on_rule_name() {
         let resolved_config =
             resolve_from_rules(vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)]);
-        let sql = r#"-- uroborosql-lint-disable no-dstinct
+        let sql = r#"-- uroborosql-lint-disable definitely-not-a-rule
 SELECT DISTINCT id FROM users;"#;
 
         let diagnostics = Linter::new().run(sql, &resolved_config).expect("lint ok");
@@ -190,16 +190,33 @@ SELECT DISTINCT id FROM users;"#;
         assert_eq!(diagnostics[0].code, "invalid-lint-directive");
         assert_eq!(
             diagnostics[0].message,
-            "unknown lint directive rule `no-dstinct`"
+            "unknown lint directive rule `definitely-not-a-rule`"
         );
         assert_eq!(diagnostics[0].span.start.line, 0);
         assert_eq!(diagnostics[0].span.start.column, 27);
-        assert_eq!(diagnostics[0].span.end.column, 37);
+        assert_eq!(diagnostics[0].span.end.column, 48);
         assert_eq!(diagnostics[1].code, "no-distinct");
     }
 
     #[test]
-    fn invalid_directive_syntax_produces_warning() {
+    fn unknown_rule_does_not_prevent_known_rules_from_being_suppressed() {
+        let resolved_config =
+            resolve_from_rules(vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)]);
+        let sql = r#"-- uroborosql-lint-disable no-distinct, definitely-not-a-rule
+SELECT DISTINCT id FROM users;"#;
+
+        let diagnostics = Linter::new().run(sql, &resolved_config).expect("lint ok");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "invalid-lint-directive");
+        assert_eq!(
+            diagnostics[0].message,
+            "unknown lint directive rule `definitely-not-a-rule`"
+        );
+    }
+
+    #[test]
+    fn malformed_rule_token_produces_unknown_rule_warning() {
         let resolved_config =
             resolve_from_rules(vec![(RuleEnum::NoDistinct(NoDistinct), Severity::Warning)]);
         let sql = r#"-- uroborosql-lint-disable no-distinct because reason
@@ -211,7 +228,7 @@ SELECT DISTINCT id FROM users;"#;
         assert_eq!(diagnostics[0].code, "invalid-lint-directive");
         assert_eq!(
             diagnostics[0].message,
-            "invalid lint directive syntax: expected comma-separated rule names"
+            "unknown lint directive rule `no-distinct because reason`"
         );
         assert_eq!(diagnostics[1].code, "no-distinct");
     }

--- a/crates/uroborosql-lint/src/linter.rs
+++ b/crates/uroborosql-lint/src/linter.rs
@@ -1,5 +1,6 @@
 use crate::{
-    context::LintContext, diagnostic::Diagnostic, tree::collect_preorder, ResolvedLintConfig,
+    context::LintContext, diagnostic::Diagnostic, directive::suppress_diagnostics,
+    tree::collect_preorder, ResolvedLintConfig,
 };
 use postgresql_cst_parser::tree_sitter;
 
@@ -44,7 +45,7 @@ impl Linter {
             }
         }
 
-        Ok(ctx.into_diagnostics())
+        Ok(suppress_diagnostics(&root, ctx.into_diagnostics()))
     }
 }
 

--- a/crates/uroborosql-lint/src/rules/missing_two_way_sample.rs
+++ b/crates/uroborosql-lint/src/rules/missing_two_way_sample.rs
@@ -86,7 +86,7 @@ mod tests {
         let diagnostics = run(sql);
         let diagnostic = diagnostics
             .iter()
-            .find(|diag| diag.rule_id == "missing-two-way-sample")
+            .find(|diag| diag.code == "missing-two-way-sample")
             .expect("should detect missing sample");
 
         let SqlSpan { start, end } = diagnostic.span;
@@ -99,7 +99,7 @@ mod tests {
         let diagnostics = run(sql);
         let diagnostic = diagnostics
             .iter()
-            .find(|diag| diag.rule_id == "missing-two-way-sample")
+            .find(|diag| diag.code == "missing-two-way-sample")
             .expect("should detect missing sample");
 
         let SqlSpan { start, end } = diagnostic.span;
@@ -112,7 +112,7 @@ mod tests {
         let diagnostics = run(sql);
         assert!(diagnostics
             .iter()
-            .all(|diag| diag.rule_id == "missing-two-way-sample"));
+            .all(|diag| diag.code == "missing-two-way-sample"));
 
         assert_eq!(diagnostics.len(), 2);
 
@@ -128,7 +128,7 @@ mod tests {
         let diagnostics = run(sql);
         assert!(diagnostics
             .iter()
-            .all(|diag| diag.rule_id == "missing-two-way-sample"));
+            .all(|diag| diag.code == "missing-two-way-sample"));
 
         assert_eq!(diagnostics.len(), 2);
 

--- a/crates/uroborosql-lint/src/rules/no_distinct.rs
+++ b/crates/uroborosql-lint/src/rules/no_distinct.rs
@@ -45,7 +45,7 @@ mod tests {
         let diagnostics = run_with_rules(sql, vec![RuleEnum::NoDistinct(NoDistinct)]);
         assert_eq!(diagnostics.len(), 1);
         let diagnostic = &diagnostics[0];
-        assert_eq!(diagnostic.rule_id, "no-distinct");
+        assert_eq!(diagnostic.code, "no-distinct");
         assert_eq!(diagnostic.severity, Severity::Warning);
         assert!(sql[diagnostic.span.start.byte..diagnostic.span.end.byte]
             .eq_ignore_ascii_case("distinct"));

--- a/crates/uroborosql-lint/src/rules/no_function_on_column_in_join_or_where.rs
+++ b/crates/uroborosql-lint/src/rules/no_function_on_column_in_join_or_where.rs
@@ -143,7 +143,7 @@ mod tests {
 
             assert!(diagnostics
                 .iter()
-                .any(|diag| diag.rule_id == "no-function-on-column-in-join-or-where"),);
+                .any(|diag| diag.code == "no-function-on-column-in-join-or-where"),);
 
             assert_eq!(diagnostics.len(), 1);
 
@@ -225,7 +225,7 @@ mod tests {
 
             assert!(diagnostics
                 .iter()
-                .all(|diag| diag.rule_id == "no-function-on-column-in-join-or-where"),);
+                .all(|diag| diag.code == "no-function-on-column-in-join-or-where"),);
 
             assert_eq!(
                 diagnostics.len(),
@@ -268,7 +268,7 @@ mod tests {
 
             assert!(diagnostics
                 .iter()
-                .any(|diag| diag.rule_id == "no-function-on-column-in-join-or-where"),);
+                .any(|diag| diag.code == "no-function-on-column-in-join-or-where"),);
 
             assert_eq!(diagnostics.len(), 1);
 
@@ -283,7 +283,7 @@ mod tests {
 
             assert!(diagnostics
                 .iter()
-                .all(|diag| diag.rule_id == "no-function-on-column-in-join-or-where"),);
+                .all(|diag| diag.code == "no-function-on-column-in-join-or-where"),);
 
             assert_eq!(diagnostics.len(), 2,);
 

--- a/crates/uroborosql-lint/src/rules/no_not_in.rs
+++ b/crates/uroborosql-lint/src/rules/no_not_in.rs
@@ -78,7 +78,7 @@ mod tests {
 
         let diagnostic = diagnostics
             .iter()
-            .find(|diag| diag.rule_id == "no-not-in")
+            .find(|diag| diag.code == "no-not-in")
             .expect("expected NOT IN to be detected");
 
         let SqlSpan { start, end } = diagnostic.span;
@@ -92,7 +92,7 @@ mod tests {
 
         let diagnostic = diagnostics
             .iter()
-            .find(|diag| diag.rule_id == "no-not-in")
+            .find(|diag| diag.code == "no-not-in")
             .expect("expected NOT IN to be detected");
 
         let SqlSpan { start, end } = diagnostic.span;
@@ -105,7 +105,7 @@ mod tests {
         let diagnostics = run_with_rules(sql, vec![RuleEnum::NoNotIn(NoNotIn)]);
 
         assert!(
-            diagnostics.iter().any(|diag| diag.rule_id == "no-not-in"),
+            diagnostics.iter().any(|diag| diag.code == "no-not-in"),
             "expected NOT IN subquery to be detected"
         );
     }

--- a/crates/uroborosql-lint/src/rules/no_union_distinct.rs
+++ b/crates/uroborosql-lint/src/rules/no_union_distinct.rs
@@ -100,7 +100,7 @@ mod tests {
         let diagnostics = run_with_rules(sql, vec![RuleEnum::NoUnionDistinct(NoUnionDistinct)]);
         let diagnostic = diagnostics
             .iter()
-            .find(|diag| diag.rule_id == "no-union-distinct")
+            .find(|diag| diag.code == "no-union-distinct")
             .expect("should detect UNION");
 
         let SqlSpan { start, end } = diagnostic.span;
@@ -113,7 +113,7 @@ mod tests {
         let diagnostics = run_with_rules(sql, vec![RuleEnum::NoUnionDistinct(NoUnionDistinct)]);
         let diagnostic = diagnostics
             .iter()
-            .find(|diag| diag.rule_id == "no-union-distinct")
+            .find(|diag| diag.code == "no-union-distinct")
             .expect("should detect UNION");
 
         let SqlSpan { start, end } = diagnostic.span;
@@ -126,7 +126,7 @@ mod tests {
         let diagnostics = run_with_rules(sql, vec![RuleEnum::NoUnionDistinct(NoUnionDistinct)]);
         let diagnostic = diagnostics
             .iter()
-            .find(|diag| diag.rule_id == "no-union-distinct")
+            .find(|diag| diag.code == "no-union-distinct")
             .expect("should detect UNION DISTINCT");
 
         let SqlSpan { start, end } = diagnostic.span;
@@ -140,7 +140,7 @@ mod tests {
         assert!(
             diagnostics
                 .iter()
-                .all(|diag| diag.rule_id != "no-union-distinct"),
+                .all(|diag| diag.code != "no-union-distinct"),
             "UNION ALL should not trigger no-union-distinct rule"
         );
     }

--- a/crates/uroborosql-lint/src/rules/no_wildcard_projection.rs
+++ b/crates/uroborosql-lint/src/rules/no_wildcard_projection.rs
@@ -73,7 +73,7 @@ mod tests {
 
         let diagnostic = diagnostics
             .iter()
-            .find(|diag| diag.rule_id == "no-wildcard-projection")
+            .find(|diag| diag.code == "no-wildcard-projection")
             .expect("should detect SELECT *");
 
         let SqlSpan { start, end } = diagnostic.span;
@@ -87,7 +87,7 @@ mod tests {
 
         let diagnostic = diagnostics
             .iter()
-            .find(|diag| diag.rule_id == "no-wildcard-projection")
+            .find(|diag| diag.code == "no-wildcard-projection")
             .expect("should detect RETURNING *");
 
         let SqlSpan { start, end } = diagnostic.span;
@@ -100,7 +100,7 @@ mod tests {
         let diagnostics = run(sql);
         let diagnostic = diagnostics
             .iter()
-            .find(|diag| diag.rule_id == "no-wildcard-projection")
+            .find(|diag| diag.code == "no-wildcard-projection")
             .expect("should detect *");
 
         let SqlSpan { start, end } = diagnostic.span;
@@ -113,7 +113,7 @@ mod tests {
         let diagnostics = run(sql);
         let diagnostic = diagnostics
             .iter()
-            .find(|diag| diag.rule_id == "no-wildcard-projection")
+            .find(|diag| diag.code == "no-wildcard-projection")
             .expect("should detect *");
 
         let SqlSpan { start, end } = diagnostic.span;

--- a/crates/uroborosql-lint/src/rules/too_large_in_list.rs
+++ b/crates/uroborosql-lint/src/rules/too_large_in_list.rs
@@ -91,7 +91,7 @@ mod tests {
         );
         let diagnostics = run(&sql);
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].rule_id, "too-large-in-list");
+        assert_eq!(diagnostics[0].code, "too-large-in-list");
     }
 
     #[test]


### PR DESCRIPTION
## 概要

`uroborosql-lint` に、ファイル内で警告を無効化するためのディレクティブコメントを追加しました。
行コメントベースのディレクティブを解釈し、lint ルール実行後の共通処理として該当する警告を無効化します。

対応したディレクティブコメントの形式：

- `-- uroborosql-lint-disable <rules>`
- `-- uroborosql-lint-disable-next-line <rules>`

※ `<rules>` はカンマ区切りのルールID

あわせて、ディレクティブコメント自体の不正も `invalid-lint-directive` warning として返せるようにしました。

## ディレクティブコメントのセマンティクス

- `uroborosql-lint-disable-next-line <rules>` （次行において当該ルールの警告を抑制）
  - コメントの次の物理行に開始位置を持つ diagnostic だけを抑制
- `uroborosql-lint-disable <rules>` （ファイル全体で当該ルールの警告を抑制）
  - ファイル冒頭の comment section にある場合だけ有効
  - 冒頭 section は「先頭から連続する空行または行コメント」
  - block comment または最初の SQL token が出た時点で冒頭 section を終了

※ルール指定がない場合、現状は不正な形式として扱われます

## 変更内容

### 診断結果を suppress する処理の追加

- `crates/uroborosql-lint/src/directive.rs` 
- parser が返す `SQL_COMMENT` node から directive を抽出
- ルール名を検証し、重複指定は正規化
- diagnostics 生成後に suppression を適用する共通処理を `Linter::run` に追加

### ディレクティブコメント自体の不正に対するフィードバックの追加

- recognized directive で rule 名の解釈に失敗した場合は `invalid-lint-directive` warning を返す
- 現在 warning を返すケース:
  - unknown rule の場合
    - `unknown lint directive rule ...`
  - ルール名が書けている場合
    - `invalid lint directive syntax: expected one or more comma-separated rule names`
  - trailing comma がある場合
    - `invalid lint directive syntax: trailing comma is not allowed`
  - `no-distinct no-wildcard-projection` のような不正形式（空白区切り）
    - `invalid lint directive syntax: expected comma-separated rule names`



### ドキュメント追加

- [`crates/uroborosql-lint/README.md`](https://github.com/future-architect/uroborosql-fmt/blob/c4265e0f5d0479a50081da70acbb1ce51a06e418/crates/uroborosql-lint/README.md) にディレクティブコメントの使い方を追加しました
