### PR TITLE
chore: align CLI binaries and help text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "uroborosql-language-server"
-version = "0.1.0"
+version = "1.0.1"
 dependencies = [
  "clap",
  "ropey",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "uroborosql-lint"
-version = "0.1.0"
+version = "1.0.1"
 dependencies = [
  "globset",
  "postgresql-cst-parser",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "uroborosql-lint-cli"
-version = "0.1.0"
+version = "1.0.1"
 dependencies = [
  "clap",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,7 @@ dependencies = [
 name = "uroborosql-language-server"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "ropey",
  "serde",
  "serde_json",

--- a/crates/uroborosql-fmt-cli/src/cli.rs
+++ b/crates/uroborosql-fmt-cli/src/cli.rs
@@ -11,7 +11,12 @@ use uroborosql_fmt::format_sql;
 pub const DEFAULT_CONFIG_PATH: &str = ".uroborosqlfmtrc.json";
 
 #[derive(Parser, Debug)]
-#[command(name = "uroborosql-fmt", version, about, long_about = None)]
+#[command(
+    name = "uroborosql-fmt",
+    version,
+    about = "SQL formatter",
+    long_about = None
+)]
 pub struct Cli {
     /// Input file. If omitted, read from STDIN.
     pub input: Option<PathBuf>,

--- a/crates/uroborosql-language-server/Cargo.toml
+++ b/crates/uroborosql-language-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uroborosql-language-server"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [[bin]]

--- a/crates/uroborosql-language-server/Cargo.toml
+++ b/crates/uroborosql-language-server/Cargo.toml
@@ -3,11 +3,16 @@ name = "uroborosql-language-server"
 version = "0.1.0"
 edition = "2024"
 
+[[bin]]
+name = "uroborosql-language-server"
+path = "src/main.rs"
+
 [features]
 default = ["runtime-tokio"]
 runtime-tokio = ["tokio", "tower-lsp-server/runtime-tokio"]
 
 [dependencies]
+clap = { workspace = true }
 ropey = "1.6.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/uroborosql-language-server/src/main.rs
+++ b/crates/uroborosql-language-server/src/main.rs
@@ -1,6 +1,17 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "uroborosql-language-server",
+    version,
+    about = "Language server for SQL formatting and linting"
+)]
+struct Cli;
+
 #[cfg(feature = "runtime-tokio")]
 #[tokio::main]
 async fn main() {
+    let _ = Cli::parse();
     uroborosql_language_server::run_stdio().await;
 }
 

--- a/crates/uroborosql-lint-cli/Cargo.toml
+++ b/crates/uroborosql-lint-cli/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[[bin]]
+name = "uroborosql-lint"
+path = "src/main.rs"
+
 [dependencies]
 clap = { workspace = true }
 uroborosql-lint = { path = "../uroborosql-lint" }

--- a/crates/uroborosql-lint-cli/Cargo.toml
+++ b/crates/uroborosql-lint-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uroborosql-lint-cli"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/uroborosql-lint-cli/src/main.rs
+++ b/crates/uroborosql-lint-cli/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use uroborosql_lint::{ConfigStore, Diagnostic, LintError, Linter, Severity};
 
 #[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
+#[command(name = "uroborosql-lint", version, about = "SQL linter")]
 struct Cli {
     /// Input SQL file
     pub input: PathBuf,

--- a/crates/uroborosql-lint/Cargo.toml
+++ b/crates/uroborosql-lint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uroborosql-lint"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -1,5 +1,20 @@
 # uroborosql-lint
 
+The CLI binary name is `uroborosql-lint`.
+
+## Usage
+
+```bash
+uroborosql-lint [OPTIONS] <INPUT>
+```
+
+Examples:
+
+```bash
+uroborosql-lint query.sql
+uroborosql-lint --config .uroborosqllintrc.json query.sql
+```
+
 ## Configuration
 
 The default config file name is `.uroborosqllintrc.json`.


### PR DESCRIPTION
## Summary

- lint CLI のコマンド名を、既存の formatter CLI と同じ命名に変更（`uroborosql-lint`）
- language server CLI で `--help` / `--version` オプションに対応
- formatter / linter / language server の help 文言を利用者向けに統一
- `release-plz` の想定に合わせて、linter / language server 系クレートの version 定義を workspace 継承に統一

## Changes

### 1. CLI 名の明示

変更前:
-  lint CLI は package 名のデフォルトに依存していた

変更後:
- lint CLI は、既存の formatter CLI (`uroborosql-fmt`) と同じ流儀に合わせ bin 名を `uroborosql-lint` として明示
- language server はパッケージ名との乖離はないものの、`uroborosql-language-server` として明示

### 2. help / version の挙動統一

変更前:
- formatter / linter / language server で help の見え方が揃っていなかった
    - language server CLI は `--help` / `--version` を返せなかった
    - formatter CLI の help 冒頭には Cargo package description (`Crate to run ...`) がそのまま出ていた

変更後:
- `uroborosql-language-server` CLI に最小の引数解析を追加し、`--help` / `--version` を返せるように修正
- help の説明文を以下のように統一
  - `uroborosql-fmt`: `SQL formatter`
  - `uroborosql-lint`: `SQL linter`
  - `uroborosql-language-server`: `Language server for SQL formatting and linting`

### 3. バージョン参照元の統一

変更前:
- `feat/linter` で追加される 3 クレートだけ `0.1.0` の個別 version のままだった

変更後:
- `uroborosql-lint`, `uroborosql-lint-cli`, `uroborosql-language-server` の version 定義をまとめて `version.workspace = true` に統一
