### PR TITLE
feat: distribute and rename CLI binary, print errors to stderr

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -144,6 +144,72 @@ jobs:
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: failure
 
+  # CLI バイナリ (uroborosql-fmt) を各プラットフォーム向けにビルド
+  build-cli:
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - host: macos-15-intel
+            target: x86_64-apple-darwin
+            asset: uroborosql-fmt-x86_64-apple-darwin
+          - host: macos-latest
+            target: aarch64-apple-darwin
+            asset: uroborosql-fmt-aarch64-apple-darwin
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+            asset: uroborosql-fmt-x86_64-pc-windows-msvc.exe
+          - host: windows-latest
+            target: aarch64-pc-windows-msvc
+            asset: uroborosql-fmt-aarch64-pc-windows-msvc.exe
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset: uroborosql-fmt-x86_64-unknown-linux-gnu
+    name: build-cli - ${{ matrix.target }}
+    runs-on: ${{ matrix.host }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.target }}-cargo-cli-${{ matrix.host }}
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }} -p uroborosql-fmt-cli
+        shell: bash
+      - name: Prepare artifact
+        shell: bash
+        run: |
+          mkdir -p cli-dist
+          if [[ "${{ matrix.target }}" == *windows* ]]; then
+            cp "target/${{ matrix.target }}/release/uroborosql-fmt.exe" "cli-dist/${{ matrix.asset }}"
+          else
+            cp "target/${{ matrix.target }}/release/uroborosql-fmt" "cli-dist/${{ matrix.asset }}"
+          fi
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-${{ matrix.target }}
+          path: cli-dist/${{ matrix.asset }}
+          if-no-files-found: error
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: ./.github/actions/slack-failure-notify
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: failure
+
   build-wasm:
     needs: test
     runs-on: ubuntu-latest
@@ -251,6 +317,32 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${GITHUB_REF_NAME}" ${{ env.WORKING_DIR }}/repo/*.tgz --clobber
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: ./.github/actions/slack-failure-notify
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: failure
+
+  # CLI バイナリを GitHub Release のアセットにアップロード
+  upload-cli-to-release:
+    if: github.repository == 'future-architect/uroborosql-fmt' &&
+      startsWith(github.ref, 'refs/tags/v')
+    needs: build-cli
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all CLI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cli-*
+          path: ./cli-artifacts
+          merge-multiple: true
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" ./cli-artifacts/* --clobber
 
       - name: Notify Slack on Failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ cargo install --git https://github.com/future-architect/uroborosql-fmt
 
 ```sh
 # Print formatted SQL to STDOUT (does not modify the file)
-uroborosql-fmt-cli input.sql
+uroborosql-fmt input.sql
 
 # Format the file
-uroborosql-fmt-cli -w input.sql
+uroborosql-fmt -w input.sql
 ```
 
 For detailed CLI usage, options, and examples, see the [CLI documentation](crates/uroborosql-fmt-cli/README.md).

--- a/crates/uroborosql-fmt-cli/Cargo.toml
+++ b/crates/uroborosql-fmt-cli/Cargo.toml
@@ -9,6 +9,10 @@ repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "uroborosql-fmt"
+path = "src/main.rs"
+
 [dependencies]
 uroborosql-fmt = { workspace = true }
 clap = { version = "4", features = ["derive"] }

--- a/crates/uroborosql-fmt-cli/README.md
+++ b/crates/uroborosql-fmt-cli/README.md
@@ -1,5 +1,7 @@
 # uroborosql-fmt-cli
 
+CLI crate for uroborosql-fmt. The installed binary name is `uroborosql-fmt`.
+
 ## Install
 
 ```bash
@@ -9,7 +11,7 @@ cargo install --git https://github.com/future-architect/uroborosql-fmt
 ## Usage
 
 ```bash
-uroborosql-fmt-cli -- [OPTIONS] [INPUT]
+uroborosql-fmt -- [OPTIONS] [INPUT]
 ```
 
 ### Arguments
@@ -39,18 +41,18 @@ uroborosql-fmt-cli -- [OPTIONS] [INPUT]
 
 ```bash
 # Format a file and output to stdout
-uroborosql-fmt-cli query.sql
+uroborosql-fmt query.sql
 
 # Read from STDIN and format
-cat query.sql | uroborosql-fmt-cli
-uroborosql-fmt-cli < query.sql
+cat query.sql | uroborosql-fmt
+uroborosql-fmt < query.sql
 
 # Check formatting differences only
-uroborosql-fmt-cli --check query.sql
+uroborosql-fmt --check query.sql
 
 # Format and overwrite the file
