### PR TITLE
feat: code actions for lint directives

### DIFF
--- a/crates/uroborosql-language-server/src/code_action.rs
+++ b/crates/uroborosql-language-server/src/code_action.rs
@@ -1,0 +1,61 @@
+use std::collections::{HashMap, HashSet};
+
+use tower_lsp_server::lsp_types::{
+    CodeActionContext, CodeActionKind, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
+    TextEdit, Uri, WorkspaceEdit,
+};
+use uroborosql_lint::{INVALID_LINT_DIRECTIVE_CODE, LINT_SOURCE};
+
+use crate::Backend;
+
+mod directive_line;
+mod disable_next_line;
+mod remove_unknown_rule;
+
+pub(crate) fn code_actions(
+    backend: &Backend,
+    params: CodeActionParams,
+) -> Option<CodeActionResponse> {
+    if !allows_quickfix(&params.context) {
+        return Some(vec![]);
+    }
+
+    let uri = params.text_document.uri;
+    let Some(rope) = backend.document_rope(&uri) else {
+        return Some(vec![]);
+    };
+
+    let mut actions = Vec::new();
+    let mut disable_next_line_seen = HashSet::new();
+
+    for diagnostic in params.context.diagnostics {
+        if let Some(action) = disable_next_line::disable_next_line_action(
+            &uri,
+            &rope,
+            &diagnostic,
+            &mut disable_next_line_seen,
+        ) {
+            actions.push(CodeActionOrCommand::CodeAction(action));
+            continue;
+        }
+
+        if let Some(action) =
+            remove_unknown_rule::remove_unknown_rule_action(&uri, &rope, &diagnostic)
+        {
+            actions.push(CodeActionOrCommand::CodeAction(action));
+        }
+    }
+
+    Some(actions)
+}
+
+fn allows_quickfix(context: &CodeActionContext) -> bool {
+    context.only.as_ref().is_none_or(|only| {
+        only.iter()
+            .any(|kind| kind.as_str() == CodeActionKind::QUICKFIX.as_str())
+    })
+}
+
+fn workspace_edit(uri: &Uri, edit: TextEdit) -> WorkspaceEdit {
+    WorkspaceEdit::new(HashMap::from([(uri.clone(), vec![edit])]))
+}

--- a/crates/uroborosql-language-server/src/code_action/directive_line.rs
+++ b/crates/uroborosql-language-server/src/code_action/directive_line.rs
@@ -17,16 +17,3 @@ pub(in crate::code_action) fn add_offset(
 ) -> std::ops::Range<usize> {
     range.start + offset..range.end + offset
 }
-
-pub(in crate::code_action) fn removal_span_with_offset(
-    line_text: &str,
-    directive_text: &str,
-    removal_span: std::ops::Range<usize>,
-    offset: usize,
-) -> std::ops::Range<usize> {
-    if removal_span.start == 0 && removal_span.end == directive_text.len() {
-        0..line_text.len()
-    } else {
-        add_offset(removal_span, offset)
-    }
-}

--- a/crates/uroborosql-language-server/src/code_action/directive_line.rs
+++ b/crates/uroborosql-language-server/src/code_action/directive_line.rs
@@ -1,0 +1,32 @@
+pub(in crate::code_action) fn leading_whitespace(text: &str) -> &str {
+    let end = text
+        .char_indices()
+        .find_map(|(idx, ch)| (!matches!(ch, ' ' | '\t')).then_some(idx))
+        .unwrap_or(text.len());
+    &text[..end]
+}
+
+pub(in crate::code_action) fn directive_text_with_offset(line_text: &str) -> (&str, usize) {
+    let offset = leading_whitespace(line_text).len();
+    (&line_text[offset..], offset)
+}
+
+pub(in crate::code_action) fn add_offset(
+    range: std::ops::Range<usize>,
+    offset: usize,
+) -> std::ops::Range<usize> {
+    range.start + offset..range.end + offset
+}
+
+pub(in crate::code_action) fn removal_span_with_offset(
+    line_text: &str,
+    directive_text: &str,
+    removal_span: std::ops::Range<usize>,
+    offset: usize,
+) -> std::ops::Range<usize> {
+    if removal_span.start == 0 && removal_span.end == directive_text.len() {
+        0..line_text.len()
+    } else {
+        add_offset(removal_span, offset)
+    }
+}

--- a/crates/uroborosql-language-server/src/code_action/disable_next_line.rs
+++ b/crates/uroborosql-language-server/src/code_action/disable_next_line.rs
@@ -6,8 +6,8 @@ use tower_lsp_server::lsp_types::{
     WorkspaceEdit,
 };
 use uroborosql_lint::{
-    DISABLE_NEXT_LINE_DIRECTIVE_KEYWORD, ParsedLineLintDirective, ParsedLintDirectiveKind,
-    RuleEnum, parse_line_comment_directive,
+    DISABLE_NEXT_LINE_DIRECTIVE_KEYWORD, ParsedLineComment, ParsedLintDirectiveKind, RuleEnum,
+    parse_line_comment_directive,
 };
 
 use super::{INVALID_LINT_DIRECTIVE_CODE, LINT_SOURCE, directive_line, workspace_edit};
