### PR TITLE
feat: gate lint behind config presence

### DIFF
--- a/crates/uroborosql-language-server/README.md
+++ b/crates/uroborosql-language-server/README.md
@@ -8,8 +8,11 @@ Language server for `uroborosql-fmt`.
 
 - SQL document formatting
 - SQL range formatting
-- diagnostics
+- diagnostics when a lint config is available
 - embedded SQL formatting via a custom request
+
+Lint diagnostics are config-gated.
+The server only publishes lint diagnostics when it can resolve a lint config file such as `.uroborosqllintrc.json`.
 
 ## Supported LSP methods
 

--- a/crates/uroborosql-language-server/README.md
+++ b/crates/uroborosql-language-server/README.md
@@ -11,7 +11,6 @@ Language server for `uroborosql-fmt`.
 - diagnostics when a lint config is available
 - embedded SQL formatting via a custom request
 
-Lint diagnostics are config-gated.
 The server only publishes lint diagnostics when it can resolve a lint config file such as `.uroborosqllintrc.json`.
 
 ## Supported LSP methods

--- a/crates/uroborosql-language-server/src/configuration.rs
+++ b/crates/uroborosql-language-server/src/configuration.rs
@@ -87,9 +87,9 @@ impl Backend {
         };
 
         let resolved_path = self.resolve_lint_config_path();
