### PR TITLE
fix: report SQL parse errors at their actual location

### DIFF
--- a/crates/uroborosql-language-server/src/document.rs
+++ b/crates/uroborosql-language-server/src/document.rs
@@ -38,6 +38,12 @@ pub(crate) fn rope_char_index_to_position(rope: &Rope, idx: usize) -> Position {
     Position::new(line as u32, utf16_col as u32)
 }
 
+/// Converts a byte offset to a UTF-16 position. An out-of-range byte is clamped to the end.
+pub(crate) fn rope_byte_to_position(rope: &Rope, byte: usize) -> Position {
+    let clamped = byte.min(rope.len_bytes());
+    rope_char_index_to_position(rope, rope.byte_to_char(clamped))
+}
+
 pub(crate) fn rope_range_to_char_index_range(rope: &Rope, range: &Range) -> Option<(usize, usize)> {
     let start = rope_position_to_char_index(rope, range.start)?;
     let end = rope_position_to_char_index(rope, range.end)?;

--- a/crates/uroborosql-language-server/src/lint.rs
+++ b/crates/uroborosql-language-server/src/lint.rs
@@ -118,23 +118,21 @@ fn to_lsp_diagnostic(diag: SqlDiagnostic, rope: Option<&ropey::Rope>) -> Diagnos
 fn to_parse_error(err: LintError, rope: Option<&ropey::Rope>) -> Diagnostic {
     let LintError::ParseError { message, span } = err;
 
-    let range = match rope {
-        Some(rope) => match span {
-            Some(span) => {
-                let start = rope_byte_to_position(rope, span.start_byte);
-                let end = rope_byte_to_position(rope, span.end_byte);
-                Range { start, end }
+    let range = match (rope, span) {
+        (Some(rope), Some(span)) => {
+            let start = rope_byte_to_position(rope, span.start_byte);
+            let end = rope_byte_to_position(rope, span.end_byte);
+            Range { start, end }
+        }
+        // Unknown position: point at the end of the file (zero-width range).
+        (Some(rope), None) => {
+            let eof = rope_char_index_to_position(rope, rope.len_chars());
+            Range {
+                start: eof,
+                end: eof,
             }
-            // Unknown position: point at the end of the file (zero-width range).
-            None => {
-                let eof = rope_char_index_to_position(rope, rope.len_chars());
-                Range {
-                    start: eof,
-                    end: eof,
-                }
-            }
-        },
-        None => Range::default(),
+        }
+        (None, _) => Range::default(),
     };
 
     Diagnostic {

--- a/crates/uroborosql-language-server/src/lint.rs
+++ b/crates/uroborosql-language-server/src/lint.rs
@@ -10,7 +10,7 @@ use uroborosql_lint::{
 
 use crate::Backend;
 use crate::configuration::resolve_config_path;
-use crate::document::rope_char_index_to_position;
+use crate::document::{rope_byte_to_position, rope_char_index_to_position};
 use crate::paths::file_uri_to_path;
 
 impl Backend {
@@ -61,15 +61,23 @@ impl Backend {
         }
 
         let resolved_config = config_store.resolve(&path);
+        let rope = self.document_rope(uri);
+        if rope.is_none() {
+            // lint_and_publish is always called with the document already tracked,
+            // so a missing rope means the document store lock is poisoned.
+            self.client
+                .log_message(
+                    MessageType::WARNING,
+                    "document rope is unavailable; diagnostic positions may be imprecise",
+                )
+                .await;
+        }
         let diagnostics = match self.linter.run(text, &resolved_config) {
-            Ok(diags) => {
-                let rope = self.document_rope(uri);
-                diags
-                    .into_iter()
-                    .map(|diag| to_lsp_diagnostic(diag, rope.as_ref()))
-                    .collect()
-            }
-            Err(err) => vec![to_parse_error(err)],
+            Ok(diags) => diags
+                .into_iter()
+                .map(|diag| to_lsp_diagnostic(diag, rope.as_ref()))
+                .collect(),
+            Err(err) => vec![to_parse_error(err, rope.as_ref())],
         };
 
         self.client
@@ -87,8 +95,8 @@ fn to_lsp_diagnostic(diag: SqlDiagnostic, rope: Option<&ropey::Rope>) -> Diagnos
 
     let range = if let Some(rope) = rope {
         Range {
-            start: rope_char_index_to_position(rope, rope.byte_to_char(diag.span.start.byte)),
-            end: rope_char_index_to_position(rope, rope.byte_to_char(diag.span.end.byte)),
+            start: rope_byte_to_position(rope, diag.span.start.byte),
+            end: rope_byte_to_position(rope, diag.span.end.byte),
         }
     } else {
         Range {
@@ -107,16 +115,33 @@ fn to_lsp_diagnostic(diag: SqlDiagnostic, rope: Option<&ropey::Rope>) -> Diagnos
     }
 }
 
-fn to_parse_error(err: LintError) -> Diagnostic {
-    let message = match err {
-        LintError::ParseError(reason) => format!("Failed to parse SQL: {reason}"),
+fn to_parse_error(err: LintError, rope: Option<&ropey::Rope>) -> Diagnostic {
+    let LintError::ParseError { message, span } = err;
+
+    let range = match rope {
+        Some(rope) => match span {
+            Some(span) => {
+                let start = rope_byte_to_position(rope, span.start_byte);
+                let end = rope_byte_to_position(rope, span.end_byte);
+                Range { start, end }
+            }
+            // Unknown position: point at the end of the file (zero-width range).
+            None => {
+                let eof = rope_char_index_to_position(rope, rope.len_chars());
+                Range {
+                    start: eof,
+                    end: eof,
+                }
+            }
+        },
+        None => Range::default(),
     };
 
     Diagnostic {
-        range: Range::default(),
+        range,
         severity: Some(DiagnosticSeverity::ERROR),
         source: Some(LINT_SOURCE.into()),
-        message,
+        message: format!("Failed to parse SQL: {message}"),
         ..Diagnostic::default()
     }
 }

--- a/crates/uroborosql-language-server/tests/diagnostics.rs
+++ b/crates/uroborosql-language-server/tests/diagnostics.rs
@@ -125,6 +125,38 @@ async fn diagnostics_include_invalid_directive_warning() {
 }
 
 #[tokio::test]
+async fn parse_error_diagnostic_points_at_error_location() {
+    let mut server = new_test_server();
+    let root_dir =
+        initialize_server_with_default_lint_config(&mut server, "uroborosql-lsp-diag-parse-error")
+            .await;
+    let uri = Uri::from_file_path(root_dir.join("invalid.sql")).unwrap();
+
+    // Invalid SQL: the WHERE on line 2 has no condition, so it errors at end of input.
+    server
+        .send_request(build_did_open(&uri, "SELECT id\nFROM users WHERE", 1))
+        .await;
+    let diag_notification = server.receive_notification().await;
+    assert_eq!(diag_notification.method(), PublishDiagnostics::METHOD);
+
+    let diagnostics = diag_notification.params().unwrap()["diagnostics"]
+        .as_array()
+        .unwrap()
+        .clone();
+    assert_eq!(diagnostics.len(), 1);
+
+    let range = &diagnostics[0]["range"];
+    let start_line = range["start"]["line"].as_u64();
+    let start_character = range["start"]["character"].as_u64();
+    assert_eq!(start_line, Some(1));
+    assert_eq!(start_character, Some(16));
+    assert!(
+        !(start_line == Some(0) && start_character == Some(0)),
+        "parse error must not collapse to 0,0"
+    );
+}
+
+#[tokio::test]
 async fn diagnostics_are_empty_when_lint_config_is_missing() {
     let mut server = new_test_server();
     let root_dir = unique_temp_dir("uroborosql-lsp-diag-no-config");

--- a/crates/uroborosql-lint-cli/src/app.rs
+++ b/crates/uroborosql-lint-cli/src/app.rs
@@ -1,6 +1,6 @@
 use std::{env, fs, path::PathBuf};
 
-use uroborosql_lint::{ConfigStore, Diagnostic, LintError, Linter, Severity};
+use uroborosql_lint::{ConfigStore, Diagnostic, LintError, Linter, ParseErrorByteSpan, Severity};
 
 use crate::args::Cli;
 
@@ -95,10 +95,10 @@ fn run_lint(args: Cli) -> Result<(), CliError> {
                 return Err(CliError::issues_found());
             }
         }
-        Err(LintError::ParseError(message)) => {
+        Err(LintError::ParseError { message, span }) => {
+            let (line, column) = parse_error_line_column(&sql, span);
             return Err(CliError::execution(format!(
-                "{}: error: failed to parse SQL: {}",
-                display, message
+                "{display}:{line}:{column}: error: failed to parse SQL: {message}"
             )));
         }
     }
@@ -146,6 +146,26 @@ fn resolve_input_path(path: PathBuf, cwd: &std::path::Path) -> Result<PathBuf, C
     })
 }
 
+/// 位置不明（`span` が `None`）のときは入力末尾にフォールバックする。
+fn parse_error_line_column(sql: &str, span: Option<ParseErrorByteSpan>) -> (usize, usize) {
+    let byte = span.map_or(sql.len(), |span| span.start_byte);
+    byte_to_line_column(sql, byte)
+}
+
+/// 1-based の (line, column) を返す。column は文字数で数える。
+fn byte_to_line_column(sql: &str, byte: usize) -> (usize, usize) {
+    // char 境界・範囲外に対して安全になるよう、直近の境界まで丸める。
+    let mut boundary = byte.min(sql.len());
+    while !sql.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+
+    let prefix = &sql[..boundary];
+    let line = prefix.matches('\n').count() + 1;
+    let column = prefix.rsplit('\n').next().map_or(0, |s| s.chars().count()) + 1;
+    (line, column)
+}
+
 fn print_diagnostic(file: &str, diagnostic: &Diagnostic) {
     let line = diagnostic.span.start.line + 1;
     let column = diagnostic.span.start.column + 1;
@@ -172,7 +192,41 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use super::resolve_input_path;
+    use uroborosql_lint::ParseErrorByteSpan;
+
+    use super::{byte_to_line_column, parse_error_line_column, resolve_input_path};
+
+    #[test]
+    fn byte_to_line_column_is_one_based() {
+        let sql = "SELECT id\nFROM users";
+        assert_eq!(byte_to_line_column(sql, 0), (1, 1));
+        assert_eq!(byte_to_line_column(sql, 7), (1, 8));
+        assert_eq!(byte_to_line_column(sql, 10), (2, 1));
+    }
+
+    #[test]
+    fn byte_to_line_column_counts_columns_in_characters() {
+        let sql = "あいう x";
+        // `x` はマルチバイト 3 文字＋空白の後ろなので 5 文字目。
+        let byte = "あいう ".len();
+        assert_eq!(byte_to_line_column(sql, byte), (1, 5));
+    }
+
+    #[test]
+    fn parse_error_line_column_falls_back_to_end_of_input() {
+        let sql = "SELECT id\nFROM users";
+        assert_eq!(parse_error_line_column(sql, None), (2, 11));
+    }
+
+    #[test]
+    fn parse_error_line_column_uses_span_start() {
+        let sql = "SELECT 1 + ;";
+        let span = Some(ParseErrorByteSpan {
+            start_byte: 11,
+            end_byte: 12,
+        });
+        assert_eq!(parse_error_line_column(sql, span), (1, 12));
+    }
 
     #[test]
     fn resolves_relative_input_path_from_cwd() {

--- a/crates/uroborosql-lint-cli/src/app.rs
+++ b/crates/uroborosql-lint-cli/src/app.rs
@@ -1,6 +1,8 @@
 use std::{env, fs, path::PathBuf};
 
-use uroborosql_lint::{ConfigStore, Diagnostic, LintError, Linter, ParseErrorByteSpan, Severity};
+use uroborosql_lint::{
+    ConfigStore, Diagnostic, LintError, Linter, OneBasedPosition, ParseErrorByteSpan, Severity,
+};
 
 use crate::args::Cli;
 
@@ -96,9 +98,9 @@ fn run_lint(args: Cli) -> Result<(), CliError> {
             }
         }
         Err(LintError::ParseError { message, span }) => {
-            let (line, column) = parse_error_line_column(&sql, span);
+            let position = parse_error_position(&sql, span);
             return Err(CliError::execution(format!(
-                "{display}:{line}:{column}: error: failed to parse SQL: {message}"
+                "{display}:{position}: error: failed to parse SQL: {message}"
             )));
         }
     }
@@ -146,32 +148,17 @@ fn resolve_input_path(path: PathBuf, cwd: &std::path::Path) -> Result<PathBuf, C
     })
 }
 
-/// 位置不明（`span` が `None`）のときは入力末尾にフォールバックする。
-fn parse_error_line_column(sql: &str, span: Option<ParseErrorByteSpan>) -> (usize, usize) {
+/// Falls back to the end of input when the position is unknown (`span` is `None`).
+fn parse_error_position(sql: &str, span: Option<ParseErrorByteSpan>) -> OneBasedPosition {
     let byte = span.map_or(sql.len(), |span| span.start_byte);
-    byte_to_line_column(sql, byte)
-}
-
-/// 1-based の (line, column) を返す。column は文字数で数える。
-fn byte_to_line_column(sql: &str, byte: usize) -> (usize, usize) {
-    // char 境界・範囲外に対して安全になるよう、直近の境界まで丸める。
-    let mut boundary = byte.min(sql.len());
-    while !sql.is_char_boundary(boundary) {
-        boundary -= 1;
-    }
-
-    let prefix = &sql[..boundary];
-    let line = prefix.matches('\n').count() + 1;
-    let column = prefix.rsplit('\n').next().map_or(0, |s| s.chars().count()) + 1;
-    (line, column)
+    OneBasedPosition::from_byte_offset(sql, byte)
 }
 
 fn print_diagnostic(file: &str, diagnostic: &Diagnostic) {
-    let line = diagnostic.span.start.line + 1;
-    let column = diagnostic.span.start.column + 1;
+    let position = OneBasedPosition::from(diagnostic.span.start);
 
     println!(
-        "{file}:{line}:{column}: {severity_label}: {code}: {message}",
+        "{file}:{position}: {severity_label}: {code}: {message}",
         severity_label = severity_label(diagnostic.severity),
         code = diagnostic.code,
         message = diagnostic.message
@@ -192,40 +179,28 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use uroborosql_lint::ParseErrorByteSpan;
+    use uroborosql_lint::{OneBasedPosition, ParseErrorByteSpan};
 
-    use super::{byte_to_line_column, parse_error_line_column, resolve_input_path};
+    use super::{parse_error_position, resolve_input_path};
+
+    fn pos(line: usize, column: usize) -> OneBasedPosition {
+        OneBasedPosition { line, column }
+    }
 
     #[test]
-    fn byte_to_line_column_is_one_based() {
+    fn parse_error_position_falls_back_to_end_of_input() {
         let sql = "SELECT id\nFROM users";
-        assert_eq!(byte_to_line_column(sql, 0), (1, 1));
-        assert_eq!(byte_to_line_column(sql, 7), (1, 8));
-        assert_eq!(byte_to_line_column(sql, 10), (2, 1));
+        assert_eq!(parse_error_position(sql, None), pos(2, 11));
     }
 
     #[test]
-    fn byte_to_line_column_counts_columns_in_characters() {
-        let sql = "あいう x";
-        // `x` はマルチバイト 3 文字＋空白の後ろなので 5 文字目。
-        let byte = "あいう ".len();
-        assert_eq!(byte_to_line_column(sql, byte), (1, 5));
-    }
-
-    #[test]
-    fn parse_error_line_column_falls_back_to_end_of_input() {
-        let sql = "SELECT id\nFROM users";
-        assert_eq!(parse_error_line_column(sql, None), (2, 11));
-    }
-
-    #[test]
-    fn parse_error_line_column_uses_span_start() {
+    fn parse_error_position_uses_span_start() {
         let sql = "SELECT 1 + ;";
         let span = Some(ParseErrorByteSpan {
             start_byte: 11,
             end_byte: 12,
         });
-        assert_eq!(parse_error_line_column(sql, span), (1, 12));
+        assert_eq!(parse_error_position(sql, span), pos(1, 12));
     }
 
     #[test]

--- a/crates/uroborosql-lint/src/diagnostic.rs
+++ b/crates/uroborosql-lint/src/diagnostic.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use postgresql_cst_parser::tree_sitter::Range;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -12,6 +14,45 @@ pub struct Position {
     pub line: usize,
     pub column: usize,
     pub byte: usize,
+}
+
+/// 1-based position for display. The column counts characters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OneBasedPosition {
+    pub line: usize,
+    pub column: usize,
+}
+
+impl OneBasedPosition {
+    /// Locates the byte offset within `text`. The column counts characters.
+    ///
+    /// An out-of-range or non-boundary `byte` is rounded down to the nearest char boundary.
+    pub fn from_byte_offset(text: &str, byte: usize) -> Self {
+        let mut boundary = byte.min(text.len());
+        while !text.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
+
+        let prefix = &text[..boundary];
+        let line = prefix.matches('\n').count() + 1;
+        let column = prefix.rsplit('\n').next().map_or(0, |s| s.chars().count()) + 1;
+        Self { line, column }
+    }
+}
+
+impl From<Position> for OneBasedPosition {
+    fn from(position: Position) -> Self {
+        Self {
+            line: position.line + 1,
+            column: position.column + 1,
+        }
+    }
+}
+
+impl fmt::Display for OneBasedPosition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.line, self.column)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -58,5 +99,36 @@ impl Diagnostic {
             message: message.into(),
             span: SqlSpan::from_range(range),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OneBasedPosition;
+
+    fn pos(line: usize, column: usize) -> OneBasedPosition {
+        OneBasedPosition { line, column }
+    }
+
+    #[test]
+    fn from_byte_offset_is_one_based() {
+        let text = "SELECT id\nFROM users";
+        assert_eq!(OneBasedPosition::from_byte_offset(text, 0), pos(1, 1));
+        assert_eq!(OneBasedPosition::from_byte_offset(text, 7), pos(1, 8));
+        assert_eq!(OneBasedPosition::from_byte_offset(text, 10), pos(2, 1));
+    }
+
+    #[test]
+    fn from_byte_offset_counts_columns_in_characters() {
+        let text = "あいう x";
+        // `x` is the 5th character: three multibyte chars plus a space.
+        let byte = "あいう ".len();
+        assert_eq!(OneBasedPosition::from_byte_offset(text, byte), pos(1, 5));
+    }
+
+    #[test]
+    fn from_byte_offset_clamps_out_of_range_byte() {
+        let text = "SELECT";
+        assert_eq!(OneBasedPosition::from_byte_offset(text, 999), pos(1, 7));
     }
 }

--- a/crates/uroborosql-lint/src/lib.rs
+++ b/crates/uroborosql-lint/src/lib.rs
@@ -10,7 +10,7 @@ mod tree;
 pub use config::{
     ConfigError, ConfigStore, ResolvedLintConfig, RuleLevel, RuleSetting, DEFAULT_CONFIG_FILENAME,
 };
-pub use diagnostic::{Diagnostic, Severity, SqlSpan};
+pub use diagnostic::{Diagnostic, OneBasedPosition, Severity, SqlSpan};
 pub use directive::{
     parse_line_comment_directive, DirectiveParseDiagnostic, DirectiveParseDiagnosticKind,
     ParsedLineComment, ParsedLintDirectiveKind, UnknownRuleRemovalRange, DISABLE_DIRECTIVE_KEYWORD,

--- a/crates/uroborosql-lint/src/lib.rs
+++ b/crates/uroborosql-lint/src/lib.rs
@@ -16,5 +16,5 @@ pub use directive::{
     ParsedLineComment, ParsedLintDirectiveKind, UnknownRuleRemovalRange, DISABLE_DIRECTIVE_KEYWORD,
     DISABLE_NEXT_LINE_DIRECTIVE_KEYWORD, INVALID_LINT_DIRECTIVE_CODE, LINT_SOURCE,
 };
-pub use linter::{LintError, Linter};
+pub use linter::{LintError, Linter, ParseErrorByteSpan};
 pub use rules::RuleEnum;

--- a/crates/uroborosql-lint/src/linter.rs
+++ b/crates/uroborosql-lint/src/linter.rs
@@ -2,11 +2,54 @@ use crate::{
     context::LintContext, diagnostic::Diagnostic, directive::suppress_diagnostics,
     tree::collect_preorder, ResolvedLintConfig,
 };
-use postgresql_cst_parser::tree_sitter;
+use postgresql_cst_parser::{tree_sitter, ParserError, ScanReport};
 
 #[derive(Debug)]
 pub enum LintError {
-    ParseError(String),
+    ParseError {
+        message: String,
+        /// `None` when the position is unavailable.
+        span: Option<ParseErrorByteSpan>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParseErrorByteSpan {
+    pub start_byte: usize,
+    pub end_byte: usize,
+}
+
+impl LintError {
+    fn from_parser_error(err: ParserError) -> Self {
+        match err {
+            ParserError::ParseError {
+                message,
+                start_byte_pos,
+                end_byte_pos,
+            } => LintError::ParseError {
+                message,
+                span: Some(ParseErrorByteSpan {
+                    start_byte: start_byte_pos,
+                    end_byte: end_byte_pos,
+                }),
+            },
+            ParserError::ScanReport(ScanReport {
+                message,
+                position_in_bytes,
+                ..
+            }) => LintError::ParseError {
+                message,
+                span: Some(ParseErrorByteSpan {
+                    start_byte: position_in_bytes,
+                    end_byte: position_in_bytes,
+                }),
+            },
+            ParserError::ScanError { message } => LintError::ParseError {
+                message,
+                span: None,
+            },
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -22,8 +65,7 @@ impl Linter {
         sql: &str,
         resolved_config: &ResolvedLintConfig,
     ) -> Result<Vec<Diagnostic>, LintError> {
-        let tree = tree_sitter::parse_2way(sql)
-            .map_err(|err| LintError::ParseError(format!("{err:?}")))?;
+        let tree = tree_sitter::parse_2way(sql).map_err(LintError::from_parser_error)?;
         let root = tree.root_node();
         let nodes = collect_preorder(root.clone());
         let mut ctx = LintContext::new(sql);
@@ -231,5 +273,33 @@ SELECT DISTINCT id FROM users;"#;
             "unknown lint directive rule `no-distinct because reason`"
         );
         assert_eq!(diagnostics[1].code, "no-distinct");
+    }
+
+    #[test]
+    fn parse_error_carries_byte_span_at_error_location() {
+        let cfg = resolve_from_rules(vec![]);
+        // WHERE has no condition, so it errors at EOF.
+        let err = Linter::new()
+            .run("SELECT id FROM users WHERE", &cfg)
+            .expect_err("should fail to parse");
+
+        let LintError::ParseError { span, .. } = err;
+        let span = span.expect("parse error should carry a byte span");
+        assert_eq!(span.start_byte, 26);
+        assert_ne!(span.start_byte, 0);
+    }
+
+    #[test]
+    fn parse_error_span_points_at_offending_token() {
+        let cfg = resolve_from_rules(vec![]);
+        // `+` has no right operand, so it errors at the `;`.
+        let err = Linter::new()
+            .run("SELECT 1 + ;", &cfg)
+            .expect_err("should fail to parse");
+
+        let LintError::ParseError { span, .. } = err;
+        let span = span.expect("parse error should carry a byte span");
+        assert_eq!(span.start_byte, 11);
+        assert_eq!(span.end_byte, 12);
     }
 }


### PR DESCRIPTION

## Summary

SQL のパースエラー時に、language server の診断が常にファイル先頭 (`0,0`) に出ていた問題を修正しました。
これまでパーサが返すエラーを String に握りつぶしていたのが原因であったため、パーサが保持している byte 位置を診断の range に反映し、エラー箇所を正しく指すようにしました。


## Changes

### 1. パースエラーの byte 位置を保持する (`uroborosql-lint`)

変更前:
- `LintError::ParseError(String)` で、パーサのエラーを `format!("{err:?}")` により文字列化し位置を捨てていた

変更後:
- `LintError::ParseError { message, span: Option<ParseErrorByteSpan> }` に構造化し、byte 範囲を保持
- `ParserError` の各バリアントから位置を抽出
  - `ParseError` → `start_byte_pos` / `end_byte_pos`
  - `ScanReport` → `position_in_bytes`（単一点）
  - `ScanError` → 位置情報なし (`span: None`)

### 2. パースエラーを実際の位置に出す (`uroborosql-language-server`)

変更前:
- パースエラーの診断 range が常に `0,0` だった

変更後:
- byte 位置を rope 経由で UTF-16 の position に変換して range に反映
- 位置を取得できない場合（`span` が `None`）は、ファイル末尾を指すゼロ幅 range にフォールバック
  - 位置情報が帰らないパース失敗は「予期せぬ EOF」系が多く、先頭より末尾のほうが直感的なため

### 3. lint CLI でパースエラーに位置を表示する (`uroborosql-lint-cli`)

変更前:
- パースエラーはメッセージのみで、位置を表示していなかった

変更後:
- `file:line:column: error: failed to parse SQL: ...` の形式で位置を表示し、通常の lint 診断と表示を揃えた
- 位置を取得できない場合はファイル末尾にフォールバック（language server と方針を統一）

### 4. 表示用の位置変換を集約する (`uroborosql-lint` / リファクタ)

変更前:
- CLI 側に `0-based → 1-based` の `+1` や `line:column` フォーマット、byte → 位置計算が散らばっていた

変更後:
- `OneBasedPosition` を導入し、表示用の 1-based 位置と `Display` (`line:column`) を一箇所に集約
- `OneBasedPosition::from(Position)`（0-based 位置から）と `OneBasedPosition::from_byte_offset(text, byte)`（byte 位置から）を生成口として用意
- byte → 位置計算（改行カウント・文字単位の桁・char 境界丸め）を `from_byte_offset` に集約
- なお language server の UTF-16 変換は単位が異なるため統合せず、別経路のまま維持している

### Notes / Scope

- パーサ (`postgresql-cst-parser`) はパースエラーに行/桁を持たないため、byte からの行/桁計算は lint crate 側で行っている。通常診断はパーサの `Point` を使うため数え直していない