@@ -88,7 +88,7 @@ fn find_existing_disable_next_line_directive(
     let line_text = rope_line_text_without_ending(rope, directive_line)?;
     let (directive_text, directive_offset) = directive_line::directive_text_with_offset(&line_text);
     match parse_line_comment_directive(directive_text) {
-        ParsedLineLintDirective::Directive {
+        ParsedLineComment::LintDirective {
             kind: ParsedLintDirectiveKind::DisableNextLine,
             rules,
             append_byte,
@@ -110,11 +110,11 @@ fn find_existing_disable_next_line_directive(
             )?;
             Some(ExistingDisableNextLineDirective::Append(position))
         }
-        ParsedLineLintDirective::Directive {
+        ParsedLineComment::LintDirective {
             kind: ParsedLintDirectiveKind::Disable,
             ..
         }
-        | ParsedLineLintDirective::NotDirective => {
+        | ParsedLineComment::NotLintDirective => {
             Some(ExistingDisableNextLineDirective::NotDirective)
         }
     }

--- a/crates/uroborosql-language-server/src/code_action/disable_next_line.rs
+++ b/crates/uroborosql-language-server/src/code_action/disable_next_line.rs
@@ -1,0 +1,288 @@
+use std::collections::HashSet;
+
+use ropey::Rope;
+use tower_lsp_server::lsp_types::{
+    CodeAction, CodeActionKind, Diagnostic, NumberOrString, Position, Range, TextEdit, Uri,
+    WorkspaceEdit,
+};
+use uroborosql_lint::{
+    DISABLE_NEXT_LINE_DIRECTIVE_KEYWORD, ParsedLineLintDirective, ParsedLintDirectiveKind,
+    RuleEnum, parse_line_comment_directive,
+};
+
+use super::{INVALID_LINT_DIRECTIVE_CODE, LINT_SOURCE, directive_line, workspace_edit};
+use crate::document::{
+    rope_line_byte_to_position, rope_line_exists, rope_line_text_without_ending,
+};
+
+pub(in crate::code_action) fn disable_next_line_action(
+    uri: &Uri,
+    rope: &Rope,
+    diagnostic: &Diagnostic,
+    seen: &mut HashSet<(u32, String)>,
+) -> Option<CodeAction> {
+    if diagnostic.source.as_deref() != Some(LINT_SOURCE) {
+        return None;
+    }
+
+    let rule_name = match diagnostic.code.as_ref()? {
+        NumberOrString::String(rule) if rule != INVALID_LINT_DIRECTIVE_CODE => rule,
+        _ => return None,
+    };
+    let _ = RuleEnum::from_name(rule_name)?;
+
+    let target_line = diagnostic.range.start.line;
+    if !rope_line_exists(rope, target_line) || !seen.insert((target_line, rule_name.clone())) {
+        return None;
+    }
+
+    let edit = build_disable_next_line_directive_edit(uri, rope, target_line, rule_name)?;
+
+    Some(CodeAction {
+        title: format!("Disable {rule_name} for next line"),
+        kind: Some(CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diagnostic.clone()]),
+        edit: Some(edit),
+        ..CodeAction::default()
+    })
+}
+
+fn build_disable_next_line_directive_edit(
+    uri: &Uri,
+    rope: &Rope,
+    target_line: u32,
+    rule: &str,
+) -> Option<WorkspaceEdit> {
+    if target_line == 0 {
+        return build_insert_disable_next_line_directive_edit(uri, rope, target_line, rule);
+    }
+
+    match find_existing_disable_next_line_directive(rope, target_line - 1, rule)? {
+        ExistingDisableNextLineDirective::Append(position) => Some(workspace_edit(
+            uri,
+            TextEdit {
+                range: Range::new(position, position),
+                new_text: format!(", {rule}"),
+            },
+        )),
+        ExistingDisableNextLineDirective::AlreadyContains
+        | ExistingDisableNextLineDirective::Blocked => None,
+        ExistingDisableNextLineDirective::NotDirective => {
+            build_insert_disable_next_line_directive_edit(uri, rope, target_line, rule)
+        }
+    }
+}
+
+enum ExistingDisableNextLineDirective {
+    Append(Position),
+    AlreadyContains,
+    Blocked,
+    NotDirective,
+}
+
+fn find_existing_disable_next_line_directive(
+    rope: &Rope,
+    directive_line: u32,
+    rule: &str,
+) -> Option<ExistingDisableNextLineDirective> {
+    let line_text = rope_line_text_without_ending(rope, directive_line)?;
+    let (directive_text, directive_offset) = directive_line::directive_text_with_offset(&line_text);
+    match parse_line_comment_directive(directive_text) {
+        ParsedLineLintDirective::Directive {
+            kind: ParsedLintDirectiveKind::DisableNextLine,
+            rules,
+            append_byte,
+            has_syntax_error,
+            ..
+        } => {
+            if rules.iter().any(|existing| existing == rule) {
+                return Some(ExistingDisableNextLineDirective::AlreadyContains);
+            }
+            if has_syntax_error {
+                return Some(ExistingDisableNextLineDirective::Blocked);
+            }
+            let append_byte = append_byte?;
+            let position = rope_line_byte_to_position(
+                rope,
+                directive_line,
+                &line_text,
+                directive_offset + append_byte,
+            )?;
+            Some(ExistingDisableNextLineDirective::Append(position))
+        }
+        ParsedLineLintDirective::Directive {
+            kind: ParsedLintDirectiveKind::Disable,
+            ..
+        }
+        | ParsedLineLintDirective::NotDirective => {
+            Some(ExistingDisableNextLineDirective::NotDirective)
+        }
+    }
+}
+
+fn build_insert_disable_next_line_directive_edit(
+    uri: &Uri,
+    rope: &Rope,
+    target_line: u32,
+    rule: &str,
+) -> Option<WorkspaceEdit> {
+    let line_text = rope_line_text_without_ending(rope, target_line)?;
+    let indent = directive_line::leading_whitespace(&line_text);
+    let line_ending = detect_line_ending(rope, target_line);
+    let position = Position::new(target_line, 0);
+    Some(workspace_edit(
+        uri,
+        TextEdit {
+            range: Range::new(position, position),
+            new_text: format!(
+                "{indent}-- {DISABLE_NEXT_LINE_DIRECTIVE_KEYWORD} {rule}{line_ending}"
+            ),
+        },
+    ))
+}
+
+fn detect_line_ending(rope: &Rope, target_line: u32) -> &'static str {
+    if let Some(line_ending) = line_ending_at(rope, target_line) {
+        return line_ending;
+    }
+
+    (0..rope.len_lines())
+        .find_map(|line| line_ending_at(rope, line as u32))
+        .unwrap_or("\n")
+}
+
+fn line_ending_at(rope: &Rope, line: u32) -> Option<&'static str> {
+    if !rope_line_exists(rope, line) {
+        return None;
+    }
+
+    let line_text = rope.line(line as usize).to_string();
+    if line_text.ends_with("\r\n") {
+        Some("\r\n")
+    } else if line_text.ends_with('\n') {
+        Some("\n")
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rope(text: &str) -> Rope {
+        Rope::from_str(text)
+    }
+
+    fn test_uri() -> Uri {
+        "file:///test.sql".parse().unwrap()
+    }
+
+    fn only_edit(edit: WorkspaceEdit) -> TextEdit {
+        edit.changes
+            .unwrap()
+            .into_values()
+            .next()
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+    }
+
+    #[test]
+    fn build_insert_disable_next_line_directive_edit_preserves_indentation() {
+        let edit = only_edit(
+            build_insert_disable_next_line_directive_edit(
+                &test_uri(),
+                &rope("    SELECT DISTINCT id FROM users;\n"),
+                0,
+                "no-distinct",
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(
+            edit.range,
+            Range::new(Position::new(0, 0), Position::new(0, 0))
+        );
+        assert_eq!(
+            edit.new_text,
+            "    -- uroborosql-lint-disable-next-line no-distinct\n"
+        );
+    }
+
+    #[test]
+    fn build_insert_disable_next_line_directive_edit_preserves_crlf() {
+        let edit = only_edit(
+            build_insert_disable_next_line_directive_edit(
+                &test_uri(),
+                &rope("SELECT DISTINCT id FROM users;\r\n"),
+                0,
+                "no-distinct",
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(
+            edit.new_text,
+            "-- uroborosql-lint-disable-next-line no-distinct\r\n"
+        );
+    }
+
+    #[test]
+    fn build_insert_disable_next_line_directive_edit_uses_target_line_ending_in_mixed_file() {
+        let edit = only_edit(
+            build_insert_disable_next_line_directive_edit(
+                &test_uri(),
+                &rope("SELECT 1;\r\nSELECT DISTINCT id FROM users;\n"),
+                1,
+                "no-distinct",
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(
+            edit.new_text,
+            "-- uroborosql-lint-disable-next-line no-distinct\n"
+        );
+    }
+
+    #[test]
+    fn find_existing_disable_next_line_directive_appends_at_line_end() {
+        let rope = rope("-- uroborosql-lint-disable-next-line no-distinct\nSELECT * FROM users;\n");
+        let result =
+            find_existing_disable_next_line_directive(&rope, 0, "no-wildcard-projection").unwrap();
+
+        assert!(matches!(
+            result,
+            ExistingDisableNextLineDirective::Append(Position {
+                line: 0,
+                character: 48,
+            })
+        ));
+    }
+
+    #[test]
+    fn find_existing_disable_next_line_directive_blocks_duplicate_rule() {
+        let rope = rope(
+            "-- uroborosql-lint-disable-next-line no-distinct\nSELECT DISTINCT id FROM users;\n",
+        );
+        let result = find_existing_disable_next_line_directive(&rope, 0, "no-distinct").unwrap();
+
+        assert!(matches!(
+            result,
+            ExistingDisableNextLineDirective::AlreadyContains
+        ));
+    }
+
+    #[test]
+    fn find_existing_disable_next_line_directive_blocks_syntax_error() {
+        let rope = rope(
+            "-- uroborosql-lint-disable-next-line no-distinct,\nSELECT DISTINCT id FROM users;\n",
+        );
+        let result =
+            find_existing_disable_next_line_directive(&rope, 0, "no-wildcard-projection").unwrap();
+
+        assert!(matches!(result, ExistingDisableNextLineDirective::Blocked));
+    }
+}

--- a/crates/uroborosql-language-server/src/code_action/remove_unknown_rule.rs
+++ b/crates/uroborosql-language-server/src/code_action/remove_unknown_rule.rs
@@ -1,0 +1,118 @@
+use ropey::Rope;
+use tower_lsp_server::lsp_types::{
+    CodeAction, CodeActionKind, Diagnostic, NumberOrString, Position, Range, TextEdit, Uri,
+};
+use uroborosql_lint::{
+    DirectiveParseDiagnosticKind, ParsedLineLintDirective, parse_line_comment_directive,
+};
+
+use super::{INVALID_LINT_DIRECTIVE_CODE, LINT_SOURCE, directive_line, workspace_edit};
+use crate::document::{
+    rope_line_byte_range_to_range, rope_line_has_ending, rope_line_text_without_ending,
+};
+
+pub(in crate::code_action) fn remove_unknown_rule_action(
+    uri: &Uri,
+    rope: &Rope,
+    diagnostic: &Diagnostic,
+) -> Option<CodeAction> {
+    if diagnostic.source.as_deref() != Some(LINT_SOURCE) {
+        return None;
+    }
+    if !matches!(
+        diagnostic.code.as_ref(),
+        Some(NumberOrString::String(code)) if code == INVALID_LINT_DIRECTIVE_CODE
+    ) {
+        return None;
+    }
+
+    let diagnostic_line = diagnostic.range.start.line;
+    let line_text = rope_line_text_without_ending(rope, diagnostic_line)?;
+    let (directive_text, directive_offset) = directive_line::directive_text_with_offset(&line_text);
+    let ParsedLineLintDirective::Directive { diagnostics, .. } =
+        parse_line_comment_directive(directive_text)
+    else {
+        return None;
+    };
+
+    for parse_diagnostic in diagnostics {
+        let DirectiveParseDiagnosticKind::UnknownRule { removal_span, .. } = parse_diagnostic.kind
+        else {
+            continue;
+        };
+        let span_range = rope_line_byte_range_to_range(
+            rope,
+            diagnostic_line,
+            &line_text,
+            directive_line::add_offset(parse_diagnostic.span, directive_offset),
+        )?;
+        if span_range != diagnostic.range {
+            continue;
+        }
+
+        let removal_span = directive_line::removal_span_with_offset(
+            &line_text,
+            directive_text,
+            removal_span,
+            directive_offset,
+        );
+        let edit_range =
+            removal_range_to_lsp_range(rope, diagnostic_line, &line_text, removal_span)?;
+        return Some(CodeAction {
+            title: "Remove unknown lint rule".into(),
+            kind: Some(CodeActionKind::QUICKFIX),
+            diagnostics: Some(vec![diagnostic.clone()]),
+            edit: Some(workspace_edit(
+                uri,
+                TextEdit {
+                    range: edit_range,
+                    new_text: String::new(),
+                },
+            )),
+            ..CodeAction::default()
+        });
+    }
+
+    None
+}
+
+fn removal_range_to_lsp_range(
+    rope: &Rope,
+    line: u32,
+    line_text: &str,
+    removal_span: std::ops::Range<usize>,
+) -> Option<Range> {
+    if removal_span.start == 0
+        && removal_span.end == line_text.len()
+        && rope_line_has_ending(rope, line)
+    {
+        return Some(Range::new(
+            Position::new(line, 0),
+            Position::new(line + 1, 0),
+        ));
+    }
+    rope_line_byte_range_to_range(rope, line, line_text, removal_span)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rope(text: &str) -> Rope {
+        Rope::from_str(text)
+    }
+
+    #[test]
+    fn remove_unknown_rule_whole_line_includes_line_ending() {
+        let rope = rope("-- uroborosql-lint-disable-next-line definitely-not-a-rule\nSELECT 1;\n");
+        let range = removal_range_to_lsp_range(
+            &rope,
+            0,
+            "-- uroborosql-lint-disable-next-line definitely-not-a-rule",
+            0..58,
+        )
+        .unwrap();
+
+        assert_eq!(range, Range::new(Position::new(0, 0), Position::new(1, 0)));
+    }
+}

--- a/crates/uroborosql-language-server/src/code_action/remove_unknown_rule.rs
+++ b/crates/uroborosql-language-server/src/code_action/remove_unknown_rule.rs
@@ -3,7 +3,8 @@ use tower_lsp_server::lsp_types::{
     CodeAction, CodeActionKind, Diagnostic, NumberOrString, Position, Range, TextEdit, Uri,
 };
 use uroborosql_lint::{
-    DirectiveParseDiagnosticKind, ParsedLineComment, parse_line_comment_directive,
+    DirectiveParseDiagnosticKind, ParsedLineComment, UnknownRuleRemovalRange,
+    parse_line_comment_directive,
 };
 
 use super::{INVALID_LINT_DIRECTIVE_CODE, LINT_SOURCE, directive_line, workspace_edit};
@@ -36,7 +37,7 @@ pub(in crate::code_action) fn remove_unknown_rule_action(
     };
 
     for parse_diagnostic in diagnostics {
-        let DirectiveParseDiagnosticKind::UnknownRule { removal_span, .. } = parse_diagnostic.kind
+        let DirectiveParseDiagnosticKind::UnknownRule { removal_range, .. } = parse_diagnostic.kind
         else {
             continue;
         };
@@ -50,14 +51,9 @@ pub(in crate::code_action) fn remove_unknown_rule_action(
             continue;
         }
 
-        let removal_span = directive_line::removal_span_with_offset(
-            &line_text,
-            directive_text,
-            removal_span,
-            directive_offset,
-        );
+        let removal_range = line_removal_range_with_offset(removal_range, directive_offset);
         let edit_range =
-            removal_range_to_lsp_range(rope, diagnostic_line, &line_text, removal_span)?;
+            removal_range_to_lsp_range(rope, diagnostic_line, &line_text, removal_range)?;
         return Some(CodeAction {
             title: "Remove unknown lint rule".into(),
             kind: Some(CodeActionKind::QUICKFIX),
@@ -76,22 +72,36 @@ pub(in crate::code_action) fn remove_unknown_rule_action(
     None
 }
 
+fn line_removal_range_with_offset(
+    removal_range: UnknownRuleRemovalRange,
+    directive_offset: usize,
+) -> UnknownRuleRemovalRange {
+    match removal_range {
+        UnknownRuleRemovalRange::FullLine => UnknownRuleRemovalRange::FullLine,
+        UnknownRuleRemovalRange::PartialLine(range) => UnknownRuleRemovalRange::PartialLine(
+            directive_line::add_offset(range, directive_offset),
+        ),
+    }
+}
+
 fn removal_range_to_lsp_range(
     rope: &Rope,
     line: u32,
     line_text: &str,
-    removal_span: std::ops::Range<usize>,
+    removal_range: UnknownRuleRemovalRange,
 ) -> Option<Range> {
-    if removal_span.start == 0
-        && removal_span.end == line_text.len()
-        && rope_line_has_ending(rope, line)
-    {
-        return Some(Range::new(
+    match removal_range {
+        UnknownRuleRemovalRange::FullLine if rope_line_has_ending(rope, line) => Some(Range::new(
             Position::new(line, 0),
             Position::new(line + 1, 0),
-        ));
+        )),
+        UnknownRuleRemovalRange::FullLine => {
+            rope_line_byte_range_to_range(rope, line, line_text, 0..line_text.len())
+        }
+        UnknownRuleRemovalRange::PartialLine(range) => {
+            rope_line_byte_range_to_range(rope, line, line_text, range)
+        }
     }
-    rope_line_byte_range_to_range(rope, line, line_text, removal_span)
 }
 
 #[cfg(test)]
@@ -109,7 +119,7 @@ mod tests {
             &rope,
             0,
             "-- uroborosql-lint-disable-next-line definitely-not-a-rule",
-            0..58,
+            UnknownRuleRemovalRange::FullLine,
         )
         .unwrap();
 

--- a/crates/uroborosql-language-server/src/code_action/remove_unknown_rule.rs
+++ b/crates/uroborosql-language-server/src/code_action/remove_unknown_rule.rs
@@ -3,7 +3,7 @@ use tower_lsp_server::lsp_types::{
     CodeAction, CodeActionKind, Diagnostic, NumberOrString, Position, Range, TextEdit, Uri,
 };
 use uroborosql_lint::{
-    DirectiveParseDiagnosticKind, ParsedLineLintDirective, parse_line_comment_directive,
+    DirectiveParseDiagnosticKind, ParsedLineComment, parse_line_comment_directive,
 };
 
 use super::{INVALID_LINT_DIRECTIVE_CODE, LINT_SOURCE, directive_line, workspace_edit};
@@ -29,7 +29,7 @@ pub(in crate::code_action) fn remove_unknown_rule_action(
     let diagnostic_line = diagnostic.range.start.line;
     let line_text = rope_line_text_without_ending(rope, diagnostic_line)?;
     let (directive_text, directive_offset) = directive_line::directive_text_with_offset(&line_text);
-    let ParsedLineLintDirective::Directive { diagnostics, .. } =
+    let ParsedLineComment::LintDirective { diagnostics, .. } =
         parse_line_comment_directive(directive_text)
     else {
         return None;

--- a/crates/uroborosql-language-server/src/document.rs
+++ b/crates/uroborosql-language-server/src/document.rs
@@ -44,6 +44,54 @@ pub(crate) fn rope_range_to_char_index_range(rope: &Rope, range: &Range) -> Opti
     Some((start, end))
 }
 
+pub(crate) fn rope_line_exists(rope: &Rope, line: u32) -> bool {
+    (line as usize) < rope.len_lines()
+}
+
+pub(crate) fn rope_line_text_without_ending(rope: &Rope, line: u32) -> Option<String> {
+    if !rope_line_exists(rope, line) {
+        return None;
+    }
+    let mut text = rope.line(line as usize).to_string();
+    if text.ends_with('\n') {
+        text.pop();
+        if text.ends_with('\r') {
+            text.pop();
+        }
+    }
+    Some(text)
+}
+
+pub(crate) fn rope_line_has_ending(rope: &Rope, line: u32) -> bool {
+    rope_line_exists(rope, line) && rope.line(line as usize).to_string().ends_with('\n')
+}
+
+pub(crate) fn rope_line_byte_to_position(
+    rope: &Rope,
+    line: u32,
+    line_text: &str,
+    byte: usize,
+) -> Option<Position> {
+    if !line_text.is_char_boundary(byte) {
+        return None;
+    }
+    let line_start = rope.line_to_char(line as usize);
+    let char_offset = line_text[..byte].chars().count();
+    Some(rope_char_index_to_position(rope, line_start + char_offset))
+}
+
+pub(crate) fn rope_line_byte_range_to_range(
+    rope: &Rope,
+    line: u32,
+    line_text: &str,
+    range: std::ops::Range<usize>,
+) -> Option<Range> {
+    Some(Range::new(
+        rope_line_byte_to_position(rope, line, line_text, range.start)?,
+        rope_line_byte_to_position(rope, line, line_text, range.end)?,
+    ))
+}
+
 impl Backend {
     pub(crate) fn upsert_document(&self, uri: &Uri, text: &str, version: Option<i32>) {
         let version = version
@@ -118,5 +166,44 @@ impl Backend {
                     .collect()
             })
             .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rope(text: &str) -> Rope {
+        Rope::from_str(text)
+    }
+
+    #[test]
+    fn rope_line_text_without_ending_strips_lf_and_crlf() {
+        let rope = rope("first\r\nsecond\nthird");
+
+        assert_eq!(
+            rope_line_text_without_ending(&rope, 0).as_deref(),
+            Some("first")
+        );
+        assert_eq!(
+            rope_line_text_without_ending(&rope, 1).as_deref(),
+            Some("second")
+        );
+        assert_eq!(
+            rope_line_text_without_ending(&rope, 2).as_deref(),
+            Some("third")
+        );
+    }
+
+    #[test]
+    fn rope_line_byte_to_position_returns_utf16_position() {
+        let rope = rope("😀 SELECT\n");
+        let line_text = rope_line_text_without_ending(&rope, 0).unwrap();
+        let byte_after_emoji = "😀".len();
+
+        assert_eq!(
+            rope_line_byte_to_position(&rope, 0, &line_text, byte_after_emoji),
+            Some(Position::new(0, 2))
+        );
     }
 }

--- a/crates/uroborosql-language-server/src/lib.rs
+++ b/crates/uroborosql-language-server/src/lib.rs
@@ -1,3 +1,4 @@
+mod code_action;
 mod configuration;
 mod document;
 mod formatting;

--- a/crates/uroborosql-language-server/src/lint.rs
+++ b/crates/uroborosql-language-server/src/lint.rs
@@ -4,7 +4,8 @@ use tower_lsp_server::lsp_types::{
     Diagnostic, DiagnosticSeverity, MessageType, NumberOrString, Position, Range, Uri,
 };
 use uroborosql_lint::{
-    DEFAULT_CONFIG_FILENAME, Diagnostic as SqlDiagnostic, LintError, Severity as SqlSeverity,
+    DEFAULT_CONFIG_FILENAME, Diagnostic as SqlDiagnostic, LINT_SOURCE, LintError,
+    Severity as SqlSeverity,
 };
 
 use crate::Backend;
@@ -97,7 +98,7 @@ fn to_lsp_diagnostic(diag: SqlDiagnostic, rope: Option<&ropey::Rope>) -> Diagnos
         range,
         severity,
         code: Some(NumberOrString::String(diag.code.to_string())),
-        source: Some("uroborosql-lint".into()),
+        source: Some(LINT_SOURCE.into()),
         message: diag.message,
         ..Diagnostic::default()
     }
@@ -111,7 +112,7 @@ fn to_parse_error(err: LintError) -> Diagnostic {
     Diagnostic {
         range: Range::default(),
         severity: Some(DiagnosticSeverity::ERROR),
-        source: Some("uroborosql-lint".into()),
+        source: Some(LINT_SOURCE.into()),
         message,
         ..Diagnostic::default()
     }

--- a/crates/uroborosql-language-server/src/server.rs
+++ b/crates/uroborosql-language-server/src/server.rs
@@ -55,6 +55,12 @@ impl LanguageServer for Backend {
                 text_document_sync: Some(TextDocumentSyncCapability::Options(sync_options)),
                 document_formatting_provider: Some(OneOf::Left(true)),
                 document_range_formatting_provider: Some(OneOf::Left(true)),
+                code_action_provider: Some(CodeActionProviderCapability::Options(
+                    CodeActionOptions {
+                        code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
+                        ..CodeActionOptions::default()
+                    },
+                )),
                 ..ServerCapabilities::default()
             },
             server_info: Some(ServerInfo {
@@ -139,8 +145,8 @@ impl LanguageServer for Backend {
         }
     }
 
-    async fn code_action(&self, _: CodeActionParams) -> Result<Option<CodeActionResponse>> {
-        Ok(None)
+    async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
+        Ok(crate::code_action::code_actions(self, params))
     }
 
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {

--- a/crates/uroborosql-language-server/tests/code_action.rs
+++ b/crates/uroborosql-language-server/tests/code_action.rs
@@ -1,0 +1,258 @@
+mod test_harness;
+
+use std::str::FromStr;
+
+use serde_json::Value;
+use tower_lsp_server::lsp_types::notification::{Notification, PublishDiagnostics};
+use tower_lsp_server::lsp_types::*;
+
+use test_harness::*;
+
+#[tokio::test]
+async fn initialize_declares_quickfix_code_action_provider() {
+    let mut server = new_test_server();
+
+    server.send_request(build_initialize(1)).await;
+    let response = server.receive_response().await;
+    let provider = &response.result().unwrap()["capabilities"]["codeActionProvider"];
+
+    assert_eq!(provider["codeActionKinds"][0].as_str(), Some("quickfix"));
+}
+
+#[tokio::test]
+async fn lint_diagnostic_returns_disable_next_line_quickfix() {
+    let mut server = new_test_server();
+    let uri = Uri::from_str("file:///code-action.sql").unwrap();
+
+    initialize_server(&mut server).await;
+    server
+        .send_request(build_did_open(
+            &uri,
+            "    SELECT DISTINCT id FROM users;\n",
+            1,
+        ))
+        .await;
+    let diagnostics = receive_diagnostics(&mut server).await;
+    let diagnostic = diagnostic_with_code(&diagnostics, "no-distinct");
+
+    server
+        .send_request(build_code_action(
+            &uri,
+            diagnostic.range,
+            vec![diagnostic],
+            Some(vec![CodeActionKind::QUICKFIX]),
+            2,
+        ))
+        .await;
+    let actions = code_action_result(server.receive_response().await);
+
+    assert_eq!(actions.len(), 1);
+    assert_eq!(
+        actions[0]["title"].as_str(),
+        Some("Disable no-distinct for next line")
+    );
+    assert_eq!(actions[0]["kind"].as_str(), Some("quickfix"));
+    let edit = first_text_edit(&actions[0], &uri);
+    assert_eq!(
+        edit["newText"].as_str(),
+        Some("    -- uroborosql-lint-disable-next-line no-distinct\n")
+    );
+    assert_eq!(edit["range"]["start"]["line"].as_u64(), Some(0));
+    assert_eq!(edit["range"]["start"]["character"].as_u64(), Some(0));
+}
+
+#[tokio::test]
+async fn existing_disable_next_line_is_appended() {
+    let mut server = new_test_server();
+    let uri = Uri::from_str("file:///append.sql").unwrap();
+    let text = "-- uroborosql-lint-disable-next-line no-distinct\nSELECT DISTINCT * FROM users;\n";
+    let diagnostic = lint_diagnostic("no-wildcard-projection", 1, 16, 1, 17);
+
+    initialize_server(&mut server).await;
+    server.send_request(build_did_open(&uri, text, 1)).await;
+    let _ = server.receive_notification().await;
+
+    server
+        .send_request(build_code_action(
+            &uri,
+            diagnostic.range,
+            vec![diagnostic],
+            None,
+            2,
+        ))
+        .await;
+    let actions = code_action_result(server.receive_response().await);
+
+    assert_eq!(actions.len(), 1);
+    let edit = first_text_edit(&actions[0], &uri);
+    assert_eq!(edit["newText"].as_str(), Some(", no-wildcard-projection"));
+    assert_eq!(edit["range"]["start"]["line"].as_u64(), Some(0));
+    assert_eq!(edit["range"]["start"]["character"].as_u64(), Some(48));
+}
+
+#[tokio::test]
+async fn indented_existing_disable_next_line_is_appended() {
+    let mut server = new_test_server();
+    let uri = Uri::from_str("file:///append-indented.sql").unwrap();
+    let text =
+        "    -- uroborosql-lint-disable-next-line no-distinct\n    SELECT DISTINCT * FROM users;\n";
+    let diagnostic = lint_diagnostic("no-wildcard-projection", 1, 20, 1, 21);
+
+    initialize_server(&mut server).await;
+    server.send_request(build_did_open(&uri, text, 1)).await;
+    let _ = server.receive_notification().await;
+
+    server
+        .send_request(build_code_action(
+            &uri,
+            diagnostic.range,
+            vec![diagnostic],
+            None,
+            2,
+        ))
+        .await;
+    let actions = code_action_result(server.receive_response().await);
+
+    assert_eq!(actions.len(), 1);
+    let edit = first_text_edit(&actions[0], &uri);
+    assert_eq!(edit["newText"].as_str(), Some(", no-wildcard-projection"));
+    assert_eq!(edit["range"]["start"]["line"].as_u64(), Some(0));
+    assert_eq!(edit["range"]["start"]["character"].as_u64(), Some(52));
+}
+
+#[tokio::test]
+async fn unknown_rule_directive_returns_remove_quickfix() {
+    let mut server = new_test_server();
+    let uri = Uri::from_str("file:///unknown-rule.sql").unwrap();
+    let text = "-- uroborosql-lint-disable-next-line no-distinct, definitely-not-a-rule\nSELECT DISTINCT id FROM users;\n";
+
+    initialize_server(&mut server).await;
+    server.send_request(build_did_open(&uri, text, 1)).await;
+    let diagnostics = receive_diagnostics(&mut server).await;
+    let diagnostic = diagnostic_with_code(&diagnostics, "invalid-lint-directive");
+
+    server
+        .send_request(build_code_action(
+            &uri,
+            diagnostic.range,
+            vec![diagnostic],
+            None,
+            2,
+        ))
+        .await;
+    let actions = code_action_result(server.receive_response().await);
+
+    assert_eq!(actions.len(), 1);
+    assert_eq!(
+        actions[0]["title"].as_str(),
+        Some("Remove unknown lint rule")
+    );
+    let edit = first_text_edit(&actions[0], &uri);
+    assert_eq!(edit["newText"].as_str(), Some(""));
+    assert_eq!(edit["range"]["start"]["character"].as_u64(), Some(48));
+    assert_eq!(edit["range"]["end"]["character"].as_u64(), Some(71));
+}
+
+#[tokio::test]
+async fn indented_unknown_rule_directive_returns_remove_quickfix() {
+    let mut server = new_test_server();
+    let uri = Uri::from_str("file:///unknown-rule-indented.sql").unwrap();
+    let text = "    -- uroborosql-lint-disable-next-line no-distinct, definitely-not-a-rule\nSELECT DISTINCT id FROM users;\n";
+
+    initialize_server(&mut server).await;
+    server.send_request(build_did_open(&uri, text, 1)).await;
+    let diagnostics = receive_diagnostics(&mut server).await;
+    let diagnostic = diagnostic_with_code(&diagnostics, "invalid-lint-directive");
+
+    server
+        .send_request(build_code_action(
+            &uri,
+            diagnostic.range,
+            vec![diagnostic],
+            None,
+            2,
+        ))
+        .await;
+    let actions = code_action_result(server.receive_response().await);
+
+    assert_eq!(actions.len(), 1);
+    assert_eq!(
+        actions[0]["title"].as_str(),
+        Some("Remove unknown lint rule")
+    );
+    let edit = first_text_edit(&actions[0], &uri);
+    assert_eq!(edit["newText"].as_str(), Some(""));
+    assert_eq!(edit["range"]["start"]["character"].as_u64(), Some(52));
+    assert_eq!(edit["range"]["end"]["character"].as_u64(), Some(75));
+}
+
+#[tokio::test]
+async fn non_quickfix_only_returns_empty_actions() {
+    let mut server = new_test_server();
+    let uri = Uri::from_str("file:///only.sql").unwrap();
+    let diagnostic = lint_diagnostic("no-distinct", 0, 0, 0, 15);
+
+    initialize_server(&mut server).await;
+    server
+        .send_request(build_did_open(&uri, "SELECT DISTINCT id FROM users;\n", 1))
+        .await;
+    let _ = server.receive_notification().await;
+
+    server
+        .send_request(build_code_action(
+            &uri,
+            diagnostic.range,
+            vec![diagnostic],
+            Some(vec![CodeActionKind::REFACTOR]),
+            2,
+        ))
+        .await;
+    let actions = code_action_result(server.receive_response().await);
+
+    assert!(actions.is_empty());
+}
+
+async fn receive_diagnostics(server: &mut TestServer) -> Vec<Diagnostic> {
+    let notification = server.receive_notification().await;
+    assert_eq!(notification.method(), PublishDiagnostics::METHOD);
+    serde_json::from_value(notification.params().unwrap()["diagnostics"].clone()).unwrap()
+}
+
+fn diagnostic_with_code(diagnostics: &[Diagnostic], code: &str) -> Diagnostic {
+    diagnostics
+        .iter()
+        .find(|diagnostic| {
+            matches!(
+                diagnostic.code.as_ref(),
+                Some(NumberOrString::String(diagnostic_code)) if diagnostic_code == code
+            )
+        })
+        .cloned()
+        .expect("diagnostic with code")
+}
+
+fn lint_diagnostic(
+    code: &str,
+    start_line: u32,
+    start_char: u32,
+    end_line: u32,
+    end_char: u32,
+) -> Diagnostic {
+    Diagnostic {
+        range: Range::new(
+            Position::new(start_line, start_char),
+            Position::new(end_line, end_char),
+        ),
+        source: Some("uroborosql-lint".into()),
+        code: Some(NumberOrString::String(code.into())),
+        ..Diagnostic::default()
+    }
+}
+
+fn code_action_result(response: tower_lsp_server::jsonrpc::Response) -> Vec<Value> {
+    response.result().unwrap().as_array().unwrap().clone()
+}
+
+fn first_text_edit<'a>(action: &'a Value, uri: &Uri) -> &'a Value {
+    &action["edit"]["changes"][uri.to_string()][0]
+}

--- a/crates/uroborosql-language-server/tests/test_harness.rs
+++ b/crates/uroborosql-language-server/tests/test_harness.rs
@@ -14,8 +14,8 @@ use tower_lsp_server::lsp_types::notification::{
     DidOpenTextDocument, DidSaveTextDocument, Initialized, LogMessage, Notification,
 };
 use tower_lsp_server::lsp_types::request::{
-    Formatting, Initialize, RangeFormatting, RegisterCapability, Request as LspRequest,
-    WorkspaceConfiguration,
+    CodeActionRequest, Formatting, Initialize, RangeFormatting, RegisterCapability,
+    Request as LspRequest, WorkspaceConfiguration,
 };
 use tower_lsp_server::lsp_types::*;
 use tower_lsp_server::{Client, LanguageServer, LspService, Server};
@@ -364,6 +364,29 @@ pub(crate) fn build_range_formatting(uri: &Uri, range: Range, id: i64) -> Reques
                 ..FormattingOptions::default()
             },
             work_done_progress_params: WorkDoneProgressParams::default(),
+        }))
+        .id(id)
+        .finish()
+}
+
+pub(crate) fn build_code_action(
+    uri: &Uri,
+    range: Range,
+    diagnostics: Vec<Diagnostic>,
+    only: Option<Vec<CodeActionKind>>,
+    id: i64,
+) -> Request {
+    Request::build(CodeActionRequest::METHOD)
+        .params(json!(CodeActionParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            range,
+            context: CodeActionContext {
+                diagnostics,
+                only,
+                trigger_kind: None,
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
         }))
         .id(id)
         .finish()

--- a/crates/uroborosql-lint/src/directive.rs
+++ b/crates/uroborosql-lint/src/directive.rs
@@ -39,9 +39,9 @@ pub struct DirectiveParseDiagnostic {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ParsedLineLintDirective {
-    NotDirective,
-    Directive {
+pub enum ParsedLineComment {
+    NotLintDirective,
+    LintDirective {
         kind: ParsedLintDirectiveKind,
         rules: Vec<String>,
         diagnostics: Vec<DirectiveParseDiagnostic>,
@@ -136,8 +136,8 @@ fn parse_directive<'tree>(comment: &Node<'tree>) -> ParsedDirective {
     let line = comment.range().start_position.row;
 
     match parse_line_comment_directive(comment_text) {
-        ParsedLineLintDirective::NotDirective => ParsedDirective::NotDirective,
-        ParsedLineLintDirective::Directive {
+        ParsedLineComment::NotLintDirective => ParsedDirective::NotDirective,
+        ParsedLineComment::LintDirective {
             kind,
             rules,
             diagnostics,
@@ -174,9 +174,9 @@ fn parse_directive<'tree>(comment: &Node<'tree>) -> ParsedDirective {
     }
 }
 
-pub fn parse_line_comment_directive(text: &str) -> ParsedLineLintDirective {
+pub fn parse_line_comment_directive(text: &str) -> ParsedLineComment {
     let Some(body) = text.strip_prefix("--") else {
-        return ParsedLineLintDirective::NotDirective;
+        return ParsedLineComment::NotLintDirective;
     };
     let body = body.trim_start_matches([' ', '\t']);
     let body_offset = text.len() - body.len();
@@ -199,7 +199,7 @@ pub fn parse_line_comment_directive(text: &str) -> ParsedLineLintDirective {
         );
     }
 
-    ParsedLineLintDirective::NotDirective
+    ParsedLineComment::NotLintDirective
 }
 
 fn parse_line_rules(
@@ -207,7 +207,7 @@ fn parse_line_rules(
     kind: ParsedLintDirectiveKind,
     rest: &str,
     directive_offset: usize,
-) -> ParsedLineLintDirective {
+) -> ParsedLineComment {
     if rest.trim().is_empty() {
         return syntax_error_directive(
             kind,
@@ -218,7 +218,7 @@ fn parse_line_rules(
     }
 
     if !rest.starts_with(char::is_whitespace) {
-        return ParsedLineLintDirective::NotDirective;
+        return ParsedLineComment::NotLintDirective;
     }
 
     let rules_offset = directive_offset + (rest.len() - rest.trim_start().len());
@@ -268,7 +268,7 @@ fn parse_line_rules(
         }
     }
 
-    ParsedLineLintDirective::Directive {
+    ParsedLineComment::LintDirective {
         kind,
         rules,
         diagnostics,
@@ -328,8 +328,8 @@ fn syntax_error_directive(
     message: impl Into<String>,
     start_offset: usize,
     end_offset: usize,
-) -> ParsedLineLintDirective {
-    ParsedLineLintDirective::Directive {
+) -> ParsedLineComment {
+    ParsedLineComment::LintDirective {
         kind,
         rules: Vec::new(),
         diagnostics: vec![DirectiveParseDiagnostic {
@@ -445,7 +445,7 @@ mod tests {
 
         assert!(matches!(
             parsed,
-            ParsedLineLintDirective::Directive {
+            ParsedLineComment::LintDirective {
                 kind: ParsedLintDirectiveKind::Disable,
                 rules,
                 diagnostics,
@@ -470,7 +470,7 @@ mod tests {
 
         assert!(matches!(
             parsed,
-            ParsedLineLintDirective::Directive {
+            ParsedLineComment::LintDirective {
                 has_syntax_error: true,
                 append_byte: None,
                 diagnostics,

--- a/crates/uroborosql-lint/src/directive.rs
+++ b/crates/uroborosql-lint/src/directive.rs
@@ -25,11 +25,17 @@ pub enum ParsedLintDirectiveKind {
 pub enum DirectiveParseDiagnosticKind {
     UnknownRule {
         rule: String,
-        removal_span: std::ops::Range<usize>,
+        removal_range: UnknownRuleRemovalRange,
     },
     SyntaxError {
         message: String,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnknownRuleRemovalRange {
+    FullLine,
+    PartialLine(std::ops::Range<usize>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -251,12 +257,18 @@ fn parse_line_rules(
         if RuleEnum::from_name(name).is_none() {
             let start = rules_offset + segment.start + trimmed_start;
             let end = start + name.len();
-            let removal_span = unknown_rule_removal_span(text, rest, &segments, index);
+            let removal_range = unknown_rule_removal_range(rest, &segments, index);
             diagnostics.push(DirectiveParseDiagnostic {
                 kind: DirectiveParseDiagnosticKind::UnknownRule {
                     rule: name.to_string(),
-                    removal_span: removal_span.start + rules_offset
-                        ..removal_span.end + rules_offset,
+                    removal_range: match removal_range {
+                        UnknownRuleRemovalRange::FullLine => UnknownRuleRemovalRange::FullLine,
+                        UnknownRuleRemovalRange::PartialLine(range) => {
+                            UnknownRuleRemovalRange::PartialLine(
+                                range.start + rules_offset..range.end + rules_offset,
+                            )
+                        }
+                    },
                 },
                 span: start..end,
             });
@@ -297,14 +309,13 @@ fn split_rule_segments(rest: &str) -> Vec<RuleSegment> {
     segments
 }
 
-fn unknown_rule_removal_span(
-    text: &str,
+fn unknown_rule_removal_range(
     rest: &str,
     segments: &[RuleSegment],
     index: usize,
-) -> std::ops::Range<usize> {
+) -> UnknownRuleRemovalRange {
     if segments.len() == 1 {
-        return 0..text.len();
+        return UnknownRuleRemovalRange::FullLine;
     }
 
     let segment = &segments[index];
@@ -314,12 +325,14 @@ fn unknown_rule_removal_span(
         let next = &segments[index + 1];
         let next_raw = &rest[next.start..next.end];
         let next_trimmed_start = next_raw.len() - next_raw.trim_start_matches([' ', '\t']).len();
-        segment.start + trimmed_start..next.start + next_trimmed_start
+        UnknownRuleRemovalRange::PartialLine(
+            segment.start + trimmed_start..next.start + next_trimmed_start,
+        )
     } else {
         let previous = &segments[index - 1];
         let previous_raw = &rest[previous.start..previous.end];
         let previous_trimmed_end = previous_raw.trim_end_matches([' ', '\t']).len();
-        previous.start + previous_trimmed_end..segment.end
+        UnknownRuleRemovalRange::PartialLine(previous.start + previous_trimmed_end..segment.end)
     }
 }
 
@@ -455,10 +468,11 @@ mod tests {
                 && matches!(
                     &diagnostics[..],
                     [DirectiveParseDiagnostic {
-                        kind: DirectiveParseDiagnosticKind::UnknownRule { rule, removal_span },
+                        kind: DirectiveParseDiagnosticKind::UnknownRule { rule, removal_range },
                         span,
                     }] if rule == "clearly-not-a-rule"
-                        && removal_span == &(38..58)
+                        && removal_range
+                            == &UnknownRuleRemovalRange::PartialLine(38..58)
                         && span == &(40..58)
                 )
         ));

--- a/crates/uroborosql-lint/src/directive.rs
+++ b/crates/uroborosql-lint/src/directive.rs
@@ -10,7 +10,45 @@ use crate::{
     rules::RuleEnum,
 };
 
-const INVALID_LINT_DIRECTIVE_CODE: &str = "invalid-lint-directive";
+pub const LINT_SOURCE: &str = "uroborosql-lint";
+pub const INVALID_LINT_DIRECTIVE_CODE: &str = "invalid-lint-directive";
+pub const DISABLE_NEXT_LINE_DIRECTIVE_KEYWORD: &str = "uroborosql-lint-disable-next-line";
+pub const DISABLE_DIRECTIVE_KEYWORD: &str = "uroborosql-lint-disable";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParsedLintDirectiveKind {
+    Disable,
+    DisableNextLine,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DirectiveParseDiagnosticKind {
+    UnknownRule {
+        rule: String,
+        removal_span: std::ops::Range<usize>,
+    },
+    SyntaxError {
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectiveParseDiagnostic {
+    pub kind: DirectiveParseDiagnosticKind,
+    pub span: std::ops::Range<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParsedLineLintDirective {
+    NotDirective,
+    Directive {
+        kind: ParsedLintDirectiveKind,
+        rules: Vec<String>,
+        diagnostics: Vec<DirectiveParseDiagnostic>,
+        append_byte: Option<usize>,
+        has_syntax_error: bool,
+    },
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LintDirectiveKind {
@@ -94,151 +132,241 @@ enum ParsedDirective {
 }
 
 fn parse_directive<'tree>(comment: &Node<'tree>) -> ParsedDirective {
-    const DISABLE_NEXT_LINE: &str = "uroborosql-lint-disable-next-line";
-    const DISABLE: &str = "uroborosql-lint-disable";
-
     let comment_text = comment.text();
     let line = comment.range().start_position.row;
-    let Some(body) = comment_text.strip_prefix("--") else {
-        return ParsedDirective::NotDirective;
+
+    match parse_line_comment_directive(comment_text) {
+        ParsedLineLintDirective::NotDirective => ParsedDirective::NotDirective,
+        ParsedLineLintDirective::Directive {
+            kind,
+            rules,
+            diagnostics,
+            has_syntax_error,
+            ..
+        } => {
+            let diagnostics = diagnostics
+                .into_iter()
+                .map(|diagnostic| to_lint_diagnostic(comment, diagnostic))
+                .collect::<Vec<_>>();
+            if has_syntax_error {
+                ParsedDirective::Invalid(
+                    diagnostics
+                        .into_iter()
+                        .next()
+                        .expect("syntax diagnostic should be present"),
+                )
+            } else {
+                ParsedDirective::Valid {
+                    directive: LintDirective {
+                        kind: match kind {
+                            ParsedLintDirectiveKind::Disable => LintDirectiveKind::Disable,
+                            ParsedLintDirectiveKind::DisableNextLine => {
+                                LintDirectiveKind::DisableNextLine
+                            }
+                        },
+                        line,
+                        rules,
+                    },
+                    diagnostics,
+                }
+            }
+        }
+    }
+}
+
+pub fn parse_line_comment_directive(text: &str) -> ParsedLineLintDirective {
+    let Some(body) = text.strip_prefix("--") else {
+        return ParsedLineLintDirective::NotDirective;
     };
     let body = body.trim_start_matches([' ', '\t']);
-    let body_offset = comment_text.len() - body.len();
+    let body_offset = text.len() - body.len();
 
-    if let Some(rest) = body.strip_prefix(DISABLE_NEXT_LINE) {
-        return match parse_rules(comment, rest, body_offset + DISABLE_NEXT_LINE.len()) {
-            ParsedRules::Valid { rules, diagnostics } => ParsedDirective::Valid {
-                directive: LintDirective {
-                    kind: LintDirectiveKind::DisableNextLine,
-                    line,
-                    rules,
-                },
-                diagnostics,
-            },
-            ParsedRules::Invalid(diagnostic) => ParsedDirective::Invalid(diagnostic),
-            ParsedRules::NotDirective => ParsedDirective::NotDirective,
-        };
+    if let Some(rest) = body.strip_prefix(DISABLE_NEXT_LINE_DIRECTIVE_KEYWORD) {
+        return parse_line_rules(
+            text,
+            ParsedLintDirectiveKind::DisableNextLine,
+            rest,
+            body_offset + DISABLE_NEXT_LINE_DIRECTIVE_KEYWORD.len(),
+        );
     }
 
-    if let Some(rest) = body.strip_prefix(DISABLE) {
-        return match parse_rules(comment, rest, body_offset + DISABLE.len()) {
-            ParsedRules::Valid { rules, diagnostics } => ParsedDirective::Valid {
-                directive: LintDirective {
-                    kind: LintDirectiveKind::Disable,
-                    line,
-                    rules,
-                },
-                diagnostics,
-            },
-            ParsedRules::Invalid(diagnostic) => ParsedDirective::Invalid(diagnostic),
-            ParsedRules::NotDirective => ParsedDirective::NotDirective,
-        };
+    if let Some(rest) = body.strip_prefix(DISABLE_DIRECTIVE_KEYWORD) {
+        return parse_line_rules(
+            text,
+            ParsedLintDirectiveKind::Disable,
+            rest,
+            body_offset + DISABLE_DIRECTIVE_KEYWORD.len(),
+        );
     }
 
-    ParsedDirective::NotDirective
+    ParsedLineLintDirective::NotDirective
 }
 
-enum ParsedRules {
-    Valid {
-        rules: Vec<String>,
-        diagnostics: Vec<Diagnostic>,
-    },
-    Invalid(Diagnostic),
-    NotDirective,
-}
-
-fn parse_rules<'tree>(comment: &Node<'tree>, rest: &str, directive_offset: usize) -> ParsedRules {
+fn parse_line_rules(
+    text: &str,
+    kind: ParsedLintDirectiveKind,
+    rest: &str,
+    directive_offset: usize,
+) -> ParsedLineLintDirective {
     if rest.trim().is_empty() {
-        return ParsedRules::Invalid(invalid_syntax_diagnostic(
-            comment,
+        return syntax_error_directive(
+            kind,
             "invalid lint directive syntax: expected one or more comma-separated rule names",
             0,
-            comment.text().len(),
-        ));
+            text.len(),
+        );
     }
 
     if !rest.starts_with(char::is_whitespace) {
-        return ParsedRules::NotDirective;
+        return ParsedLineLintDirective::NotDirective;
     }
 
-    // Keep spans in original comment coordinates for directive diagnostics.
     let rules_offset = directive_offset + (rest.len() - rest.trim_start().len());
-    let rest = rest.trim();
+    let rest = rest.trim_start().trim_end();
     let mut seen = HashSet::new();
     let mut rules = Vec::new();
     let mut diagnostics = Vec::new();
+    let segments = split_rule_segments(rest);
 
-    let mut offset = 0;
-    for raw_name in rest.split(',') {
-        let name = raw_name.trim();
-        let trimmed_start = raw_name.len() - raw_name.trim_start().len();
+    for (index, segment) in segments.iter().enumerate() {
+        let raw_name = &rest[segment.start..segment.end];
+        let name = raw_name.trim_matches([' ', '\t']);
+        let trimmed_start = raw_name.len() - raw_name.trim_start_matches([' ', '\t']).len();
 
         if name.is_empty() {
-            let start = rules_offset + offset + trimmed_start;
-            let end = if offset + raw_name.len() == rest.len() {
+            let start = rules_offset + segment.start + trimmed_start;
+            let end = if segment.end == rest.len() {
                 start.saturating_sub(1)
             } else {
                 start + raw_name.len()
             };
-            let message = if offset + raw_name.len() == rest.len() {
+            let message = if segment.end == rest.len() {
                 "invalid lint directive syntax: trailing comma is not allowed"
             } else {
                 "invalid lint directive syntax: expected comma-separated rule names"
             };
-            return ParsedRules::Invalid(invalid_syntax_diagnostic(
-                comment,
-                message,
-                start.saturating_sub(1),
-                end,
-            ));
+            return syntax_error_directive(kind, message, start.saturating_sub(1), end);
         }
 
         if RuleEnum::from_name(name).is_none() {
-            let start = rules_offset + offset + trimmed_start;
+            let start = rules_offset + segment.start + trimmed_start;
             let end = start + name.len();
-            diagnostics.push(unknown_rule_diagnostic(comment, name, start, end));
-            offset += raw_name.len() + 1;
+            let removal_span = unknown_rule_removal_span(text, rest, &segments, index);
+            diagnostics.push(DirectiveParseDiagnostic {
+                kind: DirectiveParseDiagnosticKind::UnknownRule {
+                    rule: name.to_string(),
+                    removal_span: removal_span.start + rules_offset
+                        ..removal_span.end + rules_offset,
+                },
+                span: start..end,
+            });
             continue;
         }
 
         if seen.insert(name) {
             rules.push(name.to_string());
         }
-
-        offset += raw_name.len() + 1;
     }
 
-    ParsedRules::Valid { rules, diagnostics }
+    ParsedLineLintDirective::Directive {
+        kind,
+        rules,
+        diagnostics,
+        append_byte: Some(rules_offset + rest.len()),
+        has_syntax_error: false,
+    }
 }
 
-fn unknown_rule_diagnostic<'tree>(
-    comment: &Node<'tree>,
-    unknown_rule: &str,
-    start_offset: usize,
-    end_offset: usize,
-) -> Diagnostic {
-    let range = subrange_in_comment(comment, start_offset, end_offset);
-    Diagnostic::new(
-        INVALID_LINT_DIRECTIVE_CODE,
-        Severity::Warning,
-        format!("unknown lint directive rule `{unknown_rule}`"),
-        &range,
-    )
+#[derive(Debug)]
+struct RuleSegment {
+    start: usize,
+    end: usize,
 }
 
-fn invalid_syntax_diagnostic<'tree>(
-    comment: &Node<'tree>,
+fn split_rule_segments(rest: &str) -> Vec<RuleSegment> {
+    let mut segments = Vec::new();
+    let mut start = 0;
+    for (idx, _) in rest.match_indices(',') {
+        segments.push(RuleSegment { start, end: idx });
+        start = idx + 1;
+    }
+    segments.push(RuleSegment {
+        start,
+        end: rest.len(),
+    });
+    segments
+}
+
+fn unknown_rule_removal_span(
+    text: &str,
+    rest: &str,
+    segments: &[RuleSegment],
+    index: usize,
+) -> std::ops::Range<usize> {
+    if segments.len() == 1 {
+        return 0..text.len();
+    }
+
+    let segment = &segments[index];
+    if index + 1 < segments.len() {
+        let raw_name = &rest[segment.start..segment.end];
+        let trimmed_start = raw_name.len() - raw_name.trim_start_matches([' ', '\t']).len();
+        let next = &segments[index + 1];
+        let next_raw = &rest[next.start..next.end];
+        let next_trimmed_start = next_raw.len() - next_raw.trim_start_matches([' ', '\t']).len();
+        segment.start + trimmed_start..next.start + next_trimmed_start
+    } else {
+        let previous = &segments[index - 1];
+        let previous_raw = &rest[previous.start..previous.end];
+        let previous_trimmed_end = previous_raw.trim_end_matches([' ', '\t']).len();
+        previous.start + previous_trimmed_end..segment.end
+    }
+}
+
+fn syntax_error_directive(
+    kind: ParsedLintDirectiveKind,
     message: impl Into<String>,
     start_offset: usize,
     end_offset: usize,
+) -> ParsedLineLintDirective {
+    ParsedLineLintDirective::Directive {
+        kind,
+        rules: Vec::new(),
+        diagnostics: vec![DirectiveParseDiagnostic {
+            kind: DirectiveParseDiagnosticKind::SyntaxError {
+                message: message.into(),
+            },
+            span: start_offset..end_offset.max(start_offset + 1),
+        }],
+        append_byte: None,
+        has_syntax_error: true,
+    }
+}
+
+fn to_lint_diagnostic<'tree>(
+    comment: &Node<'tree>,
+    diagnostic: DirectiveParseDiagnostic,
 ) -> Diagnostic {
-    let range = subrange_in_comment(comment, start_offset, end_offset.max(start_offset + 1));
-    Diagnostic::new(
-        INVALID_LINT_DIRECTIVE_CODE,
-        Severity::Warning,
-        message,
-        &range,
-    )
+    match diagnostic.kind {
+        DirectiveParseDiagnosticKind::UnknownRule { rule, .. } => {
+            let range = subrange_in_comment(comment, diagnostic.span.start, diagnostic.span.end);
+            Diagnostic::new(
+                INVALID_LINT_DIRECTIVE_CODE,
+                Severity::Warning,
+                format!("unknown lint directive rule `{rule}`"),
+                &range,
+            )
+        }
+        DirectiveParseDiagnosticKind::SyntaxError { message } => {
+            let range = subrange_in_comment(comment, diagnostic.span.start, diagnostic.span.end);
+            Diagnostic::new(
+                INVALID_LINT_DIRECTIVE_CODE,
+                Severity::Warning,
+                message,
+                &range,
+            )
+        }
+    }
 }
 
 fn subrange_in_comment<'tree>(
@@ -307,6 +435,54 @@ mod tests {
             .find(|node| node.kind() == SyntaxKind::SQL_COMMENT)
             .expect("sql comment");
         parse_directive(&comment_node)
+    }
+
+    #[test]
+    fn line_parser_returns_known_rules_and_unknown_diagnostics() {
+        let parsed = parse_line_comment_directive(
+            "-- uroborosql-lint-disable no-distinct, clearly-not-a-rule",
+        );
+
+        assert!(matches!(
+            parsed,
+            ParsedLineLintDirective::Directive {
+                kind: ParsedLintDirectiveKind::Disable,
+                rules,
+                diagnostics,
+                append_byte: Some(58),
+                has_syntax_error: false,
+            } if rules == vec!["no-distinct".to_string()]
+                && matches!(
+                    &diagnostics[..],
+                    [DirectiveParseDiagnostic {
+                        kind: DirectiveParseDiagnosticKind::UnknownRule { rule, removal_span },
+                        span,
+                    }] if rule == "clearly-not-a-rule"
+                        && removal_span == &(38..58)
+                        && span == &(40..58)
+                )
+        ));
+    }
+
+    #[test]
+    fn line_parser_reports_syntax_error_without_append_position() {
+        let parsed = parse_line_comment_directive("-- uroborosql-lint-disable no-distinct,");
+
+        assert!(matches!(
+            parsed,
+            ParsedLineLintDirective::Directive {
+                has_syntax_error: true,
+                append_byte: None,
+                diagnostics,
+                ..
+            } if matches!(
+                &diagnostics[..],
+                [DirectiveParseDiagnostic {
+                    kind: DirectiveParseDiagnosticKind::SyntaxError { message },
+                    ..
+                }] if message == "invalid lint directive syntax: trailing comma is not allowed"
+            )
+        ));
     }
 
     #[test]

--- a/crates/uroborosql-lint/src/lib.rs
+++ b/crates/uroborosql-lint/src/lib.rs
@@ -11,5 +11,10 @@ pub use config::{
     ConfigError, ConfigStore, ResolvedLintConfig, RuleLevel, RuleSetting, DEFAULT_CONFIG_FILENAME,
 };
 pub use diagnostic::{Diagnostic, Severity, SqlSpan};
+pub use directive::{
+    parse_line_comment_directive, DirectiveParseDiagnostic, DirectiveParseDiagnosticKind,
+    ParsedLineLintDirective, ParsedLintDirectiveKind, DISABLE_DIRECTIVE_KEYWORD,
+    DISABLE_NEXT_LINE_DIRECTIVE_KEYWORD, INVALID_LINT_DIRECTIVE_CODE, LINT_SOURCE,
+};
 pub use linter::{LintError, Linter};
 pub use rules::RuleEnum;

--- a/crates/uroborosql-lint/src/lib.rs
+++ b/crates/uroborosql-lint/src/lib.rs
@@ -13,7 +13,7 @@ pub use config::{
 pub use diagnostic::{Diagnostic, Severity, SqlSpan};
 pub use directive::{
     parse_line_comment_directive, DirectiveParseDiagnostic, DirectiveParseDiagnosticKind,
-    ParsedLineLintDirective, ParsedLintDirectiveKind, DISABLE_DIRECTIVE_KEYWORD,
+    ParsedLineComment, ParsedLintDirectiveKind, DISABLE_DIRECTIVE_KEYWORD,
     DISABLE_NEXT_LINE_DIRECTIVE_KEYWORD, INVALID_LINT_DIRECTIVE_CODE, LINT_SOURCE,
 };
 pub use linter::{LintError, Linter};

--- a/crates/uroborosql-lint/src/lib.rs
+++ b/crates/uroborosql-lint/src/lib.rs
@@ -13,7 +13,7 @@ pub use config::{
 pub use diagnostic::{Diagnostic, Severity, SqlSpan};
 pub use directive::{
     parse_line_comment_directive, DirectiveParseDiagnostic, DirectiveParseDiagnosticKind,
-    ParsedLineComment, ParsedLintDirectiveKind, DISABLE_DIRECTIVE_KEYWORD,
+    ParsedLineComment, ParsedLintDirectiveKind, UnknownRuleRemovalRange, DISABLE_DIRECTIVE_KEYWORD,
     DISABLE_NEXT_LINE_DIRECTIVE_KEYWORD, INVALID_LINT_DIRECTIVE_CODE, LINT_SOURCE,
 };
 pub use linter::{LintError, Linter};


### PR DESCRIPTION
## Summary

- lint の診断に対して LSP の `textDocument/codeAction` で Quick Fix を返す機能を追加

## Changes

- `uroborosql-lint` に `parse_line_comment_directive` public API を追加し、directive 解釈を language server と共有
- `uroborosql-language-server` に `code_action` module を追加
  - lint rule diagnostic → `Disable <rule> for next line` Quick Fix
  - `invalid-lint-directive` (unknown rule) → `Remove unknown lint rule` Quick Fix
- `initialize` response の `ServerCapabilities` に `quickfix` Code Action provider を宣言

## Behavior

### directive comment の新規挿入

`no-distinct` diagnostic が出ている行の直前に directive を挿入する。

```sql
-- Before
SELECT DISTINCT id FROM users;

-- After
-- uroborosql-lint-disable-next-line no-distinct
SELECT DISTINCT id FROM users;
```

indentation がある場合は directive 行にも同じ indentation を付ける。

### 既存 directive への追記

直前行に `disable-next-line` がある場合は新行を挿入せず既存行に rule を追記する。これにより既存 directive の対象行がずれない。

```sql
-- Before
-- uroborosql-lint-disable-next-line no-distinct
SELECT DISTINCT * FROM users;

-- After (no-wildcard-projection diagnostic に対して)
-- uroborosql-lint-disable-next-line no-distinct, no-wildcard-projection
SELECT DISTINCT * FROM users;
```

### unknown rule の削除

`invalid-lint-directive` diagnostic が出ている unknown rule を directive から削除する。

```sql
-- Before
-- uroborosql-lint-disable-next-line no-distinct, definitely-not-a-rule

-- After
-- uroborosql-lint-disable-next-line no-distinct
```

unknown rule が単独要素の場合は directive 行ごと削除する。

## Out of scope

- file-wide disable の Quick Fix
- fix all / source action
- trailing comma など unknown rule 以外の invalid directive 修復