-        match ConfigStore::new(root_dir, resolved_path) {
+        match ConfigStore::try_new(root_dir, resolved_path) {
             Ok(store) => {
-                *self.lint_config_store.write().unwrap() = Some(store);
+                *self.lint_config_store.write().unwrap() = store;
             }
             Err(err) => {
                 self.client

--- a/crates/uroborosql-language-server/src/lint.rs
+++ b/crates/uroborosql-language-server/src/lint.rs
@@ -30,22 +30,25 @@ impl Backend {
             return;
         }
 
-        let Some(config_store) = self.lint_config_store.read().unwrap().as_ref().cloned() else {
-            self.client
-                .log_message(
-                    MessageType::INFO,
-                    "lint config store is not initialized; skipping lint",
-                )
-                .await;
-            return;
-        };
-
         let Some(path) = file_uri_to_path(uri) else {
             self.client
                 .log_message(
                     MessageType::INFO,
                     "file URI is not a file URI; skipping lint",
                 )
+                .await;
+            return;
+        };
+
+        let Some(config_store) = self.lint_config_store.read().unwrap().as_ref().cloned() else {
+            self.client
+                .log_message(
+                    MessageType::INFO,
+                    "lint config store is not initialized; clearing diagnostics",
+                )
+                .await;
+            self.client
+                .publish_diagnostics(uri.clone(), vec![], version)
                 .await;
             return;
         };

--- a/crates/uroborosql-language-server/tests/code_action.rs
+++ b/crates/uroborosql-language-server/tests/code_action.rs
@@ -1,8 +1,7 @@
 mod test_harness;
 
-use std::str::FromStr;
-
 use serde_json::Value;
+use tower_lsp_server::UriExt;
 use tower_lsp_server::lsp_types::notification::{Notification, PublishDiagnostics};
 use tower_lsp_server::lsp_types::*;
 
@@ -22,9 +21,13 @@ async fn initialize_declares_quickfix_code_action_provider() {
 #[tokio::test]
 async fn lint_diagnostic_returns_disable_next_line_quickfix() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///code-action.sql").unwrap();
+    let root_dir = initialize_server_with_default_lint_config(
+        &mut server,
+        "uroborosql-lsp-code-action-disable",
+    )
+    .await;
+    let uri = Uri::from_file_path(root_dir.join("code-action.sql")).unwrap();
 
-    initialize_server(&mut server).await;
     server
         .send_request(build_did_open(
             &uri,
@@ -64,11 +67,15 @@ async fn lint_diagnostic_returns_disable_next_line_quickfix() {
 #[tokio::test]
 async fn existing_disable_next_line_is_appended() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///append.sql").unwrap();
+    let root_dir = initialize_server_with_default_lint_config(
+        &mut server,
+        "uroborosql-lsp-code-action-append",
+    )
+    .await;
+    let uri = Uri::from_file_path(root_dir.join("append.sql")).unwrap();
     let text = "-- uroborosql-lint-disable-next-line no-distinct\nSELECT DISTINCT * FROM users;\n";
     let diagnostic = lint_diagnostic("no-wildcard-projection", 1, 16, 1, 17);
 
-    initialize_server(&mut server).await;
     server.send_request(build_did_open(&uri, text, 1)).await;
     let _ = server.receive_notification().await;
 
@@ -93,12 +100,16 @@ async fn existing_disable_next_line_is_appended() {
 #[tokio::test]
 async fn indented_existing_disable_next_line_is_appended() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///append-indented.sql").unwrap();
+    let root_dir = initialize_server_with_default_lint_config(
+        &mut server,
+        "uroborosql-lsp-code-action-append-indented",
+    )
+    .await;
+    let uri = Uri::from_file_path(root_dir.join("append-indented.sql")).unwrap();
     let text =
         "    -- uroborosql-lint-disable-next-line no-distinct\n    SELECT DISTINCT * FROM users;\n";
     let diagnostic = lint_diagnostic("no-wildcard-projection", 1, 20, 1, 21);
 
-    initialize_server(&mut server).await;
     server.send_request(build_did_open(&uri, text, 1)).await;
     let _ = server.receive_notification().await;
 
@@ -123,10 +134,14 @@ async fn indented_existing_disable_next_line_is_appended() {
 #[tokio::test]
 async fn unknown_rule_directive_returns_remove_quickfix() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///unknown-rule.sql").unwrap();
+    let root_dir = initialize_server_with_default_lint_config(
+        &mut server,
+        "uroborosql-lsp-code-action-unknown",
+    )
+    .await;
+    let uri = Uri::from_file_path(root_dir.join("unknown-rule.sql")).unwrap();
     let text = "-- uroborosql-lint-disable-next-line no-distinct, definitely-not-a-rule\nSELECT DISTINCT id FROM users;\n";
 
-    initialize_server(&mut server).await;
     server.send_request(build_did_open(&uri, text, 1)).await;
     let diagnostics = receive_diagnostics(&mut server).await;
     let diagnostic = diagnostic_with_code(&diagnostics, "invalid-lint-directive");
@@ -156,10 +171,14 @@ async fn unknown_rule_directive_returns_remove_quickfix() {
 #[tokio::test]
 async fn indented_unknown_rule_directive_returns_remove_quickfix() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///unknown-rule-indented.sql").unwrap();
+    let root_dir = initialize_server_with_default_lint_config(
+        &mut server,
+        "uroborosql-lsp-code-action-unknown-indented",
+    )
+    .await;
+    let uri = Uri::from_file_path(root_dir.join("unknown-rule-indented.sql")).unwrap();
     let text = "    -- uroborosql-lint-disable-next-line no-distinct, definitely-not-a-rule\nSELECT DISTINCT id FROM users;\n";
 
-    initialize_server(&mut server).await;
     server.send_request(build_did_open(&uri, text, 1)).await;
     let diagnostics = receive_diagnostics(&mut server).await;
     let diagnostic = diagnostic_with_code(&diagnostics, "invalid-lint-directive");
@@ -189,10 +208,12 @@ async fn indented_unknown_rule_directive_returns_remove_quickfix() {
 #[tokio::test]
 async fn non_quickfix_only_returns_empty_actions() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///only.sql").unwrap();
+    let root_dir =
+        initialize_server_with_default_lint_config(&mut server, "uroborosql-lsp-code-action-only")
+            .await;
+    let uri = Uri::from_file_path(root_dir.join("only.sql")).unwrap();
     let diagnostic = lint_diagnostic("no-distinct", 0, 0, 0, 15);
 
-    initialize_server(&mut server).await;
     server
         .send_request(build_did_open(&uri, "SELECT DISTINCT id FROM users;\n", 1))
         .await;

--- a/crates/uroborosql-language-server/tests/diagnostics.rs
+++ b/crates/uroborosql-language-server/tests/diagnostics.rs
@@ -3,6 +3,7 @@ mod test_harness;
 use std::str::FromStr;
 use std::time::Duration;
 
+use tower_lsp_server::UriExt;
 use tower_lsp_server::lsp_types::Uri;
 use tower_lsp_server::lsp_types::notification::{Notification, PublishDiagnostics};
 
@@ -11,9 +12,9 @@ use test_harness::*;
 #[tokio::test]
 async fn diagnostics_publish_on_open_and_save() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///test.sql").unwrap();
-
-    initialize_server(&mut server).await;
+    let root_dir =
+        initialize_server_with_default_lint_config(&mut server, "uroborosql-lsp-diag-open").await;
+    let uri = Uri::from_file_path(root_dir.join("test.sql")).unwrap();
 
     server
         .send_request(build_did_open(&uri, "SELECT DISTINCT id FROM users;", 1))
@@ -44,9 +45,9 @@ async fn diagnostics_publish_on_open_and_save() {
 #[tokio::test]
 async fn did_close_clears_diagnostics() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///close.sql").unwrap();
-
-    initialize_server(&mut server).await;
+    let root_dir =
+        initialize_server_with_default_lint_config(&mut server, "uroborosql-lsp-diag-close").await;
+    let uri = Uri::from_file_path(root_dir.join("close.sql")).unwrap();
 
     server
         .send_request(build_did_open(&uri, "SELECT DISTINCT id FROM users;", 1))
@@ -69,9 +70,10 @@ async fn did_close_clears_diagnostics() {
 #[tokio::test]
 async fn did_change_watched_files_relints_open_documents() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///watched.sql").unwrap();
-
-    initialize_server(&mut server).await;
+    let root_dir =
+        initialize_server_with_default_lint_config(&mut server, "uroborosql-lsp-diag-watched")
+            .await;
+    let uri = Uri::from_file_path(root_dir.join("watched.sql")).unwrap();
 
     server
         .send_request(build_did_open(&uri, "SELECT DISTINCT id FROM users;", 1))
@@ -90,9 +92,10 @@ async fn did_change_watched_files_relints_open_documents() {
 #[tokio::test]
 async fn diagnostics_include_invalid_directive_warning() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///directive.sql").unwrap();
-
-    initialize_server(&mut server).await;
+    let root_dir =
+        initialize_server_with_default_lint_config(&mut server, "uroborosql-lsp-diag-directive")
+            .await;
+    let uri = Uri::from_file_path(root_dir.join("directive.sql")).unwrap();
 
     server
         .send_request(build_did_open(
@@ -119,4 +122,26 @@ async fn diagnostics_include_invalid_directive_warning() {
         Some(27)
     );
     assert_eq!(diagnostics[1]["code"].as_str(), Some("no-distinct"));
+}
+
+#[tokio::test]
+async fn diagnostics_are_empty_when_lint_config_is_missing() {
+    let mut server = new_test_server();
+    let root_dir = unique_temp_dir("uroborosql-lsp-diag-no-config");
+    let root_uri = Uri::from_file_path(&root_dir).unwrap();
+    let uri = Uri::from_file_path(root_dir.join("no-config.sql")).unwrap();
+
+    initialize_server_with_root_uri(&mut server, root_uri, None).await;
+
+    server
+        .send_request(build_did_open(&uri, "SELECT DISTINCT id FROM users;", 1))
+        .await;
+    let diag_notification = server.receive_notification().await;
+    assert_eq!(diag_notification.method(), PublishDiagnostics::METHOD);
+    assert!(
+        diag_notification.params().unwrap()["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
 }

--- a/crates/uroborosql-language-server/tests/lifecycle.rs
+++ b/crates/uroborosql-language-server/tests/lifecycle.rs
@@ -1,7 +1,5 @@
 mod test_harness;
 
-use std::str::FromStr;
-
 use tower_lsp_server::UriExt;
 use tower_lsp_server::lsp_types::Uri;
 use tower_lsp_server::lsp_types::notification::{Notification, PublishDiagnostics};
@@ -15,6 +13,7 @@ use test_harness::*;
 async fn initialize_uses_root_uri_when_workspace_folders_are_missing() {
     let mut server = new_test_server();
     let root_dir = unique_temp_dir("uroborosql-lsp-root-uri");
+    write_file(&root_dir.join(".uroborosqllintrc.json"), "{}");
     let root_uri = Uri::from_file_path(&root_dir).unwrap();
     let uri = Uri::from_file_path(root_dir.join("root-uri.sql")).unwrap();
 
@@ -45,9 +44,10 @@ async fn initialize_uses_root_uri_when_workspace_folders_are_missing() {
 #[tokio::test]
 async fn did_change_configuration_requests_workspace_configuration_again() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///config.sql").unwrap();
-
-    initialize_server(&mut server).await;
+    let root_dir =
+        initialize_server_with_default_lint_config(&mut server, "uroborosql-lsp-lifecycle-config")
+            .await;
+    let uri = Uri::from_file_path(root_dir.join("config.sql")).unwrap();
 
     server
         .send_request(build_did_open(&uri, "SELECT DISTINCT id FROM users;", 1))

--- a/crates/uroborosql-language-server/tests/test_harness.rs
+++ b/crates/uroborosql-language-server/tests/test_harness.rs
@@ -7,6 +7,7 @@ use std::time::SystemTime;
 
 use serde_json::json;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
+use tower_lsp_server::UriExt;
 use tower_lsp_server::jsonrpc::{Request, Response};
 use tower_lsp_server::lsp_types::Uri;
 use tower_lsp_server::lsp_types::notification::{
@@ -20,6 +21,7 @@ use tower_lsp_server::lsp_types::request::{
 use tower_lsp_server::lsp_types::*;
 use tower_lsp_server::{Client, LanguageServer, LspService, Server};
 use uroborosql_language_server::create_service;
+use uroborosql_lint::DEFAULT_CONFIG_FILENAME;
 
 pub(crate) struct TestServer {
     req_stream: DuplexStream,
@@ -461,4 +463,15 @@ pub(crate) fn write_file(path: &std::path::Path, contents: &str) {
         fs::create_dir_all(parent).unwrap();
     }
     fs::write(path, contents).unwrap();
+}
+
+pub(crate) async fn initialize_server_with_default_lint_config(
+    server: &mut TestServer,
+    prefix: &str,
+) -> std::path::PathBuf {
+    let root_dir = unique_temp_dir(prefix);
+    write_file(&root_dir.join(DEFAULT_CONFIG_FILENAME), "{}");
+    let root_uri = Uri::from_file_path(&root_dir).unwrap();
+    initialize_server_with_root_uri(server, root_uri, None).await;
+    root_dir
 }

--- a/crates/uroborosql-language-server/tests/utf16.rs
+++ b/crates/uroborosql-language-server/tests/utf16.rs
@@ -1,7 +1,6 @@
 mod test_harness;
 
-use std::str::FromStr;
-
+use tower_lsp_server::UriExt;
 use tower_lsp_server::lsp_types::notification::{Notification, PublishDiagnostics};
 use tower_lsp_server::lsp_types::{Position, Range, Uri};
 
@@ -10,9 +9,10 @@ use test_harness::*;
 #[tokio::test]
 async fn utf16_range_change_should_not_corrupt_text() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///utf16.sql").unwrap();
-
-    initialize_server(&mut server).await;
+    let root_dir =
+        initialize_server_with_default_lint_config(&mut server, "uroborosql-lsp-utf16-change")
+            .await;
+    let uri = Uri::from_file_path(root_dir.join("utf16.sql")).unwrap();
 
     let original = "select '😀' as v;";
     server.send_request(build_did_open(&uri, original, 1)).await;
@@ -51,9 +51,10 @@ async fn utf16_range_change_should_not_corrupt_text() {
 #[tokio::test]
 async fn diagnostics_range_uses_utf16_columns() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///utf16-diagnostics.sql").unwrap();
-
-    initialize_server(&mut server).await;
+    let root_dir =
+        initialize_server_with_default_lint_config(&mut server, "uroborosql-lsp-utf16-diagnostics")
+            .await;
+    let uri = Uri::from_file_path(root_dir.join("utf16-diagnostics.sql")).unwrap();
 
     let original = "SELECT DISTINCT '😀a';";
     server.send_request(build_did_open(&uri, original, 1)).await;
@@ -76,9 +77,9 @@ async fn diagnostics_range_uses_utf16_columns() {
 #[tokio::test]
 async fn utf16_range_formatting_returns_utf16_safe_range() {
     let mut server = new_test_server();
-    let uri = Uri::from_str("file:///utf16-range.sql").unwrap();
-
-    initialize_server(&mut server).await;
+    let root_dir =
+        initialize_server_with_default_lint_config(&mut server, "uroborosql-lsp-utf16-range").await;
+    let uri = Uri::from_file_path(root_dir.join("utf16-range.sql")).unwrap();
 
     let original = "select '😀a';";
     server.send_request(build_did_open(&uri, original, 1)).await;

--- a/crates/uroborosql-lint-cli/README.md
+++ b/crates/uroborosql-lint-cli/README.md
@@ -6,7 +6,7 @@ CLI crate for `uroborosql-lint`. The installed binary name is `uroborosql-lint`.
 
 ```bash
 uroborosql-lint [OPTIONS] <INPUT>
-uroborosql-lint init
+uroborosql-lint --init
 ```
 
 Examples:
@@ -15,19 +15,19 @@ Examples:
 uroborosql-lint query.sql
 uroborosql-lint --config .uroborosqllintrc.json query.sql
 uroborosql-lint --fail-level warning query.sql
-uroborosql-lint init
+uroborosql-lint --init
 ```
 
 If no lint config can be resolved, the CLI exits with an execution error and prints guidance to
 create one. Create `.uroborosqllintrc.json` in the current working directory, run
-`uroborosql-lint init`, or pass `--config`, to enable linting.
+`uroborosql-lint --init`, or pass `--config`, to enable linting.
 
 For config file structure, rule settings, and directive details, see the
 [`uroborosql-lint` README](../uroborosql-lint/README.md).
 
 ### Init
 
-Use `uroborosql-lint init` to create a starter `.uroborosqllintrc.json` in the current working
+Use `uroborosql-lint --init` to create a starter `.uroborosqllintrc.json` in the current working
 directory. If the file already exists, the command fails without overwriting it.
 
 ### Exit Codes

--- a/crates/uroborosql-lint-cli/README.md
+++ b/crates/uroborosql-lint-cli/README.md
@@ -1,6 +1,6 @@
 # uroborosql-lint-cli
 
-CLI crate for `uroborosql-lint`. The installed binary name is `uroborosql-lint`.
+CLI for `uroborosql-lint`. The installed binary name is `uroborosql-lint`.
 
 ## Getting Started
 

--- a/crates/uroborosql-lint-cli/README.md
+++ b/crates/uroborosql-lint-cli/README.md
@@ -18,8 +18,8 @@ uroborosql-lint --fail-level warning query.sql
 uroborosql-lint init
 ```
 
-If no lint config can be resolved, the CLI exits successfully without emitting diagnostics and prints
-guidance to create one. Create `.uroborosqllintrc.json` in the current working directory, run
+If no lint config can be resolved, the CLI exits with an execution error and prints guidance to
+create one. Create `.uroborosqllintrc.json` in the current working directory, run
 `uroborosql-lint init`, or pass `--config`, to enable linting.
 
 For config file structure, rule settings, and directive details, see the
@@ -34,7 +34,7 @@ directory. If the file already exists, the command fails without overwriting it.
 
 - `0`: lint succeeded and no diagnostics at or above `--fail-level` were found
 - `1`: lint succeeded and at least one diagnostic at or above `--fail-level` was found
-- `2`: lint could not complete because of a usage or execution failure such as invalid CLI arguments, invalid config, I/O failure, or SQL parse failure
+- `2`: lint could not complete because of a usage or execution failure such as missing config, invalid CLI arguments, invalid config, I/O failure, or SQL parse failure
 
 ### Fail Level
 

--- a/crates/uroborosql-lint-cli/README.md
+++ b/crates/uroborosql-lint-cli/README.md
@@ -22,6 +22,9 @@ If no lint config can be resolved, the CLI exits successfully without emitting d
 guidance to create one. Create `.uroborosqllintrc.json` in the current working directory, run
 `uroborosql-lint init`, or pass `--config`, to enable linting.
 
+For config file structure, rule settings, and directive details, see the
+[`uroborosql-lint` README](../uroborosql-lint/README.md).
+
 ### Init
 
 Use `uroborosql-lint init` to create a starter `.uroborosqllintrc.json` in the current working
@@ -41,5 +44,3 @@ Use `--fail-level <none|info|warning|error>` to control which diagnostics cause 
 - `info` currently behaves the same as `warning` because the implemented diagnostics are `warning` or `error` today; it exists so the CLI can stay aligned if `info` diagnostics are added later
 - `warning` is useful for CI when warnings, including lint directive warnings, should fail the run
 - `none` keeps diagnostics visible without failing the process
-
-For lint rule configuration and directive details, see the [`uroborosql-lint` README](../uroborosql-lint/README.md).

--- a/crates/uroborosql-lint-cli/README.md
+++ b/crates/uroborosql-lint-cli/README.md
@@ -6,6 +6,7 @@ CLI crate for `uroborosql-lint`. The installed binary name is `uroborosql-lint`.
 
 ```bash
 uroborosql-lint [OPTIONS] <INPUT>
+uroborosql-lint init
 ```
 
 Examples:
@@ -14,7 +15,17 @@ Examples:
 uroborosql-lint query.sql
 uroborosql-lint --config .uroborosqllintrc.json query.sql
 uroborosql-lint --fail-level warning query.sql
+uroborosql-lint init
 ```
+
+If no lint config can be resolved, the CLI exits successfully without emitting diagnostics and prints
+guidance to create one. Create `.uroborosqllintrc.json` in the current working directory, run
+`uroborosql-lint init`, or pass `--config`, to enable linting.
+
+### Init
+
+Use `uroborosql-lint init` to create a starter `.uroborosqllintrc.json` in the current working
+directory. If the file already exists, the command fails without overwriting it.
 
 ### Exit Codes
 

--- a/crates/uroborosql-lint-cli/README.md
+++ b/crates/uroborosql-lint-cli/README.md
@@ -2,6 +2,29 @@
 
 CLI crate for `uroborosql-lint`. The installed binary name is `uroborosql-lint`.
 
+## Getting Started
+
+`uroborosql-lint` only runs when a lint config file can be resolved.
+
+### 1. Create a starter config file
+
+```bash
+uroborosql-lint --init
+```
+
+This creates `.uroborosqllintrc.json` in the current working directory.
+
+### 2. Run lint
+
+```bash
+uroborosql-lint query.sql
+```
+
+You can also create `.uroborosqllintrc.json` manually or pass a config path with `--config`.
+
+For config file structure, rule settings, and directive details, see the
+[`uroborosql-lint` README](../uroborosql-lint/README.md).
+
 ## Usage
 
 ```bash
@@ -19,11 +42,7 @@ uroborosql-lint --init
 ```
 
 If no lint config can be resolved, the CLI exits with an execution error and prints guidance to
-create one. Create `.uroborosqllintrc.json` in the current working directory, run
-`uroborosql-lint --init`, or pass `--config`, to enable linting.
-
-For config file structure, rule settings, and directive details, see the
-[`uroborosql-lint` README](../uroborosql-lint/README.md).
+create one.
 
 ### Init
 

--- a/crates/uroborosql-lint-cli/src/app.rs
+++ b/crates/uroborosql-lint-cli/src/app.rs
@@ -2,7 +2,9 @@ use std::{env, fs, path::PathBuf};
 
 use uroborosql_lint::{ConfigStore, Diagnostic, LintError, Linter, Severity};
 
-use crate::args::Cli;
+use crate::args::{Cli, Command, LintArgs};
+
+const DEFAULT_CONFIG_CONTENTS: &str = "{}\n";
 
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -44,17 +46,39 @@ impl CliError {
 }
 
 pub fn run(cli: Cli) -> Result<(), CliError> {
+    if let Some(command) = cli.command {
+        return match command {
+            Command::Init => run_init(),
+        };
+    }
+
+    run_lint(cli.lint)
+}
+
+fn run_lint(args: LintArgs) -> Result<(), CliError> {
     let linter = Linter::new();
     let cwd = env::current_dir()
         .map_err(|err| CliError::execution(format!("Failed to get cwd: {err}")))?;
-    let path = resolve_input_path(cli.input, &cwd)?;
+    let input = args.input.ok_or_else(|| {
+        CliError::execution(
+            "Missing input SQL file. Provide <INPUT> or run `uroborosql-lint init`.",
+        )
+    })?;
+    let path = resolve_input_path(input, &cwd)?;
     let display = path.display().to_string();
 
     let sql = fs::read_to_string(&path)
         .map_err(|err| CliError::execution(format!("Failed to read {}: {}", display, err)))?;
 
-    let config_store = ConfigStore::new(cwd, cli.config)
+    let config_store = ConfigStore::try_new(cwd, args.config)
         .map_err(|err| CliError::execution(format!("Failed to load config: {err}")))?;
+
+    let Some(config_store) = config_store else {
+        eprintln!(
+            "No lint config found. Create .uroborosqllintrc.json or run `uroborosql-lint init`."
+        );
+        return Ok(());
+    };
 
     if config_store.is_ignored(&path) {
         return Ok(());
@@ -66,7 +90,7 @@ pub fn run(cli: Cli) -> Result<(), CliError> {
         Ok(diagnostics) => {
             let should_fail = diagnostics
                 .iter()
-                .any(|diagnostic| cli.fail_level.matches(diagnostic.severity));
+                .any(|diagnostic| args.fail_level.matches(diagnostic.severity));
 
             for diagnostic in &diagnostics {
                 print_diagnostic(&display, diagnostic);
@@ -84,6 +108,30 @@ pub fn run(cli: Cli) -> Result<(), CliError> {
         }
     }
 
+    Ok(())
+}
+
+fn run_init() -> Result<(), CliError> {
+    let cwd = env::current_dir()
+        .map_err(|err| CliError::execution(format!("Failed to get cwd: {err}")))?;
+    let config_path = cwd.join(uroborosql_lint::DEFAULT_CONFIG_FILENAME);
+
+    if config_path.exists() {
+        return Err(CliError::execution(format!(
+            "Config already exists at {}.",
+            config_path.display()
+        )));
+    }
+
+    fs::write(&config_path, DEFAULT_CONFIG_CONTENTS).map_err(|err| {
+        CliError::execution(format!(
+            "Failed to write {}: {}",
+            config_path.display(),
+            err
+        ))
+    })?;
+
+    println!("Created {}", config_path.display());
     Ok(())
 }
 

--- a/crates/uroborosql-lint-cli/src/app.rs
+++ b/crates/uroborosql-lint-cli/src/app.rs
@@ -74,10 +74,9 @@ fn run_lint(args: LintArgs) -> Result<(), CliError> {
         .map_err(|err| CliError::execution(format!("Failed to load config: {err}")))?;
 
     let Some(config_store) = config_store else {
-        eprintln!(
-            "No lint config found. Create .uroborosqllintrc.json or run `uroborosql-lint init`."
-        );
-        return Ok(());
+        return Err(CliError::execution(
+            "No lint config found. Create .uroborosqllintrc.json or run `uroborosql-lint init`.",
+        ));
     };
 
     if config_store.is_ignored(&path) {

--- a/crates/uroborosql-lint-cli/src/app.rs
+++ b/crates/uroborosql-lint-cli/src/app.rs
@@ -2,7 +2,7 @@ use std::{env, fs, path::PathBuf};
 
 use uroborosql_lint::{ConfigStore, Diagnostic, LintError, Linter, Severity};
 
-use crate::args::{Cli, Command, LintArgs};
+use crate::args::Cli;
 
 const DEFAULT_CONFIG_CONTENTS: &str = "{}\n";
 
@@ -46,24 +46,20 @@ impl CliError {
 }
 
 pub fn run(cli: Cli) -> Result<(), CliError> {
-    if let Some(command) = cli.command {
-        return match command {
-            Command::Init => run_init(),
-        };
+    if cli.init {
+        return run_init();
     }
 
-    run_lint(cli.lint)
+    run_lint(cli)
 }
 
-fn run_lint(args: LintArgs) -> Result<(), CliError> {
+fn run_lint(args: Cli) -> Result<(), CliError> {
     let linter = Linter::new();
     let cwd = env::current_dir()
         .map_err(|err| CliError::execution(format!("Failed to get cwd: {err}")))?;
-    let input = args.input.ok_or_else(|| {
-        CliError::execution(
-            "Missing input SQL file. Provide <INPUT> or run `uroborosql-lint init`.",
-        )
-    })?;
+    let input = args
+        .input
+        .expect("clap should require <INPUT> unless --init is set");
     let path = resolve_input_path(input, &cwd)?;
     let display = path.display().to_string();
 
@@ -75,7 +71,7 @@ fn run_lint(args: LintArgs) -> Result<(), CliError> {
 
     let Some(config_store) = config_store else {
         return Err(CliError::execution(
-            "No lint config found. Create .uroborosqllintrc.json or run `uroborosql-lint init`.",
+            "No lint config found. Create .uroborosqllintrc.json or run `uroborosql-lint --init`.",
         ));
     };
 

--- a/crates/uroborosql-lint-cli/src/args.rs
+++ b/crates/uroborosql-lint-cli/src/args.rs
@@ -1,33 +1,17 @@
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{Parser, ValueEnum};
 use uroborosql_lint::Severity;
 
 #[derive(Parser, Debug)]
-#[command(
-    name = "uroborosql-lint",
-    version,
-    about = "SQL linter",
-    args_conflicts_with_subcommands = true,
-    subcommand_negates_reqs = true
-)]
+#[command(name = "uroborosql-lint", version, about = "SQL linter")]
 pub struct Cli {
-    #[command(subcommand)]
-    pub command: Option<Command>,
-
-    #[command(flatten)]
-    pub lint: LintArgs,
-}
-
-#[derive(Subcommand, Debug)]
-pub enum Command {
     /// Create a starter lint config file in the current working directory
-    Init,
-}
+    #[arg(long, conflicts_with_all = ["config", "fail_level", "input"])]
+    pub init: bool,
 
-#[derive(Args, Debug)]
-pub struct LintArgs {
     /// Input SQL file
+    #[arg(required_unless_present = "init")]
     pub input: Option<PathBuf>,
 
     /// Path to configuration file

--- a/crates/uroborosql-lint-cli/src/args.rs
+++ b/crates/uroborosql-lint-cli/src/args.rs
@@ -1,13 +1,34 @@
 use std::path::PathBuf;
 
-use clap::{Parser, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use uroborosql_lint::Severity;
 
 #[derive(Parser, Debug)]
-#[command(name = "uroborosql-lint", version, about = "SQL linter")]
+#[command(
+    name = "uroborosql-lint",
+    version,
+    about = "SQL linter",
+    args_conflicts_with_subcommands = true,
+    subcommand_negates_reqs = true
+)]
 pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+
+    #[command(flatten)]
+    pub lint: LintArgs,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Create a starter lint config file in the current working directory
+    Init,
+}
+
+#[derive(Args, Debug)]
+pub struct LintArgs {
     /// Input SQL file
-    pub input: PathBuf,
+    pub input: Option<PathBuf>,
 
     /// Path to configuration file
     #[arg(long, value_name = "FILE")]

--- a/crates/uroborosql-lint-cli/tests/cli.rs
+++ b/crates/uroborosql-lint-cli/tests/cli.rs
@@ -9,13 +9,32 @@ fn write_sql(temp: &TempDir, name: &str, sql: &str) -> ChildPath {
 }
 
 #[test]
-fn warning_does_not_fail_by_default() {
+fn missing_config_is_noop_by_default() {
     let temp = TempDir::new().expect("tempdir");
     let input = write_sql(&temp, "query.sql", "SELECT DISTINCT id FROM users;");
 
     Command::cargo_bin("uroborosql-lint")
         .expect("cargo_bin")
         .current_dir(temp.path())
+        .arg(input.path())
+        .assert()
+        .code(0)
+        .stdout("")
+        .stderr(contains("No lint config found"));
+}
+
+#[test]
+fn explicit_config_emits_warning_by_default() {
+    let temp = TempDir::new().expect("tempdir");
+    let input = write_sql(&temp, "query.sql", "SELECT DISTINCT id FROM users;");
+    let config = temp.child(".uroborosqllintrc.json");
+    config.write_str("{}").expect("write config");
+
+    Command::cargo_bin("uroborosql-lint")
+        .expect("cargo_bin")
+        .current_dir(temp.path())
+        .arg("--fail-level")
+        .arg("error")
         .arg(input.path())
         .assert()
         .code(0)
@@ -26,6 +45,8 @@ fn warning_does_not_fail_by_default() {
 fn warning_fails_with_fail_level_warning() {
     let temp = TempDir::new().expect("tempdir");
     let input = write_sql(&temp, "query.sql", "SELECT DISTINCT id FROM users;");
+    let config = temp.child(".uroborosqllintrc.json");
+    config.write_str("{}").expect("write config");
 
     Command::cargo_bin("uroborosql-lint")
         .expect("cargo_bin")
@@ -70,6 +91,8 @@ fn invalid_directive_warning_does_not_fail_by_default() {
         "query.sql",
         "-- uroborosql-lint-disable definitely-not-a-rule\nSELECT 1;\n",
     );
+    let config = temp.child(".uroborosqllintrc.json");
+    config.write_str("{}").expect("write config");
 
     Command::cargo_bin("uroborosql-lint")
         .expect("cargo_bin")
@@ -88,6 +111,8 @@ fn invalid_directive_warning_fails_with_fail_level_warning() {
         "query.sql",
         "-- uroborosql-lint-disable definitely-not-a-rule\nSELECT 1;\n",
     );
+    let config = temp.child(".uroborosqllintrc.json");
+    config.write_str("{}").expect("write config");
 
     Command::cargo_bin("uroborosql-lint")
         .expect("cargo_bin")
@@ -101,9 +126,61 @@ fn invalid_directive_warning_fails_with_fail_level_warning() {
 }
 
 #[test]
-fn parse_failure_returns_execution_error() {
+fn parse_failure_is_noop_without_config() {
     let temp = TempDir::new().expect("tempdir");
     let input = write_sql(&temp, "query.sql", "SELECT FROM");
+
+    Command::cargo_bin("uroborosql-lint")
+        .expect("cargo_bin")
+        .current_dir(temp.path())
+        .arg(input.path())
+        .assert()
+        .code(0)
+        .stdout("")
+        .stderr(contains("No lint config found"));
+}
+
+#[test]
+fn init_creates_default_config_file() {
+    let temp = TempDir::new().expect("tempdir");
+    let config = temp.child(".uroborosqllintrc.json");
+
+    Command::cargo_bin("uroborosql-lint")
+        .expect("cargo_bin")
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .code(0)
+        .stdout(contains("Created"));
+
+    config.assert("{}\n");
+}
+
+#[test]
+fn init_does_not_overwrite_existing_file() {
+    let temp = TempDir::new().expect("tempdir");
+    let config = temp.child(".uroborosqllintrc.json");
+    config
+        .write_str("{\n  \"rules\": {}\n}\n")
+        .expect("write config");
+
+    Command::cargo_bin("uroborosql-lint")
+        .expect("cargo_bin")
+        .current_dir(temp.path())
+        .arg("init")
+        .assert()
+        .code(2)
+        .stderr(contains("Config already exists"));
+
+    config.assert("{\n  \"rules\": {}\n}\n");
+}
+
+#[test]
+fn parse_failure_returns_execution_error_when_config_is_present() {
+    let temp = TempDir::new().expect("tempdir");
+    let input = write_sql(&temp, "query.sql", "SELECT FROM");
+    let config = temp.child(".uroborosqllintrc.json");
+    config.write_str("{}").expect("write config");
 
     Command::cargo_bin("uroborosql-lint")
         .expect("cargo_bin")

--- a/crates/uroborosql-lint-cli/tests/cli.rs
+++ b/crates/uroborosql-lint-cli/tests/cli.rs
@@ -148,7 +148,7 @@ fn init_creates_default_config_file() {
     Command::cargo_bin("uroborosql-lint")
         .expect("cargo_bin")
         .current_dir(temp.path())
-        .arg("init")
+        .arg("--init")
         .assert()
         .code(0)
         .stdout(contains("Created"));
@@ -167,12 +167,27 @@ fn init_does_not_overwrite_existing_file() {
     Command::cargo_bin("uroborosql-lint")
         .expect("cargo_bin")
         .current_dir(temp.path())
-        .arg("init")
+        .arg("--init")
         .assert()
         .code(2)
         .stderr(contains("Config already exists"));
 
     config.assert("{\n  \"rules\": {}\n}\n");
+}
+
+#[test]
+fn init_conflicts_with_input() {
+    let temp = TempDir::new().expect("tempdir");
+    let input = write_sql(&temp, "query.sql", "SELECT 1;");
+
+    Command::cargo_bin("uroborosql-lint")
+        .expect("cargo_bin")
+        .current_dir(temp.path())
+        .arg("--init")
+        .arg(input.path())
+        .assert()
+        .code(2)
+        .stderr(contains("cannot be used with"));
 }
 
 #[test]

--- a/crates/uroborosql-lint-cli/tests/cli.rs
+++ b/crates/uroborosql-lint-cli/tests/cli.rs
@@ -9,7 +9,7 @@ fn write_sql(temp: &TempDir, name: &str, sql: &str) -> ChildPath {
 }
 
 #[test]
-fn missing_config_is_noop_by_default() {
+fn missing_config_returns_execution_error() {
     let temp = TempDir::new().expect("tempdir");
     let input = write_sql(&temp, "query.sql", "SELECT DISTINCT id FROM users;");
 
@@ -18,7 +18,7 @@ fn missing_config_is_noop_by_default() {
         .current_dir(temp.path())
         .arg(input.path())
         .assert()
-        .code(0)
+        .code(2)
         .stdout("")
         .stderr(contains("No lint config found"));
 }
@@ -126,7 +126,7 @@ fn invalid_directive_warning_fails_with_fail_level_warning() {
 }
 
 #[test]
-fn parse_failure_is_noop_without_config() {
+fn parse_failure_returns_missing_config_error_without_config() {
     let temp = TempDir::new().expect("tempdir");
     let input = write_sql(&temp, "query.sql", "SELECT FROM");
 
@@ -135,7 +135,7 @@ fn parse_failure_is_noop_without_config() {
         .current_dir(temp.path())
         .arg(input.path())
         .assert()
-        .code(0)
+        .code(2)
         .stdout("")
         .stderr(contains("No lint config found"));
 }

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -2,17 +2,7 @@
 
 Lint engine and rule/configuration crate for `uroborosql-lint`.
 
-For CLI usage, exit codes, and `--fail-level`, see the [`uroborosql-lint-cli` README](../uroborosql-lint-cli/README.md).
-
-## Getting Started
-
-The default config file name is `.uroborosqllintrc.json`.
-
-If you use the CLI, you can create a starter config with:
-
-```bash
-uroborosql-lint --init
-```
+For CLI usage, see the [`uroborosql-lint-cli` README](../uroborosql-lint-cli/README.md).
 
 ## Configuration
 

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -11,7 +11,7 @@ The default config file name is `.uroborosqllintrc.json`.
 If you use the CLI, you can create a starter config with:
 
 ```bash
-uroborosql-lint init
+uroborosql-lint --init
 ```
 
 ## Configuration

--- a/crates/uroborosql-lint/README.md
+++ b/crates/uroborosql-lint/README.md
@@ -4,41 +4,19 @@ Lint engine and rule/configuration crate for `uroborosql-lint`.
 
 For CLI usage, exit codes, and `--fail-level`, see the [`uroborosql-lint-cli` README](../uroborosql-lint-cli/README.md).
 
-## Configuration
+## Getting Started
 
 The default config file name is `.uroborosqllintrc.json`.
 
-## Directive Comments
+If you use the CLI, you can create a starter config with:
 
-Line comment directives can suppress specific lint rules directly in SQL.
-
-Supported directives:
-
-- `-- uroborosql-lint-disable <rules>`
-- `-- uroborosql-lint-disable-next-line <rules>`
-
-Rules must be comma-separated canonical rule names such as `no-distinct` or `no-wildcard-projection`.
-
-Example:
-
-```sql
--- uroborosql-lint-disable no-distinct
-SELECT DISTINCT id FROM users;
+```bash
+uroborosql-lint init
 ```
 
-```sql
--- uroborosql-lint-disable-next-line no-distinct, no-wildcard-projection
-SELECT DISTINCT * FROM users;
-```
+## Configuration
 
-Behavior:
-
-- `disable-next-line` suppresses diagnostics whose start position is on the next physical line only
-- `disable` suppresses rules for the whole file, but only when it appears in the file head comment section
-- The file head comment section is the leading sequence of blank lines and line comments
-- A block comment ends that file head section, so any later `disable` directive is ignored
-- Unknown rule names in directives produce an `invalid-lint-directive` warning on the comment, while known rules in the same directive still apply
-- Missing rule names, empty comma-separated elements, and trailing commas also produce an `invalid-lint-directive` warning
+The config file supports rule levels, file ignores, per-file overrides, and future schema-aware settings.
 
 Example:
 
@@ -64,17 +42,19 @@ Example:
 }
 ```
 
+### Rule Levels
+
+Rule severities can be configured with:
+
+- `off` / `"0"` / `0`
+- `warn` / `warning` / `"1"` / `1`
+- `error` / `"2"` / `2`
+
 ### `rules`
 
 Configures the severity for each rule.
 
 Unknown rule names are reported as configuration errors.
-
-Supported values:
-
-- `off` / `"0"` / `0`
-- `warn` / `warning` / `"1"` / `1`
-- `error` / `"2"` / `2`
 
 ### `ignore`
 
@@ -134,3 +114,35 @@ Examples:
 
 - `ignore` and `overrides.files` are resolved relative to the current working directory
 - `db.path` is resolved relative to the directory containing the loaded config file
+
+## Directive Comments
+
+Line comment directives can suppress specific lint rules directly in SQL.
+
+Supported directives:
+
+- `-- uroborosql-lint-disable <rules>`
+- `-- uroborosql-lint-disable-next-line <rules>`
+
+Rules must be comma-separated canonical rule names such as `no-distinct` or `no-wildcard-projection`.
+
+Examples:
+
+```sql
+-- uroborosql-lint-disable no-distinct
+SELECT DISTINCT id FROM users;
+```
+
+```sql
+-- uroborosql-lint-disable-next-line no-distinct, no-wildcard-projection
+SELECT DISTINCT * FROM users;
+```
+
+Behavior:
+
+- `disable-next-line` suppresses diagnostics whose start position is on the next physical line only
+- `disable` suppresses rules for the whole file, but only when it appears in the file head comment section
+- The file head comment section is the leading sequence of blank lines and line comments
+- A block comment ends that file head section, so any later `disable` directive is ignored
+- Unknown rule names in directives produce an `invalid-lint-directive` warning on the comment, while known rules in the same directive still apply
+- Missing rule names, empty comma-separated elements, and trailing commas also produce an `invalid-lint-directive` warning

--- a/crates/uroborosql-lint/src/config/config_store.rs
+++ b/crates/uroborosql-lint/src/config/config_store.rs
@@ -82,6 +82,29 @@ pub enum ConfigError {
 }
 
 impl ConfigStore {
+    pub fn try_new(
+        root_dir: impl Into<PathBuf>,
+        config_path: Option<PathBuf>,
+    ) -> Result<Option<Self>, ConfigError> {
+        let root_dir = root_dir.into();
+        let Some(config_path) = resolve_existing_config_path(&root_dir, config_path)? else {
+            return Ok(None);
+        };
+
+        let loaded_config = load_config(&root_dir, Some(config_path))?;
+        let config_base_dir = loaded_config
+            .origin
+            .as_deref()
+            .and_then(Path::parent)
+            .unwrap_or(&root_dir);
+        let unresolved_config =
+            LintConfig::from_lint_config_object(loaded_config.config, config_base_dir)?;
+        Ok(Some(Self {
+            root_dir,
+            unresolved_config,
+        }))
+    }
+
     pub fn new(
         root_dir: impl Into<PathBuf>,
         config_path: Option<PathBuf>,
@@ -159,6 +182,34 @@ impl ConfigStore {
     pub fn root_dir(&self) -> &Path {
         &self.root_dir
     }
+}
+
+fn resolve_existing_config_path(
+    root_dir: &Path,
+    config_path: Option<PathBuf>,
+) -> Result<Option<PathBuf>, ConfigError> {
+    if let Some(path) = config_path {
+        let path = if path.is_absolute() {
+            path
+        } else {
+            root_dir.join(path)
+        };
+
+        return path
+            .canonicalize()
+            .map(Some)
+            .map_err(|err| ConfigError::Io(path, err));
+    }
+
+    let path = root_dir.join(DEFAULT_CONFIG_FILENAME);
+    if path.exists() {
+        return path
+            .canonicalize()
+            .map(Some)
+            .map_err(|err| ConfigError::Io(path, err));
+    }
+
+    Ok(None)
 }
 
 impl LintConfig {

--- a/crates/uroborosql-lint/src/config/config_store.rs
+++ b/crates/uroborosql-lint/src/config/config_store.rs
@@ -105,38 +105,6 @@ impl ConfigStore {
         }))
     }
 
-    pub fn new(
-        root_dir: impl Into<PathBuf>,
-        config_path: Option<PathBuf>,
-    ) -> Result<Self, ConfigError> {
-        let root_dir = root_dir.into();
-        let config_path = config_path
-            .map(|path| {
-                if path.is_absolute() {
-                    path
-                } else {
-                    root_dir.join(path)
-                }
-            })
-            .map(|path| {
-                path.canonicalize()
-                    .map_err(|err| ConfigError::Io(path, err))
-            })
-            .transpose()?;
-        let loaded_config = load_config(&root_dir, config_path)?;
-        let config_base_dir = loaded_config
-            .origin
-            .as_deref()
-            .and_then(Path::parent)
-            .unwrap_or(&root_dir);
-        let unresolved_config =
-            LintConfig::from_lint_config_object(loaded_config.config, config_base_dir)?;
-        Ok(Self {
-            root_dir,
-            unresolved_config,
-        })
-    }
-
     pub fn resolve(&self, file: &Path) -> ResolvedLintConfig {
         let rel_path = file.strip_prefix(&self.root_dir).unwrap_or(file);
         let mut rules = self.unresolved_config.rules.clone();

--- a/crates/uroborosql-lint/tests/config_store.rs
+++ b/crates/uroborosql-lint/tests/config_store.rs
@@ -29,7 +29,9 @@ fn reads_config_from_root_file() {
 }"#,
     );
 
-    let store = ConfigStore::new(temp.path().to_path_buf(), None).expect("config store");
+    let store = ConfigStore::try_new(temp.path().to_path_buf(), None)
+        .expect("config store")
+        .expect("store should exist");
     let state = store.resolve(&temp.path().join("src/query.sql"));
 
     assert_eq!(
@@ -90,7 +92,9 @@ fn applies_overrides_by_path() {
 }"#,
     );
 
-    let store = ConfigStore::new(temp.path().to_path_buf(), None).expect("config store");
+    let store = ConfigStore::try_new(temp.path().to_path_buf(), None)
+        .expect("config store")
+        .expect("store should exist");
     let state_src = store.resolve(&temp.path().join("src/main.sql"));
     let state_test = store.resolve(&temp.path().join("test/case.sql"));
 
@@ -111,7 +115,9 @@ fn ignores_paths_matching_ignore_globs() {
 }"#,
     );
 
-    let store = ConfigStore::new(temp.path().to_path_buf(), None).expect("config store");
+    let store = ConfigStore::try_new(temp.path().to_path_buf(), None)
+        .expect("config store")
+        .expect("store should exist");
 
     assert!(store.is_ignored(&temp.path().join("dist/app.sql")));
     assert!(!store.is_ignored(&temp.path().join("src/app.sql")));
@@ -152,7 +158,9 @@ fn keeps_cwd_as_root_dir_for_explicit_config() {
     );
 
     let config_path = config_root.join(DEFAULT_CONFIG_FILENAME);
-    let store = ConfigStore::new(cwd.clone(), Some(config_path)).expect("config store");
+    let store = ConfigStore::try_new(cwd.clone(), Some(config_path))
+        .expect("config store")
+        .expect("store should exist");
 
     assert_eq!(store.root_dir(), cwd.as_path());
     assert!(store.is_ignored(&dist_file.canonicalize().expect("canonicalize dist file")));
@@ -185,7 +193,9 @@ fn resolves_db_file_path_relative_to_explicit_config() {
     );
 
     let config_path = config_root.join(DEFAULT_CONFIG_FILENAME);
-    let store = ConfigStore::new(cwd, Some(config_path)).expect("config store");
+    let store = ConfigStore::try_new(cwd, Some(config_path))
+        .expect("config store")
+        .expect("store should exist");
     let state = store.resolve(temp_root.join("anywhere/query.sql").as_path());
 
     let db = state.db.expect("resolved db config");
@@ -208,7 +218,8 @@ fn rejects_unknown_rule_in_root_rules() {
 }"#,
     );
 
-    let err = ConfigStore::new(temp.path().to_path_buf(), None).expect_err("unknown rule error");
+    let err =
+        ConfigStore::try_new(temp.path().to_path_buf(), None).expect_err("unknown rule error");
 
     assert!(matches!(
         err,
@@ -241,7 +252,8 @@ fn rejects_unknown_rule_in_override_rules() {
 }"#,
     );
 
-    let err = ConfigStore::new(temp.path().to_path_buf(), None).expect_err("unknown rule error");
+    let err =
+        ConfigStore::try_new(temp.path().to_path_buf(), None).expect_err("unknown rule error");
 
     assert!(matches!(
         err,

--- a/crates/uroborosql-lint/tests/config_store.rs
+++ b/crates/uroborosql-lint/tests/config_store.rs
@@ -39,6 +39,38 @@ fn reads_config_from_root_file() {
 }
 
 #[test]
+fn try_new_returns_none_when_default_config_is_missing() {
+    let temp = tempdir().expect("tempdir");
+
+    let store = ConfigStore::try_new(temp.path().to_path_buf(), None).expect("config store");
+
+    assert!(store.is_none());
+}
+
+#[test]
+fn try_new_returns_store_when_default_config_exists() {
+    let temp = tempdir().expect("tempdir");
+    write_config(
+        temp.path(),
+        r#"{
+  "rules": {
+    "no-distinct": "error"
+  }
+}"#,
+    );
+
+    let store = ConfigStore::try_new(temp.path().to_path_buf(), None)
+        .expect("config store")
+        .expect("store should exist");
+    let state = store.resolve(&temp.path().join("src/query.sql"));
+
+    assert_eq!(
+        severity_for_rule(&state, "no-distinct"),
+        Some(Severity::Error)
+    );
+}
+
+#[test]
 fn applies_overrides_by_path() {
     let temp = tempdir().expect("tempdir");
     write_config(


### PR DESCRIPTION

## Summary

`uroborosql-lint` の lint 実行条件を見直し、lint 設定ファイルがある場合にだけ lint を有効化するようにしました。

lint 機能をオプトインにすることで、 （特に VS Code 拡張のユーザが）意図せず lint の警告に遭遇することを防ぎます。あわせて CLI には設定ファイル作成の導線として `--init` オプションを追加し、README も整理しました。

## Changes

- `ConfigStore::try_new(...)` を追加し、lint 設定ファイル未検出を `None` として扱うように変更
- `uroborosql-lint-cli` は lint 設定ファイルがない場合は実行エラー終了とし、設定ファイルの作成方法を案内するように変更
- `uroborosql-lint --init` を追加し、`.uroborosqllintrc.json` のひな形を生成可能に変更
- language server は lint 設定ファイルが解決できない場合に lint を実行せず、空 diagnostics を publish するよう変更
- `uroborosql-lint` / `uroborosql-lint-cli` / `uroborosql-language-server` のテストを新しい挙動に合わせて更新
- `uroborosql-lint` / `uroborosql-lint-cli` / `uroborosql-language-server` の README を更新

## Reason

これまでの挙動だと、lint 設定ファイルが存在しなくても built-in のルールで lint が動作するため、lint を使う意思表示がない状態でも警告が発生しうる状態になっていました。

今回の変更では、 lint を使う意思表示を lint 設定ファイルの存在で判定する方針で CLI / Language server の挙動を整理しています。

## Behaviour

### lint 設定ファイルがある場合

- CLI は従来どおり lint を実行
- language server は diagnostics / quick fix を提供

### lint 設定ファイルがない場合

- CLI は実行エラー終了し、次のメッセージを表示

```text
No lint config found. Create .uroborosqllintrc.json or run `uroborosql-lint --init`.
```
- language server は lint を実行せず、空 diagnostics を publish

### 明示的に存在しない config を指定した場合

- 従来どおり設定読み込みエラー

## Notes

- lint README は `Getting Started` / `Configuration` / `Directive Comments` の順に整理し、導線を分離
- CLI README には config の詳細説明先として `uroborosql-lint` README へのリンクを追加
