### PR TITLE
chore: finalize release-please setup after initial release of new crates

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -55,21 +55,18 @@
       "package-name": "uroborosql-lint",
       "component": "uroborosql-lint",
       "include-component-in-tag": true,
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md"
     },
     "crates/uroborosql-lint-cli": {
       "package-name": "uroborosql-lint-cli",
       "component": "uroborosql-lint-cli",
       "include-component-in-tag": true,
-      "release-as": "0.1.0",
       "changelog-path": "CHANGELOG.md"
     },
     "crates/uroborosql-language-server": {
       "package-name": "uroborosql-language-server",
       "component": "uroborosql-language-server",
       "include-component-in-tag": true,
-      "release-as": "1.0.0",
       "changelog-path": "CHANGELOG.md"
     }
   }


### PR DESCRIPTION
## Summary
closes #260

PR #215 で追加した 3 クレートの初回リリースが完了したため、バージョン固定用に設定していた `release-as` を削除しました

（残したままだと release-please が次回以降も同じバージョンを提案し続けてしまうため）

## Changes
- `release-please-config.json`: 3 クレートから `release-as` を削除

