### PR TITLE
feat: add uroborosql-fmt-wasm-cabi crate (minimal C-ABI wasm for non-JS hosts)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -248,6 +248,37 @@ jobs:
         with:
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+  # uroborosql-fmt-wasm-cabi (最小 C-ABI wasm) をビルドして workflow artifact にアップロード
+  # (wasm-pack ではなく素の cargo build。wasm-bindgen を使わないため)
+  build-wasm-cabi:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup cargo
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Build
+        run: cargo build -p uroborosql-fmt-wasm-cabi --target wasm32-unknown-unknown --release
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-cabi
+          path: target/wasm32-unknown-unknown/release/uroborosql_fmt_wasm_cabi.wasm
+          if-no-files-found: error
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: ./.github/actions/slack-failure-notify
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: failure
+
   # NAPI バイナリを npm pack して GitHub Release のアセットにアップロード
   upload-napi-to-release:
     if: github.repository == 'future-architect/uroborosql-fmt' &&

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,6 +944,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "uroborosql-fmt-wasm-cabi"
+version = "1.0.1"
+dependencies = [
+ "uroborosql-fmt",
+]
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ members = [
     "crates/uroborosql-fmt",
     "crates/uroborosql-fmt-cli",
     "crates/uroborosql-fmt-napi",
-    "crates/uroborosql-fmt-wasm"
+    "crates/uroborosql-fmt-wasm",
+    "crates/uroborosql-fmt-wasm-cabi"
 ]
 resolver = "2"
 

--- a/crates/uroborosql-fmt-wasm-cabi/Cargo.toml
+++ b/crates/uroborosql-fmt-wasm-cabi/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "uroborosql-fmt-wasm-cabi"
+version.workspace = true
+description = "Crate to build uroborosql-fmt as a minimal C-ABI wasm (no wasm-bindgen / no JS glue); usable from non-JS hosts such as JVM WebAssembly runtimes (e.g. Chicory)"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+uroborosql-fmt = { workspace = true }
+
+[profile.release]
+# wasm のサイズ最適化（uroborosql-fmt-wasm と同様）
+opt-level = "s"

