### PR TITLE
fix: skip release-plz release step as workaround for release-plz#2595

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,5 +28,12 @@ jobs:
 
       - name: Run release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
+        with:
+          # release ステップは workspace 内 path 依存があると cargo publish を試行して失敗する
+          # 既知バグ (https://github.com/release-plz/release-plz/issues/2595) のワークアラウンドとして
+          # release-pr のみ実行する。タグ・GitHub Release の作成は当面手動で行う。
+          # 根本fix の PR (https://github.com/release-plz/release-plz/pull/2789) が
+          # マージされたら command を外して自動化に戻す。
+          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}


### PR DESCRIPTION
## 概要

release-plz workflow が main push のたびに失敗していたのを解消する。

## 原因

release-plz の既知バグ ([release-plz#2595](https://github.com/release-plz/release-plz/issues/2595)) により、workspace 内に path 依存があると `release` ステップで `cargo publish` が試行されて token エラーで失敗する。

## 対応

`release-plz/action` の `command: release-pr` 入力を指定し、`release` ステップをスキップする。

副作用として git タグ・GitHub Release の作成は当面手動になる。根本fixの [release-plz#2789](https://github.com/release-plz/release-plz/pull/2789) がマージされたら `command: release-pr` を外して自動化に戻す。

## 動作確認

- [ ] main マージ後、push トリガーで release-plz workflow が緑になることを確認
- [ ] Release PR が release-pr ステップで正しく作成/更新されることを確認

---

# 今後のリリースの流れ（このPRマージ後）

1. **開発**: `feat:` / `fix:` などの Conventional Commits で main にマージ
2. **release-plz が Release PR を自動作成/更新**（Cargo.toml のバージョン更新 + CHANGELOG.md 生成）
3. **Release PR をレビュー & マージ**  ← 人手
4. **手動で v1.0.X タグを作成・push**  ← 人手 ★ ここが手動
   ```bash
   git pull origin main
   git tag v1.0.X
   git push origin v1.0.X
   ```
   （または GitHub UI の Releases → "Draft a new release" でタグと Release を同時作成）
5. **CI.yml が tags トリガーで起動**
   - test → build-napi → build-wasm
   - `upload-napi-to-release`: NAPI .tgz を GitHub Release に添付
   - `deploy-wasm-to-gh-pages`: WASM を GitHub Pages にデプロイ

## 自動化されるもの / されないもの

| タスク | 自動 | 手動 |
|---|---|---|
| Cargo.toml のバージョン更新 | ✅ release-plz | |
| CHANGELOG 生成 | ✅ release-plz | |
| Release PR 作成 | ✅ release-plz | |
| Release PR のマージ | | ⚠️ 人 |
| **git タグ作成** | | ⚠️ **人** ★ |
| **GitHub Release 作成** | | ⚠️ **人** ★ |
| NAPI .tgz のビルド・添付 | ✅ CI.yml | |
| WASM の Pages デプロイ | ✅ CI.yml | |

凡例:
- ✅ — 自動化済み
- ⚠️ 人 — 人手作業
- **★** — このPRのワークアラウンドにより一時的に手動になっている項目。[release-plz#2789](https://github.com/release-plz/release-plz/pull/2789) マージ後に自動化に戻る

---

# #2789 がマージされた後のタスク

[release-plz#2789](https://github.com/release-plz/release-plz/pull/2789) がマージされ、新バージョンの release-plz がリリースされたら、以下の対応を行う。

## やること

### 1. release-plz/action のバージョン更新

`.github/workflows/release-plz.yml` の action 参照を、PR #2789 を含むリリースが入った新しい SHA に更新する。

```diff
-        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
+        uses: release-plz/action@<新しいSHA> # v0.X
```

参考: https://github.com/release-plz/action/releases

### 2. `command: release-pr` を削除

`release` ステップを再有効化する。

```diff
       - name: Run release-plz
         uses: release-plz/action@<新しいSHA> # v0.X
-        with:
-          # release ステップは workspace 内 path 依存があると cargo publish を試行して失敗する
-          # 既知バグ (https://github.com/release-plz/release-plz/issues/2595) のワークアラウンドとして
-          # release-pr のみ実行する。タグ・GitHub Release の作成は当面手動で行う。
-          # 根本fix の PR (https://github.com/release-plz/release-plz/pull/2789) が
-          # マージされたら command を外して自動化に戻す。
-          command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
```

### 3. 動作確認

- 万一の不具合に備え、最初の自動リリース時はワークフローを注視

---

# #2789 マージ後のリリースの流れ

1. **開発**: `feat:` / `fix:` などの Conventional Commits で main にマージ
2. **release-plz が Release PR を自動作成/更新**（Cargo.toml のバージョン更新 + CHANGELOG.md 生成）
3. **Release PR をレビュー & マージ**  ← 人手（残るのはここだけ）
4. **release-plz workflow が再起動し、release ステップが自動実行**  ← 全自動
   - git タグを自動作成
   - GitHub Release を自動作成
5. **CI.yml が tags トリガーで起動**
   - test → build-napi → build-wasm
   - `upload-napi-to-release`: NAPI .tgz を GitHub Release に添付
   - `deploy-wasm-to-gh-pages`: WASM を GitHub Pages にデプロイ

## 自動化されるもの / されないもの

| タスク | 自動 | 手動 |
|---|---|---|
| Cargo.toml のバージョン更新 | ✅ release-plz | |
| CHANGELOG 生成 | ✅ release-plz | |
| Release PR 作成 | ✅ release-plz | |
| Release PR のマージ | | ⚠️ 人 |
| git タグ作成 | ✅ release-plz | |
| GitHub Release 作成 | ✅ release-plz | |
| NAPI .tgz のビルド・添付 | ✅ CI.yml | |
| WASM の Pages デプロイ | ✅ CI.yml | |

**人手作業は Release PR のレビュー & マージのみ**。当初想定の運用に戻る。
