### PR TITLE
fix: use Vec::pop_if for join comment handling

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,6 +53,8 @@ jobs:
             target: x86_64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |-
+              rustup install 1.88.0 &&
+              rustup default 1.88.0 &&
               set -e &&
               yarn build --target x86_64-unknown-linux-gnu &&
               strip *.node

--- a/crates/uroborosql-fmt/src/visitor/clause/from/table_ref/joined_table.rs
+++ b/crates/uroborosql-fmt/src/visitor/clause/from/table_ref/joined_table.rs
@@ -142,11 +142,10 @@ impl Visitor {
 
                 // comments_after_join_keywordの最後の要素が置換文字列かどうか調べ、
                 // 置換文字列であればrightにセットする
-                if let Some(comment) = comments_after_join_keyword.last() {
-                    if comment.is_block_comment() && comment.loc().is_next_to(&right.loc()) {
-                        // last()がSome()であるため、pop().unwrap()は必ず成功する
-                        right.set_head_comment(comments_after_join_keyword.pop().unwrap());
-                    }
+                if let Some(comment) = comments_after_join_keyword.pop_if(|comment| {
+                    comment.is_block_comment() && comment.loc().is_next_to(&right.loc())
+                }) {
+                    right.set_head_comment(comment);
                 }
 
                 cursor.goto_next_sibling();


### PR DESCRIPTION
## Summary

Rust v1.96 より [`clippy::manual_pop_if`](https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#manual_pop_if) が追加され、uroborosql-fmt でも CI で検出されたため該当箇所を修正しました。

また、`x86_64-unknown-linux-gnu` 向けの N-API Docker build では `ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian` に入っている Rust が古く、`Vec::pop_if` が unstable としてビルドに失敗しました。（[詳細](https://github.com/future-architect/uroborosql-fmt/actions/runs/26739823315/job/78801053823)）
そのため該当ワークローにおける Rust バージョンの更新も含めています。

## 変更内容

- `crates/uroborosql-fmt/src/visitor/clause/from/table_ref/joined_table.rs` の join 後コメント処理で、`last() + pop().unwrap()` で実装していた処理を `Vec::pop_if(...)` に置き換えました
- 変更に伴い、不要になったコメントについても削除しました
- `x86_64-unknown-linux-gnu` 向けの N-API Docker build に `rustup install 1.88.0` / `rustup default 1.88.0` を追加しました
    - `Vec::pop_if` は Rust 1.86.0 から stable ですが、`feat/linter` で Rust 2024 edition 対応のため同じ Docker build を Rust 1.88 に指定しています。これに合わせ、今回も 1.88 に合わせる方針としました

