### PR TITLE
fix: specify version requirement for internal uroborosql-fmt workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/future-architect/uroborosql-fmt"
 
 [workspace.dependencies]
 # Internal crates
-uroborosql-fmt = { path = "./crates/uroborosql-fmt" }
+uroborosql-fmt = { path = "./crates/uroborosql-fmt", version = "1.0.1" }
 
 [profile.release]
 lto = true


### PR DESCRIPTION
## 概要

`Cargo.toml` の `[workspace.dependencies]` で `uroborosql-fmt` の path 依存に `version = "1.0.1"` を追加し、release-plz の `cargo package --workspace` が manifest 検証で落ちる問題を解消する。

## 原因

### 起きていた現象

PR #244 のマージ後、main push をトリガーに release-plz workflow が走り、以下のエラーで失敗していた。

```
error: failed to verify manifest at crates/uroborosql-fmt-cli/Cargo.toml

Caused by:
  all dependencies must have a version requirement specified when packaging.
  dependency `uroborosql-fmt` does not specify a version
```

### なぜこのタイミングで発生したか

このエラーの**根本原因は `[workspace.dependencies]` の `uroborosql-fmt` に version 制約がないこと**。これは PR #244 が入れたものではなく、ずっと前から存在していた潜在的な問題で、**v1.0.1 タグを手動で作成したことが引き金**となって表面化した。

タイミング別に整理すると：

| 時点 | release-plz の挙動 | 結果 |
|---|---|---|
| **PR #242 マージ前** | lib の `postgresql-cst-parser` 依存で manifest 検証が先に失敗 | cli まで到達しないので問題が見えなかった |
| **PR #242 マージ後 & v1.0.1 タグなし** | release-plz は「初回リリース判定」モードで動作し、`cargo package --workspace` の verification を実行しない | 成功してしまうので問題が見えない |
| **v1.0.1 タグ作成後 (PR #244 マージで trigger)** | 最新タグ v1.0.1 を検出 → 「次回リリース判定」モードに切替 → **`cargo package --workspace` で全クレートの manifest を検証** | cli/napi/wasm の path 依存に version 制約がなく失敗 ★今ここ |

つまり：

- PR #244 自体は依存設定を変えていない（`[[bin]]` セクションを追加しただけ）
- PR #244 のマージは「main push のトリガー」を発生させただけ
- 実際の引き金は **v1.0.1 タグを切ったこと**で、release-plz の動作モードが「初回」→「次回判定」に変わったため

### 修正方針

[release-plz#2595](https://github.com/release-plz/release-plz/issues/2595) のコメントで提案されている workaround として、内部 path 依存にも version 制約を明示する。

## 変更内容

```diff
 [workspace.dependencies]
 # Internal crates
-uroborosql-fmt = { path = "./crates/uroborosql-fmt" }
+uroborosql-fmt = { path = "./crates/uroborosql-fmt", version = "1.0.1" }
```

- 開発時の依存解決は引き続き path 経由（変更なし）
- `cargo package --workspace` の manifest 検証を通すための version 制約
- 将来 release-plz が bump する際は、この `version = "1.0.X"` も自動更新される

## 動作確認

- [x] `cargo package --workspace --no-verify --allow-dirty` が全 4 クレートで通過
- [x] `cargo check --workspace` 通過
- [x] `Cargo.lock` 差分なし（依存解決は path 経由のまま）

## 関連

- 失敗 CI: https://github.com/future-architect/uroborosql-fmt/actions/runs/26391458500
- [release-plz#2595](https://github.com/release-plz/release-plz/issues/2595)
- 前の修正: [#242 fix: specify version requirement for postgresql-cst-parser git dependency](https://github.com/future-architect/uroborosql-fmt/pull/242)
