### PR TITLE
feat: support multiple workspace folders in the language server

### DIFF
--- a/crates/uroborosql-language-server/src/configuration.rs
+++ b/crates/uroborosql-language-server/src/configuration.rs
@@ -1,10 +1,11 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use tower_lsp_server::lsp_types::request::{Request, WorkspaceConfiguration};
 use tower_lsp_server::lsp_types::{ConfigurationItem, MessageType, Uri};
 use uroborosql_fmt::config::PartialConfig;
-use uroborosql_lint::ConfigStore;
+use uroborosql_lint::{ConfigStore, DEFAULT_CONFIG_FILENAME};
 
 use crate::{Backend, CONFIGURATION_SECTION};
 
@@ -74,33 +75,69 @@ impl Backend {
         }
     }
 
-    pub(crate) async fn refresh_client_config(&self) {
-        let scope_uri = self.root_uri.read().unwrap().clone();
-        if let Some(config) = self.fetch_client_config(scope_uri).await {
-            *self.client_config.write().unwrap() = config;
+    /// Fetches the client config for every workspace root and rebuilds the lint
+    /// stores from the result.
+    ///
+    /// Each root is queried with its own `scopeUri`, so a multi-root client can
+    /// return a different `lintConfigurationFilePath` per folder.
+    pub(crate) async fn refresh_workspace_configs(&self) {
+        let roots = self.workspace_roots.read().unwrap().clone();
+
+        let mut configs: HashMap<PathBuf, ClientConfig> = HashMap::new();
+        for root in &roots {
+            let Some(config) = self.fetch_client_config(Some(root.uri.clone())).await else {
+                continue;
+            };
+            configs.insert(root.path.clone(), config);
         }
+        *self.workspace_configs.write().unwrap() = configs;
+
+        self.rebuild_lint_config_stores().await;
     }
 
-    pub(crate) async fn refresh_lint_config_store(&self) {
-        let Some(root_dir) = self.root_dir() else {
-            return;
-        };
+    pub(crate) fn cached_workspace_config_for_uri(&self, uri: &Uri) -> ClientConfig {
+        self.workspace_dir_for_uri(uri)
+            .and_then(|dir| self.workspace_configs.read().unwrap().get(&dir).cloned())
+            .unwrap_or_default()
+    }
 
-        let resolved_path = self.resolve_lint_config_path();
-        match ConfigStore::try_new(root_dir, resolved_path) {
-            Ok(store) => {
-                *self.lint_config_store.write().unwrap() = store;
-            }
-            Err(err) => {
-                self.client
-                    .log_message(
-                        MessageType::WARNING,
-                        format!("failed to load lint config: {err}"),
-                    )
-                    .await;
-                *self.lint_config_store.write().unwrap() = None;
+    /// Rebuilds the lint config store for every workspace root from the cached
+    /// per-root client config, without issuing new `workspace/configuration`
+    /// requests. Used when only the on-disk config files may have changed.
+    ///
+    /// The `lintConfigurationFilePath` setting (relative or absolute) is
+    /// resolved against each root independently so that nested / sibling
+    /// workspaces each pick up their own `.uroborosqllintrc.json`.
+    pub(crate) async fn rebuild_lint_config_stores(&self) {
+        let roots = self.workspace_roots.read().unwrap().clone();
+        let configs = self.workspace_configs.read().unwrap().clone();
+
+        let mut stores = HashMap::new();
+        for root in roots {
+            let lint_config_path = configs
+                .get(&root.path)
+                .and_then(|config| config.lint_configuration_file_path.clone());
+            let resolved_path =
+                resolve_config_path(Some(&root.path), lint_config_path, DEFAULT_CONFIG_FILENAME);
+            match ConfigStore::try_new(root.path.clone(), resolved_path) {
+                Ok(store) => {
+                    stores.insert(root.path, store);
+                }
+                Err(err) => {
+                    self.client
+                        .log_message(
+                            MessageType::WARNING,
+                            format!(
+                                "failed to load lint config for {}: {err}",
+                                root.path.display()
+                            ),
+                        )
+                        .await;
+                    stores.insert(root.path, None);
+                }
             }
         }
+        *self.lint_config_stores.write().unwrap() = stores;
     }
 }
 

--- a/crates/uroborosql-language-server/src/formatting.rs
+++ b/crates/uroborosql-language-server/src/formatting.rs
@@ -40,9 +40,13 @@ pub(crate) struct FormatSelectionsAsSqlResult {
 }
 
 impl Backend {
-    pub(crate) fn resolve_fmt_config_path_for(&self, config: &ClientConfig) -> Option<PathBuf> {
+    pub(crate) fn resolve_fmt_config_path_for_uri(
+        &self,
+        uri: &Uri,
+        config: &ClientConfig,
+    ) -> Option<PathBuf> {
         let raw_path = config.configuration_file_path.clone();
-        let root_dir = self.root_dir();
+        let root_dir = self.workspace_dir_for_uri(uri);
         resolve_config_path(root_dir.as_deref(), raw_path, DEFAULT_FMT_CONFIG_PATH)
     }
 
@@ -57,9 +61,9 @@ impl Backend {
         let config = self
             .fetch_client_config(Some(scope_uri.clone()))
             .await
-            .unwrap_or_else(|| self.client_config.read().unwrap().clone());
+            .unwrap_or_else(|| self.cached_workspace_config_for_uri(scope_uri));
         (
-            self.resolve_fmt_config_path_for(&config),
+            self.resolve_fmt_config_path_for_uri(scope_uri, &config),
             self.client_config_json_explicit_only_for(&config),
         )
     }

--- a/crates/uroborosql-language-server/src/lib.rs
+++ b/crates/uroborosql-language-server/src/lib.rs
@@ -7,6 +7,7 @@ mod paths;
 mod server;
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 
 pub use tower_lsp_server::ClientSocket;
@@ -19,6 +20,7 @@ use uroborosql_lint::{ConfigStore, Linter};
 use crate::configuration::ClientConfig;
 use crate::document::DocumentState;
 use crate::formatting::FORMAT_SELECTIONS_AS_SQL_METHOD;
+use crate::paths::WorkspaceRoot;
 
 const CONFIGURATION_SECTION: &str = "uroborosql-fmt";
 const DEFAULT_FMT_CONFIG_PATH: &str = ".uroborosqlfmtrc.json";
@@ -28,9 +30,17 @@ pub struct Backend {
     client: Client,
     linter: Arc<Linter>,
     documents: Arc<RwLock<HashMap<Uri, DocumentState>>>,
-    client_config: Arc<RwLock<ClientConfig>>,
-    lint_config_store: Arc<RwLock<Option<ConfigStore>>>,
-    root_uri: Arc<RwLock<Option<Uri>>>,
+    /// Client config fetched per workspace root, so each root resolves its own
+    /// `lintConfigurationFilePath`. Also reused as the formatting fallback when a
+    /// live config fetch fails.
+    workspace_configs: Arc<RwLock<HashMap<PathBuf, ClientConfig>>>,
+    /// Lint config stores keyed by the normalized workspace root path.
+    /// `None` distinguishes "no `.uroborosqllintrc.json` for this root" from
+    /// "this root has not been resolved yet".
+    lint_config_stores: Arc<RwLock<HashMap<PathBuf, Option<ConfigStore>>>>,
+    /// Normalized workspace roots resolved from `workspaceFolders` (or the
+    /// `rootUri` fallback). All config resolution is scoped through these.
+    workspace_roots: Arc<RwLock<Vec<WorkspaceRoot>>>,
     supports_dynamic_watched_files: Arc<RwLock<bool>>,
     has_watched_files_registration: Arc<RwLock<bool>>,
 }
@@ -41,9 +51,9 @@ impl Backend {
             client,
             linter: Arc::new(Linter::new()),
             documents: Arc::new(RwLock::new(HashMap::new())),
-            client_config: Arc::new(RwLock::new(ClientConfig::default())),
-            lint_config_store: Arc::new(RwLock::new(None)),
-            root_uri: Arc::new(RwLock::new(None)),
+            workspace_configs: Arc::new(RwLock::new(HashMap::new())),
+            lint_config_stores: Arc::new(RwLock::new(HashMap::new())),
+            workspace_roots: Arc::new(RwLock::new(Vec::new())),
             supports_dynamic_watched_files: Arc::new(RwLock::new(false)),
             has_watched_files_registration: Arc::new(RwLock::new(false)),
         }

--- a/crates/uroborosql-language-server/src/lint.rs
+++ b/crates/uroborosql-language-server/src/lint.rs
@@ -1,35 +1,16 @@
-use std::path::PathBuf;
-
 use tower_lsp_server::lsp_types::{
     Diagnostic, DiagnosticSeverity, MessageType, NumberOrString, Position, Range, Uri,
 };
 use uroborosql_lint::{
-    DEFAULT_CONFIG_FILENAME, Diagnostic as SqlDiagnostic, LINT_SOURCE, LintError,
-    Severity as SqlSeverity,
+    Diagnostic as SqlDiagnostic, LINT_SOURCE, LintError, Severity as SqlSeverity,
 };
 
 use crate::Backend;
-use crate::configuration::resolve_config_path;
 use crate::document::{rope_byte_to_position, rope_char_index_to_position};
-use crate::paths::file_uri_to_path;
+use crate::paths::{file_uri_to_path, has_parent_dir_component};
 
 impl Backend {
-    pub(crate) fn resolve_lint_config_path(&self) -> Option<PathBuf> {
-        let raw_path = self
-            .client_config
-            .read()
-            .unwrap()
-            .lint_configuration_file_path
-            .clone();
-        let root_dir = self.root_dir();
-        resolve_config_path(root_dir.as_deref(), raw_path, DEFAULT_CONFIG_FILENAME)
-    }
-
     pub(crate) async fn lint_and_publish(&self, uri: &Uri, text: &str, version: Option<i32>) {
-        if self.root_dir().is_none() {
-            return;
-        }
-
         let Some(path) = file_uri_to_path(uri) else {
             self.client
                 .log_message(
@@ -39,14 +20,43 @@ impl Backend {
                 .await;
             return;
         };
-
-        let Some(config_store) = self.lint_config_store.read().unwrap().as_ref().cloned() else {
+        // A `..` would make containment ambiguous; conformant clients never send
+        // one, so surface it loudly rather than guessing the owning workspace.
+        if has_parent_dir_component(&path) {
             self.client
                 .log_message(
-                    MessageType::INFO,
-                    "lint config store is not initialized; clearing diagnostics",
+                    MessageType::WARNING,
+                    format!(
+                        "document path contains '..'; skipping lint: {}",
+                        path.display()
+                    ),
                 )
                 .await;
+            self.client
+                .publish_diagnostics(uri.clone(), vec![], version)
+                .await;
+            return;
+        }
+
+        // Resolve against the workspace that actually owns this document so a
+        // sibling folder that merely appears first is never used by accident.
+        let Some(workspace) = self.workspace_root_for_uri(uri) else {
+            // The document is outside every workspace root. Publish empty rather
+            // than guessing a config from an unrelated workspace.
+            self.client
+                .publish_diagnostics(uri.clone(), vec![], version)
+                .await;
+            return;
+        };
+
+        let config_store = self
+            .lint_config_stores
+            .read()
+            .unwrap()
+            .get(&workspace.path)
+            .cloned()
+            .flatten();
+        let Some(config_store) = config_store else {
             self.client
                 .publish_diagnostics(uri.clone(), vec![], version)
                 .await;

--- a/crates/uroborosql-language-server/src/paths.rs
+++ b/crates/uroborosql-language-server/src/paths.rs
@@ -200,29 +200,33 @@ mod tests {
 
     #[test]
     fn resolve_workspace_roots_prefers_folders() {
+        let other = env::temp_dir().join("uroborosql-workspace-other");
+        let project = env::temp_dir().join("uroborosql-workspace-project");
         let folders = vec![
             WorkspaceFolder {
-                uri: Uri::from_str("file:///work/other").expect("uri"),
+                uri: Uri::from_file_path(&other).expect("uri"),
                 name: "other".into(),
             },
             WorkspaceFolder {
-                uri: Uri::from_str("file:///work/project").expect("uri"),
+                uri: Uri::from_file_path(&project).expect("uri"),
                 name: "project".into(),
             },
         ];
-        let root_uri = Uri::from_str("file:///fallback").expect("uri");
+        let fallback = env::temp_dir().join("uroborosql-workspace-fallback");
+        let root_uri = Uri::from_file_path(&fallback).expect("uri");
         let roots = resolve_workspace_roots(Some(&folders), Some(&root_uri));
         assert_eq!(roots.len(), 2);
-        assert_eq!(roots[0].path, PathBuf::from("/work/other"));
-        assert_eq!(roots[1].path, PathBuf::from("/work/project"));
+        assert_eq!(roots[0].path, other);
+        assert_eq!(roots[1].path, project);
     }
 
     #[test]
     fn resolve_workspace_roots_falls_back_to_root_uri() {
-        let root_uri = Uri::from_str("file:///fallback").expect("uri");
+        let fallback = env::temp_dir().join("uroborosql-workspace-fallback");
+        let root_uri = Uri::from_file_path(&fallback).expect("uri");
         let roots = resolve_workspace_roots(None, Some(&root_uri));
         assert_eq!(roots.len(), 1);
-        assert_eq!(roots[0].path, PathBuf::from("/fallback"));
+        assert_eq!(roots[0].path, fallback);
     }
 
     #[test]
@@ -231,10 +235,11 @@ mod tests {
             uri: Uri::from_str("untitled:scratch").expect("uri"),
             name: "scratch".into(),
         }];
-        let root_uri = Uri::from_str("file:///fallback").expect("uri");
+        let fallback = env::temp_dir().join("uroborosql-workspace-fallback");
+        let root_uri = Uri::from_file_path(&fallback).expect("uri");
         let roots = resolve_workspace_roots(Some(&folders), Some(&root_uri));
         assert_eq!(roots.len(), 1);
-        assert_eq!(roots[0].path, PathBuf::from("/fallback"));
+        assert_eq!(roots[0].path, fallback);
     }
 
     #[test]

--- a/crates/uroborosql-language-server/src/paths.rs
+++ b/crates/uroborosql-language-server/src/paths.rs
@@ -1,8 +1,33 @@
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
-use tower_lsp_server::{UriExt, lsp_types::Uri};
+use tower_lsp_server::{
+    UriExt,
+    lsp_types::{Uri, WorkspaceFolder},
+};
 
 use crate::Backend;
+
+/// A workspace folder that resolves to a real file system path.
+///
+/// The LSP contract is expressed in URIs, but containment checks, map lookups
+/// and lint store management are all done on `path`. Comparisons rely on
+/// `Path`'s component semantics, which already ignore `.`, repeated separators
+/// and trailing slashes, so no separate normalization step is needed. The `uri`
+/// is retained for logging, notifications and client request scopes.
+#[derive(Debug, Clone)]
+pub(crate) struct WorkspaceRoot {
+    pub(crate) uri: Uri,
+    pub(crate) path: PathBuf,
+}
+
+impl WorkspaceRoot {
+    pub(crate) fn from_uri(uri: &Uri) -> Option<Self> {
+        Some(Self {
+            uri: uri.clone(),
+            path: file_uri_to_path(uri)?,
+        })
+    }
+}
 
 pub(crate) fn is_file_uri(uri: &Uri) -> bool {
     matches!(uri.scheme(), Some(scheme) if scheme.as_str().eq_ignore_ascii_case("file"))
@@ -15,13 +40,82 @@ pub(crate) fn file_uri_to_path(uri: &Uri) -> Option<PathBuf> {
     uri.to_file_path().map(|path| path.to_path_buf())
 }
 
-pub(crate) fn root_dir_from_uri(root_uri: Option<&Uri>) -> Option<PathBuf> {
-    root_uri.and_then(file_uri_to_path)
+/// Returns whether `path` contains a `..` component.
+///
+/// `Path` comparison already ignores `.`, repeated separators and trailing
+/// slashes, so containment needs no normalization for those. `..` is the only
+/// component that could let a path masquerade as living under a sibling root
+/// via prefix matching. Conformant clients send dot-segment-normalized URIs, so
+/// this should never fire; callers surface it instead of guessing.
+pub(crate) fn has_parent_dir_component(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, Component::ParentDir))
+}
+
+/// Resolves the workspace roots for a session.
+///
+/// `workspaceFolders` takes precedence; only when it yields no usable (file)
+/// root do we fall back to the deprecated `rootUri` as a single pseudo
+/// workspace. Non-`file` folders are dropped so they are never used as a
+/// containment target.
+pub(crate) fn resolve_workspace_roots(
+    workspace_folders: Option<&[WorkspaceFolder]>,
+    root_uri: Option<&Uri>,
+) -> Vec<WorkspaceRoot> {
+    let mut roots: Vec<WorkspaceRoot> = Vec::new();
+
+    if let Some(folders) = workspace_folders {
+        for folder in folders {
+            push_unique_root(&mut roots, WorkspaceRoot::from_uri(&folder.uri));
+        }
+    }
+
+    if roots.is_empty()
+        && let Some(uri) = root_uri
+    {
+        push_unique_root(&mut roots, WorkspaceRoot::from_uri(uri));
+    }
+
+    roots
+}
+
+fn push_unique_root(roots: &mut Vec<WorkspaceRoot>, root: Option<WorkspaceRoot>) {
+    if let Some(root) = root
+        && !roots.iter().any(|existing| existing.path == root.path)
+    {
+        roots.push(root);
+    }
+}
+
+/// Returns the workspace root that contains `path`, preferring the longest
+/// (most specific) match when several roots are nested.
+///
+/// A `..` in `path` is refused: it could otherwise prefix-match a sibling root
+/// and misattribute the document. Callers are expected to have screened it.
+pub(crate) fn workspace_root_for_path<'a>(
+    path: &Path,
+    roots: &'a [WorkspaceRoot],
+) -> Option<&'a WorkspaceRoot> {
+    if has_parent_dir_component(path) {
+        return None;
+    }
+    roots
+        .iter()
+        // `Path::starts_with` compares whole path components, so `/foo` is not
+        // treated as a prefix of `/foobar`.
+        .filter(|root| path.starts_with(&root.path))
+        .max_by_key(|root| root.path.components().count())
 }
 
 impl Backend {
-    pub(crate) fn root_dir(&self) -> Option<PathBuf> {
-        root_dir_from_uri(self.root_uri.read().unwrap().as_ref())
+    pub(crate) fn workspace_root_for_uri(&self, uri: &Uri) -> Option<WorkspaceRoot> {
+        let path = file_uri_to_path(uri)?;
+        let roots = self.workspace_roots.read().unwrap();
+        workspace_root_for_path(&path, &roots).cloned()
+    }
+
+    pub(crate) fn workspace_dir_for_uri(&self, uri: &Uri) -> Option<PathBuf> {
+        self.workspace_root_for_uri(uri).map(|root| root.path)
     }
 }
 
@@ -32,16 +126,19 @@ mod tests {
 
     use super::*;
 
+    fn root(path: &str) -> WorkspaceRoot {
+        WorkspaceRoot {
+            uri: Uri::from_str(&format!("file://{path}")).expect("valid uri"),
+            path: PathBuf::from(path),
+        }
+    }
+
     #[test]
     fn non_file_uri_is_none() {
         let uri = Uri::from_str("untitled:Untitled-1").expect("valid uri");
         assert!(!is_file_uri(&uri));
         assert_eq!(file_uri_to_path(&uri), None);
-    }
-
-    #[test]
-    fn root_dir_none_is_none() {
-        assert_eq!(root_dir_from_uri(None), None);
+        assert!(WorkspaceRoot::from_uri(&uri).is_none());
     }
 
     #[test]
@@ -55,9 +152,104 @@ mod tests {
     }
 
     #[test]
-    fn root_dir_from_uri_resolves() {
-        let root = env::temp_dir().join("uroborosql project");
-        let uri = Uri::from_file_path(&root).expect("path to uri");
-        assert_eq!(root_dir_from_uri(Some(&uri)), Some(root));
+    fn workspace_root_for_path_ignores_dot_and_trailing_slash() {
+        let roots = vec![root("/work/project/")];
+        let selected =
+            workspace_root_for_path(Path::new("/work/./project/src/main.sql"), &roots).unwrap();
+        assert_eq!(selected.path, PathBuf::from("/work/project"));
+    }
+
+    #[test]
+    fn workspace_root_for_path_refuses_parent_dir() {
+        // `/work/project/../other/a.sql` really lives in `/work/other`, so it
+        // must not prefix-match `/work/project`.
+        let roots = vec![root("/work/project")];
+        assert!(
+            workspace_root_for_path(Path::new("/work/project/../other/a.sql"), &roots).is_none()
+        );
+    }
+
+    #[test]
+    fn workspace_root_for_path_picks_longest_prefix() {
+        let roots = vec![root("/work"), root("/work/project")];
+        let selected =
+            workspace_root_for_path(Path::new("/work/project/src/main.sql"), &roots).unwrap();
+        assert_eq!(selected.path, PathBuf::from("/work/project"));
+    }
+
+    #[test]
+    fn workspace_root_for_path_ignores_partial_component_match() {
+        // `/work/proj` must not be treated as a prefix of `/work/project-x`.
+        let roots = vec![root("/work/proj")];
+        assert!(workspace_root_for_path(Path::new("/work/project-x/a.sql"), &roots).is_none());
+    }
+
+    #[test]
+    fn workspace_root_for_path_selects_owning_root_regardless_of_order() {
+        let roots = vec![root("/work/other"), root("/work/project")];
+        let selected =
+            workspace_root_for_path(Path::new("/work/project/test.sql"), &roots).unwrap();
+        assert_eq!(selected.path, PathBuf::from("/work/project"));
+    }
+
+    #[test]
+    fn workspace_root_for_path_none_when_unowned() {
+        let roots = vec![root("/work/project")];
+        assert!(workspace_root_for_path(Path::new("/other/a.sql"), &roots).is_none());
+    }
+
+    #[test]
+    fn resolve_workspace_roots_prefers_folders() {
+        let folders = vec![
+            WorkspaceFolder {
+                uri: Uri::from_str("file:///work/other").expect("uri"),
+                name: "other".into(),
+            },
+            WorkspaceFolder {
+                uri: Uri::from_str("file:///work/project").expect("uri"),
+                name: "project".into(),
+            },
+        ];
+        let root_uri = Uri::from_str("file:///fallback").expect("uri");
+        let roots = resolve_workspace_roots(Some(&folders), Some(&root_uri));
+        assert_eq!(roots.len(), 2);
+        assert_eq!(roots[0].path, PathBuf::from("/work/other"));
+        assert_eq!(roots[1].path, PathBuf::from("/work/project"));
+    }
+
+    #[test]
+    fn resolve_workspace_roots_falls_back_to_root_uri() {
+        let root_uri = Uri::from_str("file:///fallback").expect("uri");
+        let roots = resolve_workspace_roots(None, Some(&root_uri));
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].path, PathBuf::from("/fallback"));
+    }
+
+    #[test]
+    fn resolve_workspace_roots_falls_back_when_only_non_file_folders() {
+        let folders = vec![WorkspaceFolder {
+            uri: Uri::from_str("untitled:scratch").expect("uri"),
+            name: "scratch".into(),
+        }];
+        let root_uri = Uri::from_str("file:///fallback").expect("uri");
+        let roots = resolve_workspace_roots(Some(&folders), Some(&root_uri));
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].path, PathBuf::from("/fallback"));
+    }
+
+    #[test]
+    fn resolve_workspace_roots_deduplicates() {
+        let folders = vec![
+            WorkspaceFolder {
+                uri: Uri::from_str("file:///work/project").expect("uri"),
+                name: "a".into(),
+            },
+            WorkspaceFolder {
+                uri: Uri::from_str("file:///work/project/").expect("uri"),
+                name: "b".into(),
+            },
+        ];
+        let roots = resolve_workspace_roots(Some(&folders), None);
+        assert_eq!(roots.len(), 1);
     }
 }

--- a/crates/uroborosql-language-server/src/server.rs
+++ b/crates/uroborosql-language-server/src/server.rs
@@ -9,28 +9,27 @@ use uroborosql_lint::DEFAULT_CONFIG_FILENAME;
 
 use crate::Backend;
 use crate::document::{rope_char_index_to_position, rope_range_to_char_index_range};
+use crate::paths::{WorkspaceRoot, file_uri_to_path, resolve_workspace_roots};
 
 impl LanguageServer for Backend {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
-        // This server only supports a single workspace folder for now, so it uses the first one.
-        // `InitializeParams::root_uri` is deprecated, but some clients still omit
-        // `workspaceFolders`, so keep `rootUri` as a fallback for compatibility.
+        // Config / lint resolution is scoped per document workspace, so no single
+        // folder is treated as "the" root (see `resolve_workspace_roots`).
         #[allow(deprecated)]
-        let root_uri = params
-            .workspace_folders
-            .as_ref()
-            .and_then(|folders| folders.first().map(|folder| folder.uri.clone()))
-            .or(params.root_uri);
-        *self.root_uri.write().unwrap() = root_uri.clone();
+        let workspace_roots = resolve_workspace_roots(
+            params.workspace_folders.as_deref(),
+            params.root_uri.as_ref(),
+        );
 
-        if root_uri.is_none() {
+        if workspace_roots.is_empty() {
             self.client
                 .log_message(
                     MessageType::INFO,
-                    "no workspace folders or rootUri provided",
+                    "no file workspace folders or rootUri provided",
                 )
                 .await;
         }
+        *self.workspace_roots.write().unwrap() = workspace_roots;
 
         let supports_dynamic_watched_files = params
             .capabilities
@@ -61,6 +60,13 @@ impl LanguageServer for Backend {
                         ..CodeActionOptions::default()
                     },
                 )),
+                workspace: Some(WorkspaceServerCapabilities {
+                    workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                        supported: Some(true),
+                        change_notifications: Some(OneOf::Left(true)),
+                    }),
+                    ..WorkspaceServerCapabilities::default()
+                }),
                 ..ServerCapabilities::default()
             },
             server_info: Some(ServerInfo {
@@ -75,20 +81,45 @@ impl LanguageServer for Backend {
             .log_message(MessageType::INFO, "uroborosql-language-server initialized")
             .await;
 
-        self.refresh_client_config().await;
-        self.refresh_lint_config_store().await;
+        self.refresh_workspace_configs().await;
         self.sync_watched_files_registration().await;
     }
 
     async fn did_change_configuration(&self, _: DidChangeConfigurationParams) {
-        self.refresh_client_config().await;
-        self.refresh_lint_config_store().await;
+        self.refresh_workspace_configs().await;
         self.sync_watched_files_registration().await;
         self.relint_open_documents().await;
     }
 
     async fn did_change_watched_files(&self, _: DidChangeWatchedFilesParams) {
-        self.refresh_lint_config_store().await;
+        // A config file on disk changed: rebuild every workspace's store from the
+        // already-fetched client config rather than re-querying the client.
+        self.rebuild_lint_config_stores().await;
+        self.relint_open_documents().await;
+    }
+
+    async fn did_change_workspace_folders(&self, params: DidChangeWorkspaceFoldersParams) {
+        {
+            let mut roots = self.workspace_roots.write().unwrap();
+
+            for removed in &params.event.removed {
+                if let Some(path) = file_uri_to_path(&removed.uri) {
+                    roots.retain(|root| root.path != path);
+                }
+            }
+
+            for added in &params.event.added {
+                if let Some(root) = WorkspaceRoot::from_uri(&added.uri)
+                    && !roots.iter().any(|existing| existing.path == root.path)
+                {
+                    roots.push(root);
+                }
+            }
+        }
+
+        // Re-fetch per-root config so added roots get their own settings.
+        self.refresh_workspace_configs().await;
+        self.sync_watched_files_registration().await;
         self.relint_open_documents().await;
     }
 

--- a/crates/uroborosql-language-server/tests/diagnostics.rs
+++ b/crates/uroborosql-language-server/tests/diagnostics.rs
@@ -3,6 +3,7 @@ mod test_harness;
 use std::str::FromStr;
 use std::time::Duration;
 
+use serde_json::json;
 use tower_lsp_server::UriExt;
 use tower_lsp_server::lsp_types::Uri;
 use tower_lsp_server::lsp_types::notification::{Notification, PublishDiagnostics};
@@ -153,6 +154,127 @@ async fn parse_error_diagnostic_points_at_error_location() {
     assert!(
         !(start_line == Some(0) && start_character == Some(0)),
         "parse error must not collapse to 0,0"
+    );
+}
+
+#[tokio::test]
+async fn lint_picks_each_documents_own_workspace_config() {
+    let mut server = new_test_server();
+    let project_a = unique_temp_dir("uroborosql-lsp-multi-a");
+    let project_b = unique_temp_dir("uroborosql-lsp-multi-b");
+    write_file(&project_a.join(".uroborosqllintrc.json"), "{}");
+    write_file(
+        &project_b.join(".uroborosqllintrc.json"),
+        r#"{ "rules": { "no-distinct": "off" } }"#,
+    );
+
+    let uri_a = Uri::from_file_path(project_a.join("a.sql")).unwrap();
+    let uri_b = Uri::from_file_path(project_b.join("b.sql")).unwrap();
+    initialize_server_with_workspace_folders(
+        &mut server,
+        vec![
+            workspace_folder(Uri::from_file_path(&project_a).unwrap(), "a"),
+            workspace_folder(Uri::from_file_path(&project_b).unwrap(), "b"),
+        ],
+        None,
+    )
+    .await;
+
+    server
+        .send_request(build_did_open(&uri_a, "SELECT DISTINCT id FROM users;", 1))
+        .await;
+    let diag_a = server.receive_notification().await;
+    assert_eq!(
+        diag_a.params().unwrap()["uri"].as_str(),
+        Some(uri_a.as_str())
+    );
+    assert!(
+        !diag_a.params().unwrap()["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "project A should report no-distinct"
+    );
+
+    server
+        .send_request(build_did_open(&uri_b, "SELECT DISTINCT id FROM users;", 1))
+        .await;
+    let diag_b = server.receive_notification().await;
+    assert_eq!(
+        diag_b.params().unwrap()["uri"].as_str(),
+        Some(uri_b.as_str())
+    );
+    assert!(
+        diag_b.params().unwrap()["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "project B disables no-distinct, so it should report nothing"
+    );
+}
+
+#[tokio::test]
+async fn lint_resolves_per_root_lint_config_path_override() {
+    let mut server = new_test_server();
+    let project_a = unique_temp_dir("uroborosql-lsp-per-root-a");
+    let project_b = unique_temp_dir("uroborosql-lsp-per-root-b");
+
+    // Project A: the default file would report, but its explicit override turns
+    // no-distinct off, so honoring the override means A stays silent.
+    write_file(&project_a.join(".uroborosqllintrc.json"), "{}");
+    write_file(
+        &project_a.join("a-config.json"),
+        r#"{ "rules": { "no-distinct": "off" } }"#,
+    );
+    // Project B keeps no-distinct on, but only under its own override filename.
+    // If B were resolved with A's path ("a-config.json"), B would find nothing.
+    write_file(&project_b.join("b-config.json"), "{}");
+
+    let uri_a = Uri::from_file_path(project_a.join("a.sql")).unwrap();
+    let uri_b = Uri::from_file_path(project_b.join("b.sql")).unwrap();
+    initialize_server_with_workspace_folder_configs(
+        &mut server,
+        vec![
+            workspace_folder(Uri::from_file_path(&project_a).unwrap(), "a"),
+            workspace_folder(Uri::from_file_path(&project_b).unwrap(), "b"),
+        ],
+        vec![
+            json!([{ "lintConfigurationFilePath": "a-config.json" }]),
+            json!([{ "lintConfigurationFilePath": "b-config.json" }]),
+        ],
+    )
+    .await;
+
+    server
+        .send_request(build_did_open(&uri_a, "SELECT DISTINCT id FROM users;", 1))
+        .await;
+    let diag_a = server.receive_notification().await;
+    assert_eq!(
+        diag_a.params().unwrap()["uri"].as_str(),
+        Some(uri_a.as_str())
+    );
+    assert!(
+        diag_a.params().unwrap()["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "project A's explicit override disables no-distinct, so it must be used over the default file"
+    );
+
+    server
+        .send_request(build_did_open(&uri_b, "SELECT DISTINCT id FROM users;", 1))
+        .await;
+    let diag_b = server.receive_notification().await;
+    assert_eq!(
+        diag_b.params().unwrap()["uri"].as_str(),
+        Some(uri_b.as_str())
+    );
+    assert!(
+        !diag_b.params().unwrap()["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "project B must resolve its own override path, not the first root's"
     );
 }
 

--- a/crates/uroborosql-language-server/tests/formatting.rs
+++ b/crates/uroborosql-language-server/tests/formatting.rs
@@ -113,6 +113,54 @@ async fn formatting_merges_config_file_with_explicit_client_overrides() {
 }
 
 #[tokio::test]
+async fn formatting_resolves_relative_config_against_document_workspace() {
+    let mut server = new_test_server();
+    let other_dir = unique_temp_dir("uroborosql-lsp-fmt-multi-other");
+    let project_dir = unique_temp_dir("uroborosql-lsp-fmt-multi-project");
+    write_file(
+        &project_dir.join(".uroborosqlfmtrc.json"),
+        r#"{ "keyword_case": "upper", "identifier_case": "upper" }"#,
+    );
+
+    let uri = Uri::from_file_path(project_dir.join("format.sql")).unwrap();
+    initialize_server_with_workspace_folders(
+        &mut server,
+        vec![
+            workspace_folder(Uri::from_file_path(&other_dir).unwrap(), "other"),
+            workspace_folder(Uri::from_file_path(&project_dir).unwrap(), "project"),
+        ],
+        Some(json!([
+            {
+                "configurationFilePath": ".uroborosqlfmtrc.json",
+                "lintConfigurationFilePath": ""
+            }
+        ])),
+    )
+    .await;
+
+    server
+        .send_request(build_did_open(&uri, "select distinct id from users;", 1))
+        .await;
+    let _ = server.receive_notification().await;
+
+    server.send_request(build_formatting(&uri, 2)).await;
+    let response = server.receive_response().await;
+    assert!(response.is_ok());
+
+    let value = serde_json::to_value(&response).unwrap();
+    let edits = value["result"]
+        .as_array()
+        .expect("formatting against project config should return edits");
+    let new_text = edits[0]["newText"]
+        .as_str()
+        .expect("text edit should contain newText");
+    // Upper-casing proves the project's config file was used (not the empty
+    // first folder, which would have left the file unconfigured / null).
+    assert!(new_text.contains("ID"));
+    assert!(new_text.contains("USERS"));
+}
+
+#[tokio::test]
 async fn formatting_returns_null_when_explicit_config_file_is_missing() {
     let mut server = new_test_server();
     let root_dir = unique_temp_dir("uroborosql-lsp-missing-config");

--- a/crates/uroborosql-language-server/tests/lifecycle.rs
+++ b/crates/uroborosql-language-server/tests/lifecycle.rs
@@ -42,6 +42,110 @@ async fn initialize_uses_root_uri_when_workspace_folders_are_missing() {
 }
 
 #[tokio::test]
+async fn did_change_workspace_folders_adds_workspace_and_lints() {
+    let mut server = new_test_server();
+    let project_a = unique_temp_dir("uroborosql-lsp-wsf-add-a");
+    write_file(&project_a.join(".uroborosqllintrc.json"), "{}");
+    let project_b = unique_temp_dir("uroborosql-lsp-wsf-add-b");
+    write_file(&project_b.join(".uroborosqllintrc.json"), "{}");
+    let uri_b = Uri::from_file_path(project_b.join("b.sql")).unwrap();
+
+    initialize_server_with_workspace_folders(
+        &mut server,
+        vec![workspace_folder(
+            Uri::from_file_path(&project_a).unwrap(),
+            "a",
+        )],
+        None,
+    )
+    .await;
+
+    // Document B is outside any known workspace yet: no diagnostics.
+    server
+        .send_request(build_did_open(&uri_b, "SELECT DISTINCT id FROM users;", 1))
+        .await;
+    let before = server.receive_notification().await;
+    assert_eq!(before.method(), PublishDiagnostics::METHOD);
+    assert!(
+        before.params().unwrap()["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+
+    server
+        .send_request(build_did_change_workspace_folders(
+            vec![workspace_folder(
+                Uri::from_file_path(&project_b).unwrap(),
+                "b",
+            )],
+            vec![],
+        ))
+        .await;
+    let after = server.receive_notification().await;
+    assert_eq!(after.method(), PublishDiagnostics::METHOD);
+    assert_eq!(
+        after.params().unwrap()["uri"].as_str(),
+        Some(uri_b.as_str())
+    );
+    assert!(
+        !after.params().unwrap()["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "after adding project B, its document should be linted"
+    );
+}
+
+#[tokio::test]
+async fn did_change_workspace_folders_removes_workspace() {
+    let mut server = new_test_server();
+    let project_a = unique_temp_dir("uroborosql-lsp-wsf-remove-a");
+    write_file(&project_a.join(".uroborosqllintrc.json"), "{}");
+    let uri = Uri::from_file_path(project_a.join("a.sql")).unwrap();
+
+    initialize_server_with_workspace_folders(
+        &mut server,
+        vec![workspace_folder(
+            Uri::from_file_path(&project_a).unwrap(),
+            "a",
+        )],
+        None,
+    )
+    .await;
+
+    server
+        .send_request(build_did_open(&uri, "SELECT DISTINCT id FROM users;", 1))
+        .await;
+    let before = server.receive_notification().await;
+    assert!(
+        !before.params().unwrap()["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+
+    server
+        .send_request(build_did_change_workspace_folders(
+            vec![],
+            vec![workspace_folder(
+                Uri::from_file_path(&project_a).unwrap(),
+                "a",
+            )],
+        ))
+        .await;
+    let after = server.receive_notification().await;
+    assert_eq!(after.method(), PublishDiagnostics::METHOD);
+    assert!(
+        after.params().unwrap()["diagnostics"]
+            .as_array()
+            .unwrap()
+            .is_empty(),
+        "removing the workspace should clear diagnostics"
+    );
+}
+
+#[tokio::test]
 async fn did_change_configuration_requests_workspace_configuration_again() {
     let mut server = new_test_server();
     let root_dir =

--- a/crates/uroborosql-language-server/tests/test_harness.rs
+++ b/crates/uroborosql-language-server/tests/test_harness.rs
@@ -11,8 +11,9 @@ use tower_lsp_server::UriExt;
 use tower_lsp_server::jsonrpc::{Request, Response};
 use tower_lsp_server::lsp_types::Uri;
 use tower_lsp_server::lsp_types::notification::{
-    DidChangeConfiguration, DidChangeTextDocument, DidChangeWatchedFiles, DidCloseTextDocument,
-    DidOpenTextDocument, DidSaveTextDocument, Initialized, LogMessage, Notification,
+    DidChangeConfiguration, DidChangeTextDocument, DidChangeWatchedFiles,
+    DidChangeWorkspaceFolders, DidCloseTextDocument, DidOpenTextDocument, DidSaveTextDocument,
+    Initialized, LogMessage, Notification,
 };
 use tower_lsp_server::lsp_types::request::{
     CodeActionRequest, Formatting, Initialize, RangeFormatting, RegisterCapability,
@@ -244,6 +245,51 @@ pub(crate) fn build_initialize_with_root_uri(
         .finish()
 }
 
+pub(crate) fn workspace_folder(uri: Uri, name: &str) -> WorkspaceFolder {
+    WorkspaceFolder {
+        uri,
+        name: name.into(),
+    }
+}
+
+#[allow(deprecated)]
+pub(crate) fn build_initialize_with_workspace_folders(
+    id: i64,
+    workspace_folders: Vec<WorkspaceFolder>,
+    root_uri: Option<Uri>,
+) -> Request {
+    let params = InitializeParams {
+        root_uri,
+        workspace_folders: Some(workspace_folders),
+        capabilities: ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
+                    dynamic_registration: Some(true),
+                    relative_pattern_support: Some(false),
+                }),
+                ..WorkspaceClientCapabilities::default()
+            }),
+            ..ClientCapabilities::default()
+        },
+        ..InitializeParams::default()
+    };
+    Request::build(Initialize::METHOD)
+        .params(json!(params))
+        .id(id)
+        .finish()
+}
+
+pub(crate) fn build_did_change_workspace_folders(
+    added: Vec<WorkspaceFolder>,
+    removed: Vec<WorkspaceFolder>,
+) -> Request {
+    Request::build(DidChangeWorkspaceFolders::METHOD)
+        .params(json!(DidChangeWorkspaceFoldersParams {
+            event: WorkspaceFoldersChangeEvent { added, removed },
+        }))
+        .finish()
+}
+
 pub(crate) fn build_initialized() -> Request {
     Request::build(Initialized::METHOD)
         .params(json!(InitializedParams {}))
@@ -443,6 +489,52 @@ pub(crate) async fn initialize_server_with_root_uri(
 
     let config_request = server.receive_server_request().await;
     assert_eq!(config_request.method(), WorkspaceConfiguration::METHOD);
+
+    let register_request = server.receive_server_request().await;
+    assert_eq!(register_request.method(), RegisterCapability::METHOD);
+}
+
+pub(crate) async fn initialize_server_with_workspace_folders(
+    server: &mut TestServer,
+    workspace_folders: Vec<WorkspaceFolder>,
+    workspace_config: Option<serde_json::Value>,
+) {
+    initialize_server_with_workspace_folder_configs(
+        server,
+        workspace_folders,
+        workspace_config.into_iter().collect(),
+    )
+    .await;
+}
+
+/// Like [`initialize_server_with_workspace_folders`], but enqueues one
+/// `workspace/configuration` response per root (in root order). The server
+/// fetches config once per root during `initialized`, so the responses are
+/// consumed in the same order the folders are passed.
+pub(crate) async fn initialize_server_with_workspace_folder_configs(
+    server: &mut TestServer,
+    workspace_folders: Vec<WorkspaceFolder>,
+    workspace_configs: Vec<serde_json::Value>,
+) {
+    for workspace_config in workspace_configs {
+        server.push_workspace_configuration_response(workspace_config);
+    }
+
+    let folder_count = workspace_folders.len();
+    server
+        .send_request(build_initialize_with_workspace_folders(
+            1,
+            workspace_folders,
+            None,
+        ))
+        .await;
+    assert!(server.receive_response().await.is_ok());
+    server.send_request(build_initialized()).await;
+
+    for _ in 0..folder_count {
+        let config_request = server.receive_server_request().await;
+        assert_eq!(config_request.method(), WorkspaceConfiguration::METHOD);
+    }
 
     let register_request = server.receive_server_request().await;
     assert_eq!(register_request.method(), RegisterCapability::METHOD);


### PR DESCRIPTION


## Summary

言語サーバを multi-workspace folders 対応としました。これまでは `workspaceFolders[0]` を唯一の root とみなしていましたが、document ごとに所属 workspace を解決し、その workspace を基準に lint / formatting の config が解決されるようにしました。

これにより、複数プロジェクトを同時に開いた場合や、`workspaceFolders` の先頭が実プロジェクトでない client（例: 補助フォルダが先頭に入る環境）でも、各 document が正しい config で扱われるようになります。

## Changes

- document path を包含する workspace を選んで config を解決する（複数候補は最長一致）。`workspaceFolders` の順序に依存しない
- client 設定は workspace ごとに `workspace/configuration`（scopeUri 付き）で引き、root 単位で `lintConfigurationFilePath` を解決して `ConfigStore` を分離する
- どの workspace にも属さない document は、他 workspace の設定を拾わず空の diagnostics を返す
- `didChangeWorkspaceFolders` に対応し、追加・削除へ追従する（config 再取得 + store 再構築 + watcher 再登録 + relint）
- `workspaceFolders` を送らない client の `rootUri` fallback は従来どおり維持

