### PR TITLE
fix: address clippy::collapsible_match warning introduced by Rust 1.95

### DIFF
--- a/crates/uroborosql-fmt/src/two_way_sql/merge.rs
+++ b/crates/uroborosql-fmt/src/two_way_sql/merge.rs
@@ -18,12 +18,10 @@ fn read_before_end(src_lines: &[&str], cursor: &mut usize) -> Vec<String> {
         let kind = Kind::guess_from_str(current_line);
 
         match kind {
-            Kind::If | Kind::Begin => {
-                // 入れ子カウントをインクリメント
-                // ただし、一行目の場合は入れ子とは関係のない/*IF*/、/*BEGIN*/なので無視する
-                if !is_first_line {
-                    nest_count += 1;
-                }
+            // 入れ子カウントをインクリメント
+            // ただし、一行目の場合は入れ子とは関係のない/*IF*/、/*BEGIN*/なので無視する
+            Kind::If | Kind::Begin if !is_first_line => {
+                nest_count += 1;
             }
             Kind::End => {
                 if nest_count == 0 {


### PR DESCRIPTION
## 概要

Rust 1.95.0 で `clippy::collapsible_match` lint が厳しくなり、`crates/uroborosql-fmt/src/two_way_sql/merge.rs` の `match` 内のネストした `if` が新たに警告対象となったため、match guard に書き換える。

## 背景

- v1.0.1 タグ push 時の CI で clippy が `--deny warnings` により失敗

## 変更内容

`match` の `Kind::If | Kind::Begin` アームに包含されていた `if !is_first_line` を match guard に変換。意味的に等価（`is_first_line` が `true` のときは `_ => ()` に落ちて何もしない）。

```diff
 match kind {
-    Kind::If | Kind::Begin => {
-        // 入れ子カウントをインクリメント
-        // ただし、一行目の場合は入れ子とは関係のない/*IF*/、/*BEGIN*/なので無視する
-        if !is_first_line {
-            nest_count += 1;
-        }
+    // 入れ子カウントをインクリメント
+    // ただし、一行目の場合は入れ子とは関係のない/*IF*/、/*BEGIN*/なので無視する
+    Kind::If | Kind::Begin if !is_first_line => {
+        nest_count += 1;
     }
     Kind::End => {
```

## 動作確認

- [x] `cargo clippy -- --deny warnings` 通過
- [x] `cargo clippy --workspace --all-targets -- --deny warnings` 通過
- [x] `cargo fmt --check` 通過

検証環境: Rust 1.95.0 / clippy 0.1.95（CI の stable と同じバージョン）

## マージ後の想定タスク

1. CIが通っていることを確認
2. 既存のv1.0.1 releaseを削除
3. v1.0.1 release再作成
4. CIによってrelealseにnapi等が追加されていることを確認