-uroborosql-fmt-cli --write query.sql
+uroborosql-fmt --write query.sql
 
 # Format with a specific configuration file
-uroborosql-fmt-cli --config mycfg.json query.sql
+uroborosql-fmt --config mycfg.json query.sql
 ```

--- a/crates/uroborosql-fmt-cli/src/cli.rs
+++ b/crates/uroborosql-fmt-cli/src/cli.rs
@@ -11,7 +11,7 @@ use uroborosql_fmt::format_sql;
 pub const DEFAULT_CONFIG_PATH: &str = ".uroborosqlfmtrc.json";
 
 #[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
+#[command(name = "uroborosql-fmt", version, about, long_about = None)]
 pub struct Cli {
     /// Input file. If omitted, read from STDIN.
     pub input: Option<PathBuf>,
@@ -66,9 +66,12 @@ pub fn run(cli: Cli) -> Result<(), ExitCode> {
     };
 
     // 3) Format SQL
-    let formatted = format_sql(&src, None, config_path).map_err(|e| match e {
-        UroboroSQLFmtError::ParseError(_) => ExitCode::ParseError,
-        _ => ExitCode::OtherError,
+    let formatted = format_sql(&src, None, config_path).map_err(|e| {
+        eprintln!("error: {e}");
+        match e {
+            UroboroSQLFmtError::ParseError(_) => ExitCode::ParseError,
+            _ => ExitCode::OtherError,
+        }
     })?;
 
     // 4) Option handling
@@ -107,7 +110,7 @@ pub fn run(cli: Cli) -> Result<(), ExitCode> {
                 Some(ref path) => {
                     eprintln!("{}", path.display());
                     eprintln!(
-                        "Code style issues found in the file. Run uroborosql-fmt-cli with --write to fix."
+                        "Code style issues found in the file. Run uroborosql-fmt with --write to fix."
                     );
                 }
                 None => {

--- a/crates/uroborosql-fmt-cli/tests/cli.rs
+++ b/crates/uroborosql-fmt-cli/tests/cli.rs
@@ -14,7 +14,7 @@ fn sample_sql() -> (&'static str, String) {
 /// 標準入力からSQLを読み込んでフォーマットする
 fn format_from_stdin() {
     let (raw, formatted) = sample_sql();
-    let mut cmd = Command::cargo_bin("uroborosql-fmt-cli").unwrap();
+    let mut cmd = Command::cargo_bin("uroborosql-fmt").unwrap();
     cmd.write_stdin(raw)
         .assert()
         .success()
@@ -24,7 +24,7 @@ fn format_from_stdin() {
 #[test]
 /// check モードと write モードは排他である
 fn check_and_write_mode_conflict() {
-    let mut cmd = Command::cargo_bin("uroborosql-fmt-cli").unwrap();
+    let mut cmd = Command::cargo_bin("uroborosql-fmt").unwrap();
     cmd.arg("--check").arg("--write").assert().failure();
 }
 
@@ -39,8 +39,8 @@ mod check_mode {
         let file = assert_fs::NamedTempFile::new("ok.sql").unwrap();
         file.write_str(&formatted).unwrap();
 
-        // uroborosql-fmt-cli --check ok.sql
-        Command::cargo_bin("uroborosql-fmt-cli")
+        // uroborosql-fmt --check ok.sql
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .arg("--check")
             .arg(file.path())
@@ -55,8 +55,8 @@ mod check_mode {
         let file = assert_fs::NamedTempFile::new("ng.sql").unwrap();
         file.write_str(raw).unwrap();
 
-        // uroborosql-fmt-cli --check ng.sql
-        Command::cargo_bin("uroborosql-fmt-cli")
+        // uroborosql-fmt --check ng.sql
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .arg("--check")
             .arg(file.path())
@@ -76,8 +76,8 @@ mod write_mode {
         let file = assert_fs::NamedTempFile::new("rewrite.sql").unwrap();
         file.write_str(raw).unwrap();
 
-        // uroborosql-fmt-cli -w rewrite.sql
-        Command::cargo_bin("uroborosql-fmt-cli")
+        // uroborosql-fmt -w rewrite.sql
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .arg("--write")
             .arg(file.path())
@@ -91,8 +91,8 @@ mod write_mode {
     #[test]
     /// write モードでパスが指定されていなければ失敗する
     fn write_mode_fails_without_path() {
-        // uroborosql-fmt-cli -w
-        Command::cargo_bin("uroborosql-fmt-cli")
+        // uroborosql-fmt -w
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .arg("--write")
             .assert()

--- a/crates/uroborosql-fmt-cli/tests/cli_ext.rs
+++ b/crates/uroborosql-fmt-cli/tests/cli_ext.rs
@@ -15,8 +15,8 @@ fn file_to_stdout() {
     let file = assert_fs::NamedTempFile::new("input.sql").unwrap();
     file.write_str(raw).unwrap();
 
-    // uroborosql-fmt-cli input.sql
-    Command::cargo_bin("uroborosql-fmt-cli")
+    // uroborosql-fmt input.sql
+    Command::cargo_bin("uroborosql-fmt")
         .unwrap()
         .arg(file.path())
         .assert()
@@ -43,8 +43,8 @@ mod config {
         let config_file = NamedTempFile::new("mycfg.json").unwrap();
         config_file.write_str(config_json).unwrap();
 
-        // uroborosql-fmt-cli --config mycfg.json input.sql
-        Command::cargo_bin("uroborosql-fmt-cli")
+        // uroborosql-fmt --config mycfg.json input.sql
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .arg("--config")
             .arg(config_file.path())
@@ -70,8 +70,8 @@ mod config {
         let input_file = dir.child("q.sql");
         input_file.write_str(raw).unwrap();
 
-        // uroborosql-fmt-cli q.sql
-        Command::cargo_bin("uroborosql-fmt-cli")
+        // uroborosql-fmt q.sql
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .current_dir(&dir)
             .arg(input_file.path())
@@ -103,8 +103,8 @@ mod config {
         let input_file = dir.child("q.sql");
         input_file.write_str(raw).unwrap();
 
-        // uroborosql-fmt-cli --config exp.json q.sql
-        Command::cargo_bin("uroborosql-fmt-cli")
+        // uroborosql-fmt --config exp.json q.sql
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .current_dir(&dir)
             .arg("--config")
@@ -125,9 +125,9 @@ mod exit_code {
     fn parse_error_exit_code() {
         let invalid_sql = "SELECT FROM";
 
-        // uroborosql-fmt-cli < echo "SELECT FROM"
+        // uroborosql-fmt < echo "SELECT FROM"
         // error code 1
-        Command::cargo_bin("uroborosql-fmt-cli")
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .write_stdin(invalid_sql)
             .assert()
@@ -144,9 +144,9 @@ mod exit_code {
         let input_file = NamedTempFile::new("input.sql").unwrap();
         input_file.write_str("select 1;").unwrap();
 
-        // uroborosql-fmt-cli --config bad.json input.sql
+        // uroborosql-fmt --config bad.json input.sql
         // error code 2
-        Command::cargo_bin("uroborosql-fmt-cli")
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .arg("--config")
             .arg(config_file.path())
@@ -158,9 +158,9 @@ mod exit_code {
     #[test]
     /// 入力なしの場合、終了コード 2 (OtherError) を返す
     fn no_input_exit_other_error() {
-        // uroborosql-fmt-cli
+        // uroborosql-fmt
         // error code 2
-        Command::cargo_bin("uroborosql-fmt-cli")
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .assert()
             .code(2);
@@ -169,9 +169,9 @@ mod exit_code {
     #[test]
     /// 存在しないファイルの場合、終了コード 2 (OtherError) を返す
     fn nonexistent_file_exit_other_error() {
-        // uroborosql-fmt-cli no_such_file.sql
+        // uroborosql-fmt no_such_file.sql
         // error code 2
-        Command::cargo_bin("uroborosql-fmt-cli")
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .arg("no_such_file.sql")
             .assert()
@@ -190,9 +190,9 @@ mod exit_code {
         perm.set_readonly(true);
         fs::set_permissions(file.path(), perm).unwrap();
 
-        // uroborosql-fmt-cli -w ro.sql
+        // uroborosql-fmt -w ro.sql
         // error code 2
-        Command::cargo_bin("uroborosql-fmt-cli")
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .arg("-w")
             .arg(file.path())
@@ -203,9 +203,9 @@ mod exit_code {
     #[test]
     /// -w と --check が競合する場合、終了コード 2 (OtherError) を返す
     fn write_and_check_conflict() {
-        // uroborosql-fmt-cli -w --check
+        // uroborosql-fmt -w --check
         // error code 2
-        Command::cargo_bin("uroborosql-fmt-cli")
+        Command::cargo_bin("uroborosql-fmt")
             .unwrap()
             .arg("-w")
             .arg("--check")


### PR DESCRIPTION
## 概要

AI エージェントなどから利用しやすいよう、以下 3 点に対応する。

1. CLI バイナリを GitHub Releases に配布する
2. CLI バイナリ名を `uroborosql-fmt-cli` から `uroborosql-fmt` に変更する
3. フォーマット失敗時のエラー詳細を stderr に出力する

## 背景

### 1. CLI バイナリ配布

PR #233 (release-plz 導入) の検討事項として「CLI バイナリも GitHub Release に含めるか」が残されていた。今回 AI エージェントからの利用要望を受けて実装する。

### 2. CLI バイナリ名の変更

`[[bin]]` セクションを指定しないと package 名のまま `uroborosql-fmt-cli.exe` でビルドされる。AI エージェント等から扱いやすいよう、binary 名を短い `uroborosql-fmt` に変更する。

package 名 `uroborosql-fmt-cli` は workspace 内の crate 識別子として残し、binary 名のみを変更する。これは `biome`, `ruff`, `swc` 等の workspace 型 Rust CLI と同じパターン。

### 3. stderr 出力

PR #203 のレビューで `map_err` パターン化が採用された際、元々あった `eprintln!("{}", e)` が落ちていた経緯がある。終了コード（1 / 2）だけが返り、エラー詳細は出力されない状態になっていたため、AI エージェントが失敗理由を把握できない問題があった。

参考: https://github.com/future-architect/uroborosql-fmt/pull/203#discussion_r2272003335

## 変更内容

### CLI コード

- `crates/uroborosql-fmt-cli/Cargo.toml`: `[[bin]] name = "uroborosql-fmt"` を追加
- `crates/uroborosql-fmt-cli/src/cli.rs`:
  - `format_sql` エラー時に `eprintln!("error: {e}")` で stderr に出力
  - `#[command(name = "uroborosql-fmt", ...)]` で `--version` 表示を binary 名に揃える
  - help メッセージ内の `uroborosql-fmt-cli` 表記を `uroborosql-fmt` に更新

