### PR TITLE
fix: remove custom release-please group pr title

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "release-type": "rust",
   "bootstrap-sha": "c2b2b58ebbe1bd1a41cbacc92efa17728c731566",
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore: release",
   "plugins": ["cargo-workspace"],
   "packages": {
     "crates/uroborosql-fmt": {


### PR DESCRIPTION
## Summary
PR #253 マージ後に Release が発行されない問題の修正

リリース作成が中断されてしまう原因となっていた以下の設定を削除
`release-please-config.json` 

```json
"group-pull-request-title-pattern": "chore: release"
```


## ログ


```
✖ Bad pull request title: 'chore: release'
⚠ There are untagged, merged release PRs outstanding - aborting
```
https://github.com/future-architect/uroborosql-fmt/actions/runs/27332825745/job/80749283771