--- a/crates/uroborosql-fmt-wasm-cabi/README.md
+++ b/crates/uroborosql-fmt-wasm-cabi/README.md
@@ -1,0 +1,45 @@
+# uroborosql-fmt-wasm-cabi
+
+Builds uroborosql-fmt as a wasm module that exposes a **minimal C-ABI**.
+
+Unlike [`uroborosql-fmt-wasm`](../uroborosql-fmt-wasm) (wasm-bindgen) or the distributed demo (emscripten),
+this crate uses **neither wasm-bindgen nor emscripten, and has no dependency on JS glue**.
+All interaction happens through linear memory plus numeric (pointer/length) arguments, and the module has **zero imports**.
+As a result it can be consumed as-is from non-JS hosts such as JVM WebAssembly runtimes (e.g. [Chicory](https://chicory.dev)),
+without any additional glue.
+
+## Exported functions
+
+| Function | Purpose |
+|---|---|
+| `alloc(size) -> ptr` | Allocate linear memory for input |
+| `dealloc(ptr, size)` | Free memory allocated by `alloc` |
+| `format(src_ptr, src_len, cfg_ptr, cfg_len) -> ptr` | Format SQL and return the head of a result buffer |
+| `free_result(ptr)` | Free the buffer returned by `format` |
+
+Result buffer layout (a contract shared with the host, little-endian):
+
+```text
+offset 0 : u32  cap     ... total allocated size of the buffer (used by free_result)
+offset 4 : u8   status  ... 0 = OK / 1 = error
+offset 5 : u32  len     ... byte length of body
+offset 9 : u8[len] body ... UTF-8. Formatted SQL on success, error message on failure
+```
+
+## Build
+
+```sh
+rustup target add wasm32-unknown-unknown
+cargo build -p uroborosql-fmt-wasm-cabi --target wasm32-unknown-unknown --release
+# => target/wasm32-unknown-unknown/release/uroborosql_fmt_wasm_cabi.wasm
+```
+
+## Host-side calling sequence
+
+1. Allocate with `alloc(len)` and write UTF-8 bytes into linear memory (the SQL, and the config JSON if any).
+2. Call `format(src_ptr, src_len, cfg_ptr, cfg_len)` (pass `cfg_ptr = 0, cfg_len = 0` when there is no config).
+3. Read `status` / `len` / `body` from the returned pointer.
+4. Free with `free_result(ptr)`, and `dealloc(ptr, len)` for the input.
+
+Config JSON keys follow uroborosql-fmt's
+[Configuration options](../../README.md#configuration-options).

--- a/crates/uroborosql-fmt-wasm-cabi/src/lib.rs
+++ b/crates/uroborosql-fmt-wasm-cabi/src/lib.rs
@@ -1,0 +1,144 @@
+//! Build uroborosql-fmt as a wasm module with a tiny, plain C-ABI.
+//!
+//! It does NOT use wasm-bindgen or emscripten, so it needs no JavaScript glue.
+//! Data crosses the boundary through the wasm linear memory, using only numbers
+//! (a pointer and a length). The module has zero imports, so any host
+//! (for example a JVM wasm runtime like Chicory) can call it directly.
+//!
+//! # Exported functions
+//! - `alloc(size) -> ptr`  : reserve memory for the input
+//! - `dealloc(ptr, size)`  : free memory that `alloc` returned
+//! - `format(src_ptr, src_len, cfg_ptr, cfg_len) -> ptr` : format SQL and return a result buffer
+//! - `free_result(ptr)`    : free the buffer that `format` returned
+//!
+//! # Result buffer layout (the rule the host must follow)
+//! ```text
+//! offset 0 : u32 LE  cap     ... total size of this buffer (free_result needs it)
+//! offset 4 : u8      status  ... 0 = OK, 1 = error
+//! offset 5 : u32 LE  len     ... length of body in bytes
+//! offset 9 : u8[len] body    ... UTF-8 text: the formatted SQL when OK, an error message when error
+//! ```
+//!
+//! # Build
+//! ```sh
+//! cargo build -p uroborosql-fmt-wasm-cabi --target wasm32-unknown-unknown --release
+//! ```
+
+use std::alloc::{alloc as sys_alloc, dealloc as sys_dealloc, Layout};
+
+use uroborosql_fmt::format_sql;
+
+/// Size of the result buffer header: cap(4) + status(1) + len(4).
+const HEADER: usize = 9;
+
+/// Reserve memory in the wasm linear memory so the host can write input text.
+#[no_mangle]
+pub extern "C" fn alloc(size: usize) -> *mut u8 {
+    if size == 0 {
+        return std::ptr::null_mut();
+    }
+    let layout = Layout::from_size_align(size, 1).expect("invalid layout");
+    // SAFETY: size is greater than 0 (checked above).
+    unsafe { sys_alloc(layout) }
+}
+
+/// Free memory that `alloc` returned.
+///
+/// # Safety
+/// `ptr` must be a pointer returned by `alloc`, and `size` must be the same
+/// value that was passed to that `alloc` call.
+#[no_mangle]
+pub unsafe extern "C" fn dealloc(ptr: *mut u8, size: usize) {
+    if ptr.is_null() || size == 0 {
+        return;
+    }
+    let layout = Layout::from_size_align(size, 1).expect("invalid layout");
+    sys_dealloc(ptr, layout);
+}
+
+/// Format the SQL and return a pointer to the result buffer.
+///
+/// # Safety
+/// `(src_ptr, src_len)` and `(cfg_ptr, cfg_len)` must each describe a valid
+/// range inside the wasm linear memory, or be `(null, 0)`.
+#[no_mangle]
+pub unsafe extern "C" fn format(
+    src_ptr: *const u8,
+    src_len: usize,
+    cfg_ptr: *const u8,
+    cfg_len: usize,
+) -> *mut u8 {
+    let src = match slice_to_str(src_ptr, src_len) {
+        Ok(s) => s,
+        Err(_) => return pack(1, b"invalid UTF-8 in SQL input"),
+    };
+
+    // An empty or whitespace-only config means "use the default settings" (None).
+    let cfg: Option<&str> = match slice_to_str(cfg_ptr, cfg_len) {
+        Ok(s) if !s.trim().is_empty() => Some(s),
+        Ok(_) => None,
+        Err(_) => return pack(1, b"invalid UTF-8 in config JSON"),
+    };
+
+    match format_sql(src, cfg, None) {
+        Ok(out) => pack(0, out.as_bytes()),
+        Err(e) => pack(1, e.to_string().as_bytes()),
+    }
+}
+
+/// Free the buffer that `format` returned.
+///
+/// # Safety
+/// `ptr` must be a pointer returned by `format` that has not been freed yet.
+#[no_mangle]
+pub unsafe extern "C" fn free_result(ptr: *mut u8) {
+    if ptr.is_null() {
+        return;
+    }
+    // The first 4 bytes hold `cap` (pack wrote it there).
+    let mut cap_bytes = [0u8; 4];
+    std::ptr::copy_nonoverlapping(ptr, cap_bytes.as_mut_ptr(), 4);
+    let cap = u32::from_le_bytes(cap_bytes) as usize;
+    if cap < HEADER {
+        return;
+    }
+    let layout = Layout::from_size_align(cap, 1).expect("invalid layout");
+    sys_dealloc(ptr, layout);
+}
+
+/// Turn (ptr, len) into a `&str`. Returns an empty string if ptr is null or len is 0.
+///
+/// # Safety
+/// The caller must make sure (ptr, len) is a valid range inside the linear memory.
+unsafe fn slice_to_str<'a>(ptr: *const u8, len: usize) -> Result<&'a str, std::str::Utf8Error> {
+    if ptr.is_null() || len == 0 {
+        return Ok("");
+    }
+    let slice = std::slice::from_raw_parts(ptr, len);
+    std::str::from_utf8(slice)
+}
+
+/// Put `status` and `body` into a result buffer (see the layout in the module doc)
+/// and return the pointer to its start.
+fn pack(status: u8, body: &[u8]) -> *mut u8 {
+    let cap = HEADER + body.len();
+    let layout = Layout::from_size_align(cap, 1).expect("invalid layout");
+    // SAFETY: cap >= HEADER > 0. Every write below stays inside the allocated buffer.
+    unsafe {
+        let p = sys_alloc(layout);
+        if p.is_null() {
+            return std::ptr::null_mut();
+        }
+        // cap (u32 LE)
+        std::ptr::copy_nonoverlapping((cap as u32).to_le_bytes().as_ptr(), p, 4);
+        // status
+        *p.add(4) = status;
+        // len (u32 LE)
+        std::ptr::copy_nonoverlapping((body.len() as u32).to_le_bytes().as_ptr(), p.add(5), 4);
+        // body
+        if !body.is_empty() {
+            std::ptr::copy_nonoverlapping(body.as_ptr(), p.add(HEADER), body.len());
+        }
+        p
+    }
+}


### PR DESCRIPTION
## What
Adds a new workspace member **`uroborosql-fmt-wasm-cabi`** that builds uroborosql-fmt as a wasm module exposing a **minimal C-ABI** — no `wasm-bindgen`, no `emscripten`, **zero imports**.

## Why
The existing `uroborosql-fmt-wasm` (wasm-bindgen) expects a JS host to provide the `__wbindgen_*` glue, so it cannot be loaded by non-JS WebAssembly hosts. This crate lets uroborosql-fmt run on **JVM WebAssembly runtimes such as [Chicory](https://chicory.dev)** (and other non-JS hosts) using only linear memory + numeric (pointer/length) arguments — i.e. without shipping per-OS/arch native binaries.

## What's in it
- `crates/uroborosql-fmt-wasm-cabi/` — a `cdylib` crate depending on `uroborosql-fmt`.
  - Exports: `alloc(size)`, `dealloc(ptr, size)`, `format(src_ptr, src_len, cfg_ptr, cfg_len)`, `free_result(ptr)`.
  - Result buffer layout (little-endian): `[u32 cap][u8 status][u32 len][u8; len body]`; `body` is UTF-8 (formatted SQL on success, error message on failure).
- Registered in the workspace `members`.
- **No changes to existing crates.**

## Build
```sh
rustup target add wasm32-unknown-unknown
cargo build -p uroborosql-fmt-wasm-cabi --target wasm32-unknown-unknown --release
# => target/wasm32-unknown-unknown/release/uroborosql_fmt_wasm_cabi.wasm
```
Verified to build; the resulting module has **0 imports** (no host glue required).

## Notes
- Opened as a draft for early review.
- CI to build/publish the `.wasm` artifact can be added as a follow-up if desired.