### テスト・ドキュメント

- テストファイル: `Command::cargo_bin("uroborosql-fmt-cli")` → `Command::cargo_bin("uroborosql-fmt")`
- `crates/uroborosql-fmt-cli/README.md`: usage 例を binary 名に統一。タイトルは package 名のまま維持し、本文 1 行目に binary 名を注記
- `README.md` (workspace root): usage 例を binary 名に統一

### CI ワークフロー

`.github/workflows/CI.yml` に 2 ジョブを追加:

- **`build-cli`**: 各プラットフォーム向けに CLI バイナリをビルド
  - `x86_64-apple-darwin` / `aarch64-apple-darwin`
  - `x86_64-pc-windows-msvc` / `aarch64-pc-windows-msvc`
  - `x86_64-unknown-linux-gnu`
- **`upload-cli-to-release`**: タグ push 時に CLI バイナリを GitHub Release のアセットにアップロード

ダウンロード URL の例:

```
https://github.com/future-architect/uroborosql-fmt/releases/download/v1.0.X/uroborosql-fmt-x86_64-pc-windows-msvc.exe
```

## 動作確認

### ローカル

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- --deny warnings`
- [x] `cargo test -p uroborosql-fmt-cli` (16 tests)
- [x] `cargo install --path crates/uroborosql-fmt-cli` で `uroborosql-fmt.exe` がインストールされる
- [x] `uroborosql-fmt --version` → `uroborosql-fmt 1.0.1`
- [x] 正常 SQL → フォーマット結果を stdout 出力
- [x] 不正 SQL → `error: Parse error: ...` を stderr 出力 + exit 1

### CI

- [x] `build-cli` マトリックスが 5 ターゲット全て成功
  - `x86_64-apple-darwin` (5.11 MB)
  - `aarch64-apple-darwin` (4.85 MB)
  - `x86_64-pc-windows-msvc` (5.42 MB)
  - `aarch64-pc-windows-msvc` (4.82 MB) ※ クロスコンパイル
  - `x86_64-unknown-linux-gnu` (5.51 MB)
- [x] artifact をダウンロードして `uroborosql-fmt-x86_64-pc-windows-msvc.exe` を実行
  - `--version` → `uroborosql-fmt 1.0.1`
  - 正常 SQL → フォーマット結果を stdout 出力
  - 不正 SQL → `error: Parse error: ...` を stderr 出力 + exit 1
- [ ] `upload-cli-to-release` の動作確認はタグ push 必須のためマージ後に検証
  - 次の `v1.0.X` リリースのタグ push 時に確認

## 関連

- PR #203 (CLI 改善・機能追加): https://github.com/future-architect/uroborosql-fmt/pull/203
- PR #233 (release-plz 導入、検討事項): https://github.com/future-architect/uroborosql-fmt/pull/233
