### PR TITLE
chore: add linter artifact build jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,6 +15,9 @@ permissions:
       - "uroborosql-fmt-cli-v*"
       - "uroborosql-fmt-napi-v*"
       - "uroborosql-fmt-wasm-v*"
+      - "uroborosql-lint-v*"
+      - "uroborosql-lint-cli-v*"
+      - "uroborosql-language-server-v*"
     paths-ignore:
       - "**/*.md"
       - LICENSE
@@ -219,6 +222,140 @@ jobs:
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: failure
 
+  # CLI バイナリ (uroborosql-lint) を各プラットフォーム向けにビルド
+  build-lint-cli:
+    if: ${{ github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/') || startsWith(github.ref_name, 'uroborosql-lint-cli-v') }}
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - host: macos-15-intel
+            target: x86_64-apple-darwin
+            asset: uroborosql-lint-x86_64-apple-darwin
+          - host: macos-latest
+            target: aarch64-apple-darwin
+            asset: uroborosql-lint-aarch64-apple-darwin
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+            asset: uroborosql-lint-x86_64-pc-windows-msvc.exe
+          - host: windows-latest
+            target: aarch64-pc-windows-msvc
+            asset: uroborosql-lint-aarch64-pc-windows-msvc.exe
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset: uroborosql-lint-x86_64-unknown-linux-gnu
+    name: build-lint-cli - ${{ matrix.target }}
+    runs-on: ${{ matrix.host }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.target }}-cargo-lint-cli-${{ matrix.host }}
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }} -p uroborosql-lint-cli
+        shell: bash
+      - name: Prepare artifact
+        shell: bash
+        run: |
+          mkdir -p lint-cli-dist
+          if [[ "${{ matrix.target }}" == *windows* ]]; then
+            cp "target/${{ matrix.target }}/release/uroborosql-lint.exe" "lint-cli-dist/${{ matrix.asset }}"
+          else
+            cp "target/${{ matrix.target }}/release/uroborosql-lint" "lint-cli-dist/${{ matrix.asset }}"
+          fi
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-cli-${{ matrix.target }}
+          path: lint-cli-dist/${{ matrix.asset }}
+          if-no-files-found: error
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: ./.github/actions/slack-failure-notify
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: failure
+
+  # Language Server バイナリを各プラットフォーム向けにビルド
+  build-language-server:
+    if: ${{ github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/') || startsWith(github.ref_name, 'uroborosql-language-server-v') }}
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - host: macos-15-intel
+            target: x86_64-apple-darwin
+            asset: uroborosql-language-server-x86_64-apple-darwin
+          - host: macos-latest
+            target: aarch64-apple-darwin
+            asset: uroborosql-language-server-aarch64-apple-darwin
+          - host: windows-latest
+            target: x86_64-pc-windows-msvc
+            asset: uroborosql-language-server-x86_64-pc-windows-msvc.exe
+          - host: windows-latest
+            target: aarch64-pc-windows-msvc
+            asset: uroborosql-language-server-aarch64-pc-windows-msvc.exe
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset: uroborosql-language-server-x86_64-unknown-linux-gnu
+    name: build-language-server - ${{ matrix.target }}
+    runs-on: ${{ matrix.host }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ matrix.target }}-cargo-language-server-${{ matrix.host }}
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }} -p uroborosql-language-server
+        shell: bash
+      - name: Prepare artifact
+        shell: bash
+        run: |
+          mkdir -p language-server-dist
+          if [[ "${{ matrix.target }}" == *windows* ]]; then
+            cp "target/${{ matrix.target }}/release/uroborosql-language-server.exe" "language-server-dist/${{ matrix.asset }}"
+          else
+            cp "target/${{ matrix.target }}/release/uroborosql-language-server" "language-server-dist/${{ matrix.asset }}"
+          fi
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: language-server-${{ matrix.target }}
+          path: language-server-dist/${{ matrix.asset }}
+          if-no-files-found: error
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: ./.github/actions/slack-failure-notify
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: failure
+
   build-wasm:
     if: ${{ github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/') || startsWith(github.ref_name, 'uroborosql-fmt-wasm-v') }}
     needs: test
@@ -353,6 +490,58 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "${GITHUB_REF_NAME}" ./cli-artifacts/* --clobber
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: ./.github/actions/slack-failure-notify
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: failure
+
+  # Lint CLI バイナリを GitHub Release のアセットにアップロード
+  upload-lint-cli-to-release:
+    if: github.repository == 'future-architect/uroborosql-fmt' &&
+      startsWith(github.ref_name, 'uroborosql-lint-cli-v')
+    needs: build-lint-cli
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all lint CLI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: lint-cli-*
+          path: ./lint-cli-artifacts
+          merge-multiple: true
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" ./lint-cli-artifacts/* --clobber
+
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: ./.github/actions/slack-failure-notify
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: failure
+
+  # Language Server バイナリを GitHub Release のアセットにアップロード
+  upload-language-server-to-release:
+    if: github.repository == 'future-architect/uroborosql-fmt' &&
+      startsWith(github.ref_name, 'uroborosql-language-server-v')
+    needs: build-language-server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all language server artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: language-server-*
+          path: ./language-server-artifacts
+          merge-multiple: true
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" ./language-server-artifacts/* --clobber
 
       - name: Notify Slack on Failure
         if: failure()


### PR DESCRIPTION
## Summary

`uroborosql-lint-cli` と `uroborosql-language-server` の成果物ビルドと Release asset への upload を GitHub Actions に追加する。

## Changes

- `CI.yml` の tag trigger に `uroborosql-lint-v*`、`uroborosql-lint-cli-v*`、`uroborosql-language-server-v*` を追加
- `uroborosql-lint-cli` 向けの matrix build job を追加
- `uroborosql-lint-cli` の Release asset upload job を追加
- `uroborosql-language-server` 向けの matrix build job を追加
- `uroborosql-language-server` の Release asset upload job を追加

## Notes

- `uroborosql-lint-cli` は `uroborosql-fmt-cli` と同様に、 Release asset を実バイナリ名ベース（`-cli` 無し）で作成
