### PR TITLE
fix: specify version requirement for postgresql-cst-parser git dependency

### DIFF
--- a/crates/uroborosql-fmt/Cargo.toml
+++ b/crates/uroborosql-fmt/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0.91"
 thiserror = "1.0.38"
 
 # git config --global core.longpaths true を管理者権限で実行しないとけない
-postgresql-cst-parser = { git = "https://github.com/future-architect/postgresql-cst-parser" }
+postgresql-cst-parser = { git = "https://github.com/future-architect/postgresql-cst-parser", version = "0.2" }
 
 [dev-dependencies]
 console = "0.15.10"


### PR DESCRIPTION
## 概要

`crates/uroborosql-fmt/Cargo.toml` の `postgresql-cst-parser` 依存に `version = "0.2"` を追加し、release-plz の内部処理で実行される `cargo package` が manifest 検証で落ちる問題を解消する。

## 背景

`feat: automate version management with release-plz` (#233) のマージ後、main 向けに release-plz workflow が走るたびに以下のエラーで失敗していた。

```
error: failed to verify manifest at `crates/uroborosql-fmt/Cargo.toml`

Caused by:
  all dependencies must have a version requirement specified when packaging.
  dependency `postgresql-cst-parser` does not specify a version
  Note: The packaged dependency will use the version from crates.io,
  the `git` specification will be removed from the dependency declaration.
```

release-plz は次回バージョンを決定するために内部で `cargo package` を実行するが、cargo は package 検証時に全依存に version 制約を要求するため、git URL のみの指定では検証を通せない。

`release-plz.toml` で `git_only = true` / `semver_check = false` を設定しているが、`cargo package` 自体は実行されるため、この問題は config 側では回避できない。

## 変更内容

```diff
-postgresql-cst-parser = { git = "https://github.com/future-architect/postgresql-cst-parser" }
+postgresql-cst-parser = { git = "https://github.com/future-architect/postgresql-cst-parser", version = "0.2" }
```

`version = "0.2"` を追加することで cargo の manifest 検証を通す。

- 開発時の依存解決は**従来通り git source（commit `d252fb2a`）を使用**
- `version = "0.2"` は cargo の manifest 検証用の制約宣言として機能
- `postgresql-cst-parser` は crates.io に 0.2.0 で公開済みのため、version 制約は実態と一致

## 動作確認

ローカルで CI と同等の検証を実施：

- [x] **修正前**: `cargo package -p uroborosql-fmt --no-verify --allow-dirty` で CI と同じエラーを再現
- [x] **修正後**: `cargo package -p uroborosql-fmt --no-verify --allow-dirty` が `Packaged 650 files, 738.5KiB (154.9KiB compressed)` で通過
- [x] **修正後**: `cargo check --workspace` 通過（既存ビルドへの影響なし）
- [x] **修正後**: `Cargo.lock` に差分なし（依存解決の挙動は不変）

## 関連

- release-plz workflow の失敗ジョブ: https://github.com/future-architect/uroborosql-fmt/actions/runs/26379073205
- このPRをマージしないと、main への push のたびに release-plz が失敗し続け、v1.0.2 以降の自動 Release PR も作成されない