### PR TITLE
chore: configure release-please for linter packages

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,8 +2,5 @@
   "crates/uroborosql-fmt": "1.0.1",
   "crates/uroborosql-fmt-cli": "1.0.1",
   "crates/uroborosql-fmt-napi": "1.0.1",
-  "crates/uroborosql-fmt-wasm": "1.0.1",
-  "crates/uroborosql-lint": "0.1.0",
-  "crates/uroborosql-lint-cli": "0.1.0",
-  "crates/uroborosql-language-server": "1.0.0"
+  "crates/uroborosql-fmt-wasm": "1.0.1"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,8 @@
   "crates/uroborosql-fmt": "1.0.1",
   "crates/uroborosql-fmt-cli": "1.0.1",
   "crates/uroborosql-fmt-napi": "1.0.1",
-  "crates/uroborosql-fmt-wasm": "1.0.1"
+  "crates/uroborosql-fmt-wasm": "1.0.1",
+  "crates/uroborosql-lint": "0.1.0",
+  "crates/uroborosql-lint-cli": "0.1.0",
+  "crates/uroborosql-language-server": "1.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -51,6 +51,24 @@
       "component": "uroborosql-fmt-wasm",
       "include-component-in-tag": true,
       "changelog-path": "CHANGELOG.md"
+    },
+    "crates/uroborosql-lint": {
+      "package-name": "uroborosql-lint",
+      "component": "uroborosql-lint",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "crates/uroborosql-lint-cli": {
+      "package-name": "uroborosql-lint-cli",
+      "component": "uroborosql-lint-cli",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "crates/uroborosql-language-server": {
+      "package-name": "uroborosql-language-server",
+      "component": "uroborosql-language-server",
+      "include-component-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -56,18 +56,21 @@
       "package-name": "uroborosql-lint",
       "component": "uroborosql-lint",
       "include-component-in-tag": true,
+      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md"
     },
     "crates/uroborosql-lint-cli": {
       "package-name": "uroborosql-lint-cli",
       "component": "uroborosql-lint-cli",
       "include-component-in-tag": true,
+      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md"
     },
     "crates/uroborosql-language-server": {
       "package-name": "uroborosql-language-server",
       "component": "uroborosql-language-server",
       "include-component-in-tag": true,
+      "release-as": "1.0.0",
       "changelog-path": "CHANGELOG.md"
     }
   }


### PR DESCRIPTION
## 概要

`feat/linter` で追加された以下の 3 クレートを `release-please` の管理対象に追加する。

- `uroborosql-lint`
- `uroborosql-lint-cli`
- `uroborosql-language-server`

## 変更内容

- `release-please-config.json` に上記 3 クレートの package 定義を追加
- `.release-please-manifest.json` は既存 4 クレートのみを保持

## 初回リリース version について

新規クレートの初回リリース version を固定するため、manifest には version を入れず、package ごとの `release-as` を使う。

- `uroborosql-lint`: `0.1.0`
- `uroborosql-lint-cli`: `0.1.0`
- `uroborosql-language-server`: `1.0.0`

## マージ・リリース後にやること

初回 release PR のマージ後は、今回追加した `release-as` を削除する
（残したままだと、次回以降も同じ version を固定で提案されるため）
